### PR TITLE
neki sitni fixevi

### DIFF
--- a/setup/.env.example
+++ b/setup/.env.example
@@ -111,7 +111,7 @@ EXCHANGE_DB_EX_PORT=5440
 EXCHANGE_DB_NAME=exchange_db
 EXCHANGE_DB_USER=postgres
 EXCHANGE_DB_PASSWORD=postgres
-TWELVE_DATA_API_KEY=73db21801cb341b5ba5052c6c340eb54
+TWELVE_DATA_API_KEY=replace_with_provider_api_key
 
 # =========================
 # Verification Service


### PR DESCRIPTION
added ports where missing and changed SERVICES_USER_URL to point to client-service instead of employee-service

Account creation was failing with error 500 because account-service was calling GET /customers/{id} on employee-service, which does not expose that endpoint. The endpoint exists on client-service, so the URL was updated http://client-service:8083.