### PR TITLE
feat: integrate Firebase Cloud Messaging for push notifications and update related configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,10 @@ application-local.properties
 application-local.yml
 application-local.yaml
 
+# Firebase service account keys
+*-firebase-adminsdk-*.json
+google-services.json
+
 # Test reports & coverage
 test-results/
 reports/

--- a/account-service/src/main/java/com/banka1/account_service/rest_client/CardServiceRestClient.java
+++ b/account-service/src/main/java/com/banka1/account_service/rest_client/CardServiceRestClient.java
@@ -24,7 +24,7 @@ public class CardServiceRestClient {
     public List<CardResponseDto> getCardsForAccount(String accountNumber) {
         try {
             List<CardResponseDto> cards = cardRestClient.get()
-                    .uri("/cards/account/{accountNumber}", accountNumber)
+                    .uri("/internal/account/{accountNumber}", accountNumber)
                     .retrieve()
                     .body(new ParameterizedTypeReference<List<CardResponseDto>>() {});
             return cards != null ? cards : List.of();

--- a/account-service/src/main/java/com/banka1/account_service/service/implementation/ClientServiceImplementation.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/implementation/ClientServiceImplementation.java
@@ -148,7 +148,9 @@ public class ClientServiceImplementation implements ClientService {
     public AccountDetailsResponseDto getDetails(Jwt jwt, Long id) {
         Account account=accountRepository.findById(id).orElse(null);
         validation(account,jwt);
-        return new AccountDetailsResponseDto(account);
+        AccountDetailsResponseDto dto = new AccountDetailsResponseDto(account);
+        dto.setCards(cardServiceRestClient.getCardsForAccount(account.getBrojRacuna()));
+        return dto;
     }
 
     @Override
@@ -156,7 +158,9 @@ public class ClientServiceImplementation implements ClientService {
     public AccountDetailsResponseDto getDetails(Jwt jwt, String accountNumber) {
         Account account=accountRepository.findByBrojRacuna(accountNumber).orElse(null);
         validation(account,jwt);
-        return new AccountDetailsResponseDto(account);
+        AccountDetailsResponseDto dto = new AccountDetailsResponseDto(account);
+        dto.setCards(cardServiceRestClient.getCardsForAccount(account.getBrojRacuna()));
+        return dto;
     }
 
     @Override

--- a/api-gateway/default.conf.template
+++ b/api-gateway/default.conf.template
@@ -39,6 +39,10 @@ upstream order_service {
     server order-service:${ORDER_SERVER_PORT};
 }
 
+upstream notification_service {
+    server notification-service:${NOTIFICATION_SERVICE_PORT};
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -185,6 +189,20 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Prefix /order;
+    }
+
+    location = /notifications {
+        return 301 /notifications/;
+    }
+
+    # Notification Service (FCM token registration)
+    location /notifications/ {
+        proxy_pass http://notification_service/notifications/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Prefix /notifications;
     }
 
     # Health check

--- a/card-service/src/main/java/com/banka1/card_service/controller/CardManagementController.java
+++ b/card-service/src/main/java/com/banka1/card_service/controller/CardManagementController.java
@@ -2,6 +2,7 @@ package com.banka1.card_service.controller;
 
 import com.banka1.card_service.dto.card_management.request.UpdateCardLimitDTO;
 import com.banka1.card_service.dto.card_management.response.CardDetailDTO;
+import com.banka1.card_service.dto.card_management.response.CardInternalSummaryDTO;
 import com.banka1.card_service.dto.card_management.response.CardSummaryDTO;
 import com.banka1.card_service.service.CardLifecycleService;
 import jakarta.validation.Valid;
@@ -148,6 +149,26 @@ public class CardManagementController {
     @PreAuthorize("hasRole('BASIC')")
     public ResponseEntity<List<CardSummaryDTO>> getCardsByAccount(@PathVariable String accountNumber) {
         return ResponseEntity.ok(cardLifecycleService.getCardsByAccountNumber(accountNumber));
+    }
+
+    // ############################################################
+    // INTERNAL SERVICE ENDPOINTS
+    // Restricted to trusted service-to-service callers (SERVICE role)
+    // ############################################################
+
+    /**
+     * Returns all cards linked to the given account number in the richer internal shape
+     * consumed by account-service when it composes account detail responses.
+     * Only trusted services authenticated with the {@code SERVICE} role may call this endpoint.
+     * Card numbers in the response are masked.
+     *
+     * @param accountNumber bank account number
+     * @return list of internal card summaries
+     */
+    @GetMapping("/internal/account/{accountNumber}")
+    @PreAuthorize("hasRole('SERVICE')")
+    public ResponseEntity<List<CardInternalSummaryDTO>> getCardsByAccountInternal(@PathVariable String accountNumber) {
+        return ResponseEntity.ok(cardLifecycleService.getInternalCardsByAccountNumber(accountNumber));
     }
 
     /**

--- a/card-service/src/main/java/com/banka1/card_service/dto/card_management/response/CardInternalSummaryDTO.java
+++ b/card-service/src/main/java/com/banka1/card_service/dto/card_management/response/CardInternalSummaryDTO.java
@@ -1,0 +1,33 @@
+package com.banka1.card_service.dto.card_management.response;
+
+import com.banka1.card_service.domain.Card;
+import com.banka1.card_service.util.SensitiveDataMasker;
+import lombok.Getter;
+
+/**
+ * Internal service-to-service card summary returned to trusted callers with the {@code SERVICE} role.
+ * Field names intentionally mirror the consumer DTO on the account-service side so Jackson can
+ * deserialize the payload directly without an intermediate mapping step.
+ *
+ * The card number is masked for the same reason as {@link CardSummaryDTO} — downstream callers
+ * only need the last four digits for display.
+ */
+@Getter
+public class CardInternalSummaryDTO {
+
+    private final Long id;
+    private final String cardNumber;
+    private final String cardType;
+    private final String status;
+    private final String expiryDate;
+    private final String accountNumber;
+
+    public CardInternalSummaryDTO(Card card) {
+        this.id = card.getId();
+        this.cardNumber = SensitiveDataMasker.maskCardNumber(card.getCardNumber());
+        this.cardType = card.getCardName();
+        this.status = card.getStatus() == null ? null : card.getStatus().name();
+        this.expiryDate = card.getExpirationDate() == null ? null : card.getExpirationDate().toString();
+        this.accountNumber = card.getAccountNumber();
+    }
+}

--- a/card-service/src/main/java/com/banka1/card_service/service/CardLifecycleService.java
+++ b/card-service/src/main/java/com/banka1/card_service/service/CardLifecycleService.java
@@ -1,6 +1,7 @@
 package com.banka1.card_service.service;
 
 import com.banka1.card_service.dto.card_management.response.CardDetailDTO;
+import com.banka1.card_service.dto.card_management.response.CardInternalSummaryDTO;
 import com.banka1.card_service.dto.card_management.response.CardSummaryDTO;
 
 import java.math.BigDecimal;
@@ -46,6 +47,16 @@ public interface CardLifecycleService {
      * @return list of masked card summaries (may be empty)
      */
     List<CardSummaryDTO> getCardsByAccountNumber(String accountNumber);
+
+    /**
+     * Returns all cards linked to the given account number in the richer internal shape
+     * consumed by trusted service-to-service callers such as account-service when it
+     * populates account detail responses.
+     *
+     * @param accountNumber account number to filter by
+     * @return list of internal card summaries (may be empty)
+     */
+    List<CardInternalSummaryDTO> getInternalCardsByAccountNumber(String accountNumber);
 
     /**
      * Blocks an active card. Both clients and employees may call this.

--- a/card-service/src/main/java/com/banka1/card_service/service/implementation/CardLifecycleServiceImpl.java
+++ b/card-service/src/main/java/com/banka1/card_service/service/implementation/CardLifecycleServiceImpl.java
@@ -4,6 +4,7 @@ import com.banka1.card_service.domain.Card;
 import com.banka1.card_service.domain.enums.CardStatus;
 import com.banka1.card_service.dto.card_management.internal.CardNotificationDto;
 import com.banka1.card_service.dto.card_management.response.CardDetailDTO;
+import com.banka1.card_service.dto.card_management.response.CardInternalSummaryDTO;
 import com.banka1.card_service.dto.card_management.response.CardSummaryDTO;
 import com.banka1.card_service.dto.enums.CardNotificationType;
 import com.banka1.card_service.exception.BusinessException;
@@ -98,6 +99,14 @@ public class CardLifecycleServiceImpl implements CardLifecycleService {
         return cardRepository.findByAccountNumber(accountNumber)
                 .stream()
                 .map(CardSummaryDTO::new)
+                .toList();
+    }
+
+    @Override
+    public List<CardInternalSummaryDTO> getInternalCardsByAccountNumber(String accountNumber) {
+        return cardRepository.findByAccountNumber(accountNumber)
+                .stream()
+                .map(CardInternalSummaryDTO::new)
                 .toList();
     }
 

--- a/card-service/src/test/java/com/banka1/card_service/controller/CardManagementControllerWebMvcTest.java
+++ b/card-service/src/test/java/com/banka1/card_service/controller/CardManagementControllerWebMvcTest.java
@@ -6,6 +6,7 @@ import com.banka1.card_service.domain.enums.CardStatus;
 import com.banka1.card_service.domain.enums.CardType;
 import com.banka1.card_service.dto.card_management.request.UpdateCardLimitDTO;
 import com.banka1.card_service.dto.card_management.response.CardDetailDTO;
+import com.banka1.card_service.dto.card_management.response.CardInternalSummaryDTO;
 import com.banka1.card_service.dto.card_management.response.CardSummaryDTO;
 import com.banka1.card_service.service.CardLifecycleService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -120,6 +121,21 @@ class CardManagementControllerWebMvcTest {
                                 .jwt(jwt -> jwt.claim("id", 100L))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].maskedCardNumber").value("5798********5571"));
+    }
+
+    @Test
+    void getCardsByAccountInternalReturnsInternalSummaries() throws Exception {
+        when(cardLifecycleService.getInternalCardsByAccountNumber("265000000000123456"))
+                .thenReturn(List.of(new CardInternalSummaryDTO(card())));
+
+        mockMvc.perform(get("/internal/account/265000000000123456")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_SERVICE"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].cardNumber").value("5798********5571"))
+                .andExpect(jsonPath("$[0].cardType").value("Visa Debit"))
+                .andExpect(jsonPath("$[0].status").value("ACTIVE"))
+                .andExpect(jsonPath("$[0].expiryDate").value("2031-03-20"))
+                .andExpect(jsonPath("$[0].accountNumber").value("265000000000123456"));
     }
 
     @Test

--- a/card-service/src/test/java/com/banka1/card_service/service/implementation/CardLifecycleServiceImplTest.java
+++ b/card-service/src/test/java/com/banka1/card_service/service/implementation/CardLifecycleServiceImplTest.java
@@ -289,6 +289,23 @@ class CardLifecycleServiceImplTest {
         assertEquals("5798********5571", result.get(0).getMaskedCardNumber());
     }
 
+    @Test
+    void getInternalCardsByAccountNumber_returnsInternalSummaries() {
+        Card card = cardWithStatus(CardStatus.ACTIVE);
+        card.setCardNumber("5798123456785571");
+        card.setCardName("Visa Debit");
+        card.setAccountNumber("265000000000123456");
+        when(cardRepository.findByAccountNumber("265000000000123456")).thenReturn(List.of(card));
+
+        var result = service.getInternalCardsByAccountNumber("265000000000123456");
+
+        assertEquals(1, result.size());
+        assertEquals("5798********5571", result.get(0).getCardNumber());
+        assertEquals("Visa Debit", result.get(0).getCardType());
+        assertEquals("ACTIVE", result.get(0).getStatus());
+        assertEquals("265000000000123456", result.get(0).getAccountNumber());
+    }
+
     // --- getCardByCardNumber ---
 
     @Test

--- a/client-service/src/main/java/com/banka1/clientService/controller/ClientController.java
+++ b/client-service/src/main/java/com/banka1/clientService/controller/ClientController.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import java.util.Collection;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -161,11 +160,13 @@ public class ClientController {
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyRole('SERVICE','ADMIN','CLIENT_BASIC')")
     public ResponseEntity<ClientInfoResponseDto> getInfoById(@AuthenticationPrincipal Jwt jwt, @PathVariable Long id) {
-        String roles = jwt.getClaimAsString("roles");
-        if (roles != null && roles.startsWith("CLIENT_")) {
-            Long tokenId = jwt.getClaim("id");
-            if (!id.equals(tokenId)) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        if (jwt != null) {
+            String roles = jwt.getClaimAsString("roles");
+            if (roles != null && roles.startsWith("CLIENT_")) {
+                Long tokenId = jwt.getClaim("id");
+                if (!id.equals(tokenId)) {
+                    return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+                }
             }
         }
         return ResponseEntity.ok(clientService.getInfoById(id));

--- a/client-service/src/main/java/com/banka1/clientService/controller/ClientController.java
+++ b/client-service/src/main/java/com/banka1/clientService/controller/ClientController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import java.util.Collection;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -151,14 +152,22 @@ public class ClientController {
 
     /**
      * Vraca osnovne informacije o klijentu na osnovu internog ID-a.
-     * Ovoj ruti moze pristupiti SAMO SERVICE token (interni pozivi izmedju servisa).
+     * Dostupno SERVICE i ADMIN tokenima, kao i CLIENT_BASIC/CLIENT_TRADING tokenima
+     * iskljucivo za preuzimanje sopstvenih podataka.
      *
      * @param id identifikator klijenta
      * @return DTO sa ID-em, imenom i prezimenom klijenta
      */
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyRole('SERVICE','ADMIN')")
-    public ResponseEntity<ClientInfoResponseDto> getInfoById(@AuthenticationPrincipal Jwt jwt,@PathVariable Long id) {
+    @PreAuthorize("hasAnyRole('SERVICE','ADMIN','CLIENT_BASIC')")
+    public ResponseEntity<ClientInfoResponseDto> getInfoById(@AuthenticationPrincipal Jwt jwt, @PathVariable Long id) {
+        String roles = jwt.getClaimAsString("roles");
+        if (roles != null && roles.startsWith("CLIENT_")) {
+            Long tokenId = jwt.getClaim("id");
+            if (!id.equals(tokenId)) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+        }
         return ResponseEntity.ok(clientService.getInfoById(id));
     }
 }

--- a/exchange-service/src/main/java/com/banka1/exchangeService/controller/ExchangeRateController.java
+++ b/exchange-service/src/main/java/com/banka1/exchangeService/controller/ExchangeRateController.java
@@ -72,7 +72,7 @@ public class ExchangeRateController {
      * @return list of daily exchange rates sorted by currency code
      */
     @GetMapping("/rates")
-    @PreAuthorize("hasAnyRole('ADMIN','SERVICE')")
+    @PreAuthorize("hasAnyRole('ADMIN','SERVICE','CLIENT_BASIC')")
     @Operation(
             summary = "Get stored exchange rates",
             responses = @ApiResponse(
@@ -98,7 +98,7 @@ public class ExchangeRateController {
      */
     @GetMapping("/rates/{currencyCode}")
     @Operation(summary = "Get a single exchange rate")
-    @PreAuthorize("hasAnyRole('ADMIN','SERVICE')")
+    @PreAuthorize("hasAnyRole('ADMIN','SERVICE','CLIENT_BASIC')")
 
     public ExchangeRateDto getRate(
             @PathVariable String currencyCode,

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation("me.paulschwarz:springboot3-dotenv:5.0.1")
     implementation 'io.github.cdimascio:dotenv-java:3.0.0'
     implementation 'org.flywaydb:flyway-core'
+    implementation 'com.google.firebase:firebase-admin:9.4.1'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/notification-service/src/main/java/app/config/FirebaseConfig.java
+++ b/notification-service/src/main/java/app/config/FirebaseConfig.java
@@ -1,0 +1,78 @@
+package app.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * Initializes the Firebase Admin SDK on application startup.
+ *
+ * <p>This configuration reads the path to a Google service account JSON file from
+ * the {@code firebase.credentials-path} property (which is backed by the
+ * {@code FIREBASE_CREDENTIALS_PATH} environment variable) and bootstraps a
+ * {@link FirebaseApp} instance that downstream code uses via
+ * {@link com.google.firebase.messaging.FirebaseMessaging}.
+ *
+ * <p>Initialization is deliberately best-effort: if the credentials path is not
+ * configured or the file cannot be read, the service logs a warning and continues
+ * booting. In that degraded mode {@link app.service.FcmPushService} detects the
+ * missing {@link FirebaseApp} and silently skips push sends while the rest of
+ * the notification pipeline (email delivery, RabbitMQ consumption, audit
+ * persistence) keeps working. This is intentional because email is the
+ * authoritative delivery channel and FCM is only an additive convenience
+ * channel used by the mobile app.
+ */
+@Configuration
+@Slf4j
+public class FirebaseConfig {
+
+    /**
+     * Filesystem path to the Firebase service account JSON.
+     * Empty string when the service is running in email-only mode.
+     */
+    @Value("${firebase.credentials-path:}")
+    private String credentialsPath;
+
+    /**
+     * Initializes the Firebase Admin SDK if credentials are configured.
+     *
+     * <p>Executed once after bean construction. Handles three cases:
+     * <ul>
+     *   <li>property not set → logs a warning and skips initialization so FCM
+     *       pushes become no-ops</li>
+     *   <li>{@link FirebaseApp} already initialized (e.g. by a prior call in the
+     *       same JVM during tests) → leaves the existing instance in place</li>
+     *   <li>credentials file missing or unreadable → logs an error and leaves
+     *       Firebase uninitialized; the service continues running without FCM</li>
+     * </ul>
+     */
+    @PostConstruct
+    public void initFirebase() {
+        if (credentialsPath == null || credentialsPath.isBlank()) {
+            log.warn("FIREBASE_CREDENTIALS_PATH not set — FCM push notifications disabled");
+            return;
+        }
+
+        if (!FirebaseApp.getApps().isEmpty()) {
+            log.info("FirebaseApp already initialized");
+            return;
+        }
+
+        try (FileInputStream serviceAccount = new FileInputStream(credentialsPath)) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            FirebaseApp.initializeApp(options);
+            log.info("Firebase initialized from {}", credentialsPath);
+        } catch (IOException e) {
+            log.error("Failed to initialize Firebase from {}: {}", credentialsPath, e.getMessage());
+        }
+    }
+}

--- a/notification-service/src/main/java/app/controller/FcmTokenController.java
+++ b/notification-service/src/main/java/app/controller/FcmTokenController.java
@@ -1,0 +1,107 @@
+package app.controller;
+
+import app.dto.FcmTestRequest;
+import app.dto.FcmTokenRequest;
+import app.service.FcmPushService;
+import app.service.FcmTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+/**
+ * REST surface for managing Firebase Cloud Messaging device tokens and for
+ * manually triggering a push during development and integration testing.
+ *
+ * <p>All endpoints live under {@code /notifications/fcm} and are proxied
+ * through nginx by the api-gateway. The register/deregister endpoints are
+ * called by the mobile app on login and logout; the {@code /test} endpoint is
+ * used from Postman or Swagger UI to verify the FCM wiring end-to-end without
+ * having to go through verification-service and RabbitMQ.
+ */
+@RestController
+@RequestMapping("/notifications/fcm")
+@RequiredArgsConstructor
+@Tag(name = "FCM Token Management", description = "Register and test Firebase Cloud Messaging tokens")
+public class FcmTokenController {
+
+    /** Application service that manages the {@code fcm_tokens} registry. */
+    private final FcmTokenService fcmTokenService;
+    /** Application service that performs the actual FCM send. */
+    private final FcmPushService fcmPushService;
+
+    /**
+     * Registers a new FCM token for a client or refreshes the existing one.
+     *
+     * <p>This is the endpoint the mobile app calls after login as soon as the
+     * Firebase SDK has produced a device token. Re-invocation is safe — the
+     * token is upserted in place.
+     *
+     * @param request body with {@code clientId} and the raw {@code fcmToken}
+     * @return HTTP 200 on successful persistence
+     */
+    @PutMapping("/token")
+    @Operation(summary = "Register or update FCM token for a client")
+    public ResponseEntity<Void> registerToken(@Valid @RequestBody FcmTokenRequest request) {
+        fcmTokenService.upsertToken(request.getClientId(), request.getFcmToken());
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Removes the FCM token registration for a client.
+     *
+     * <p>Called by the mobile app on logout so the service stops targeting a
+     * device that should no longer receive verification pushes.
+     *
+     * @param clientId id of the client whose device should be deregistered
+     * @return HTTP 200 regardless of whether a row existed
+     */
+    @DeleteMapping("/token/{clientId}")
+    @Operation(summary = "Deregister FCM token for a client (called on logout)")
+    public ResponseEntity<Void> deregisterToken(@PathVariable Long clientId) {
+        fcmTokenService.deleteToken(clientId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Sends a single test FCM push directly to the client's registered device.
+     *
+     * <p>This endpoint bypasses verification-service and RabbitMQ entirely. It
+     * looks up the currently registered token for {@code clientId} and sends a
+     * push with whatever {@code code}, {@code operationType}, and
+     * {@code sessionId} the caller supplies. It exists purely for manual
+     * testing from Postman/Swagger while iterating on the mobile display code.
+     *
+     * @param request body with the target {@code clientId}, the code to
+     *                display, and optional operation/session metadata
+     * @return HTTP 200 with a confirmation message on success, or HTTP 400
+     *         when no token is registered for the given client
+     */
+    @PostMapping("/test")
+    @Operation(summary = "Send a test FCM push notification (for Swagger testing)")
+    public ResponseEntity<String> testPush(@Valid @RequestBody FcmTestRequest request) {
+        Optional<String> token = fcmTokenService.findToken(request.getClientId());
+        if (token.isEmpty()) {
+            return ResponseEntity.badRequest()
+                    .body("No FCM token registered for clientId=" + request.getClientId());
+        }
+
+        fcmPushService.sendVerificationPush(
+                token.get(),
+                request.getCode(),
+                request.getOperationType(),
+                request.getSessionId()
+        );
+        return ResponseEntity.ok("FCM push sent to clientId=" + request.getClientId());
+    }
+}

--- a/notification-service/src/main/java/app/dto/FcmTestRequest.java
+++ b/notification-service/src/main/java/app/dto/FcmTestRequest.java
@@ -1,0 +1,52 @@
+package app.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Request body for {@code POST /notifications/fcm/test} — used from Postman
+ * and Swagger to send a single FCM push directly to a client's registered
+ * device without going through verification-service or RabbitMQ.
+ *
+ * <p>This DTO deliberately mirrors the payload fields that
+ * {@link app.service.FcmPushService#sendVerificationPush} sends so manual
+ * tests exercise the same mobile-side rendering path as real verification
+ * events.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FcmTestRequest {
+
+    /** Target client whose registered device should receive the test push. */
+    @NotNull
+    @Schema(description = "Client ID to send test push to", example = "1")
+    private Long clientId;
+
+    /** 6-digit OTP that the mobile app will display in the notification. */
+    @NotBlank
+    @Schema(description = "6-digit code to send", example = "123456")
+    private String code;
+
+    /**
+     * Business operation label shown on the device, typically one of
+     * {@code PAYMENT} or {@code TRANSFER}. Optional — a fallback label is
+     * substituted when null.
+     */
+    @Schema(description = "Operation type", example = "PAYMENT")
+    private String operationType;
+
+    /**
+     * Verification session id passed through to the mobile app so it can call
+     * {@code /verification/validate} after the user enters the code. Optional
+     * for pure display smoke tests.
+     */
+    @Schema(description = "Session ID", example = "42")
+    private String sessionId;
+}

--- a/notification-service/src/main/java/app/dto/FcmTokenRequest.java
+++ b/notification-service/src/main/java/app/dto/FcmTokenRequest.java
@@ -1,0 +1,31 @@
+package app.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Request body for {@code PUT /notifications/fcm/token} — carries the mapping
+ * between a Banka1 {@code clientId} and a Firebase Cloud Messaging device token
+ * produced by the Firebase SDK on the mobile app.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FcmTokenRequest {
+
+    /** Id of the client that owns the device. */
+    @NotNull
+    @Schema(description = "Client ID", example = "1")
+    private Long clientId;
+
+    /** Raw FCM device token produced by the Firebase SDK. */
+    @NotBlank
+    @Schema(description = "FCM device token", example = "dK3x...")
+    private String fcmToken;
+}

--- a/notification-service/src/main/java/app/dto/NotificationRequest.java
+++ b/notification-service/src/main/java/app/dto/NotificationRequest.java
@@ -48,6 +48,24 @@ public class NotificationRequest implements Serializable {
     private Map<String, String> templateVariables = new HashMap<>();
 
     /**
+     * Client ID for FCM token lookup (nullable, backward-compatible).
+     */
+    @Schema(description = "Client ID for push notification delivery")
+    private Long clientId;
+
+    /**
+     * Operation type (e.g. PAYMENT, TRANSFER) for display in push notification.
+     */
+    @Schema(description = "Operation type for the verification")
+    private String operationType;
+
+    /**
+     * Verification session ID, passed to mobile for validate calls.
+     */
+    @Schema(description = "Verification session ID")
+    private String sessionId;
+
+    /**
      * Convenience constructor for tests and manual object creation.
      *
      * @param reqName          display username

--- a/notification-service/src/main/java/app/entities/FcmToken.java
+++ b/notification-service/src/main/java/app/entities/FcmToken.java
@@ -1,0 +1,61 @@
+package app.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * JPA entity mapping the {@code fcm_tokens} table that tracks the active
+ * Firebase Cloud Messaging device token for each client.
+ *
+ * <p>The {@code clientId} column carries a unique constraint because the
+ * project intentionally allows at most one active device per client — upserting
+ * through {@link app.service.FcmTokenService#upsertToken(Long, String)} is the
+ * only supported way to mutate this table.
+ */
+@Entity
+@Table(name = "fcm_tokens")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FcmToken {
+
+    /** Surrogate primary key. */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * Client id that owns this registration. Unique — re-registration replaces
+     * the existing row rather than inserting a parallel one.
+     */
+    @Column(nullable = false, unique = true)
+    private Long clientId;
+
+    /**
+     * Raw FCM device token as produced by the Firebase SDK on the mobile client.
+     * The 512 character cap comfortably fits the current token shapes produced
+     * by the Firebase Android SDK.
+     */
+    @Column(nullable = false, length = 512)
+    private String fcmToken;
+
+    /**
+     * Wall-clock time of the last upsert, used mainly for observability and
+     * future stale-token cleanup.
+     */
+    @Column(nullable = false)
+    private Instant updatedAt;
+}

--- a/notification-service/src/main/java/app/repository/FcmTokenRepository.java
+++ b/notification-service/src/main/java/app/repository/FcmTokenRepository.java
@@ -1,0 +1,35 @@
+package app.repository;
+
+import app.entities.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * Spring Data repository for {@link FcmToken} rows in the {@code fcm_tokens}
+ * table.
+ *
+ * <p>Only two access paths exist beyond the standard {@code JpaRepository}
+ * surface because all FCM token lookups in this service are keyed by
+ * {@code clientId} — which is the unique constraint on the table.
+ */
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    /**
+     * Finds the active FCM registration for a client.
+     *
+     * @param clientId id of the client to look up
+     * @return the registration if one exists, otherwise empty
+     */
+    Optional<FcmToken> findByClientId(Long clientId);
+
+    /**
+     * Removes the registration for a client, if any. Absent rows are a silent
+     * no-op.
+     *
+     * @param clientId id of the client to deregister
+     */
+    void deleteByClientId(Long clientId);
+}

--- a/notification-service/src/main/java/app/service/FcmPushService.java
+++ b/notification-service/src/main/java/app/service/FcmPushService.java
@@ -1,0 +1,101 @@
+package app.service;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.AndroidConfig.Priority;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Sends verification OTP pushes to the mobile client via Firebase Cloud Messaging.
+ *
+ * <p>This service is deliberately decoupled from the main delivery pipeline:
+ * <ul>
+ *   <li>Email delivery remains the authoritative channel for verification codes
+ *       and is handled by {@link NotificationDeliveryService}.</li>
+ *   <li>FCM pushes are an additive convenience that lets the mobile app display
+ *       the code in a notification. If Firebase is not initialized or the send
+ *       fails for any reason the rest of the pipeline is unaffected.</li>
+ * </ul>
+ *
+ * <p>The service captures the initialization state of {@link FirebaseApp} at
+ * construction time. In environments where {@code FIREBASE_CREDENTIALS_PATH} is
+ * not set {@link FirebaseConfig} never creates a {@link FirebaseApp}, and every
+ * call here becomes a no-op.
+ */
+@Service
+@Slf4j
+public class FcmPushService {
+
+    /**
+     * True when a {@link FirebaseApp} was successfully initialized before this
+     * service was constructed. Checked on each send to short-circuit cleanly in
+     * email-only deployments.
+     */
+    private final boolean firebaseAvailable;
+
+    /**
+     * Captures the availability of Firebase at bean construction time.
+     * Logs a single warning if Firebase has not been initialized so that
+     * operators immediately notice the degraded mode in service logs.
+     */
+    public FcmPushService() {
+        this.firebaseAvailable = !FirebaseApp.getApps().isEmpty();
+        if (!firebaseAvailable) {
+            log.warn("Firebase is not initialized — FCM push will be skipped");
+        }
+    }
+
+    /**
+     * Sends a high-priority data-only FCM message containing a verification OTP
+     * to a single device.
+     *
+     * <p>The payload carries {@code type=VERIFICATION_OTP} together with the
+     * verification code, operation type, and session id so the mobile app can
+     * render the notification, store the code locally, and later validate it via
+     * the verification-service. No notification block is included — the mobile
+     * app is responsible for building the user-visible notification from the
+     * data payload so it behaves consistently regardless of app lifecycle state.
+     *
+     * <p>Failures never propagate: any exception thrown by the FCM SDK is logged
+     * at warn level and swallowed so that email delivery (the authoritative
+     * channel) is not disturbed.
+     *
+     * @param fcmToken device token previously registered via
+     *                 {@link FcmTokenService#upsertToken(Long, String)}
+     * @param code raw 6-digit OTP code to display on the device
+     * @param operationType business operation triggering the verification, e.g.
+     *                      {@code PAYMENT} or {@code TRANSFER}; {@code UNKNOWN}
+     *                      is substituted when null
+     * @param sessionId verification-service session id used by the mobile app
+     *                  when calling {@code /verification/validate}; empty string
+     *                  is substituted when null
+     */
+    public void sendVerificationPush(String fcmToken, String code,
+                                      String operationType, String sessionId) {
+        if (!firebaseAvailable) {
+            log.debug("Firebase not available, skipping FCM push");
+            return;
+        }
+
+        Message message = Message.builder()
+                .setToken(fcmToken)
+                .putData("type", "VERIFICATION_OTP")
+                .putData("code", code)
+                .putData("operationType", operationType != null ? operationType : "UNKNOWN")
+                .putData("sessionId", sessionId != null ? sessionId : "")
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(Priority.HIGH)
+                        .build())
+                .build();
+
+        try {
+            String messageId = FirebaseMessaging.getInstance().send(message);
+            log.info("FCM push sent: messageId={}, operationType={}", messageId, operationType);
+        } catch (Exception e) {
+            log.warn("FCM push failed (email delivery is authoritative): {}", e.getMessage());
+        }
+    }
+}

--- a/notification-service/src/main/java/app/service/FcmTokenService.java
+++ b/notification-service/src/main/java/app/service/FcmTokenService.java
@@ -1,0 +1,97 @@
+package app.service;
+
+import app.entities.FcmToken;
+import app.repository.FcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Manages the {@link FcmToken} registry that maps a {@code clientId} to a single
+ * active Firebase Cloud Messaging device token.
+ *
+ * <p>The lifecycle mirrors the mobile app: a token is inserted or refreshed on
+ * login, looked up when a verification push must be delivered, and removed on
+ * logout or explicit deregistration. Only one active token is kept per client
+ * — re-registering with a different token replaces the previous value rather
+ * than creating a parallel row, because a client is expected to have a single
+ * active mobile device at a time in this project's scope.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmTokenService {
+
+    /**
+     * Persistence entry point for {@link FcmToken} records.
+     */
+    private final FcmTokenRepository fcmTokenRepository;
+
+    /**
+     * Registers a new FCM token for the given client or refreshes the existing
+     * one in place.
+     *
+     * <p>If a row already exists for {@code clientId}, its token value and
+     * {@code updatedAt} timestamp are overwritten. This upsert semantics matches
+     * the mobile app's behavior of calling {@code PUT /notifications/fcm/token}
+     * on every login regardless of whether the token changed.
+     *
+     * @param clientId id of the client whose device is being registered
+     * @param token the FCM device token produced by the Firebase SDK on the
+     *              mobile client
+     */
+    @Transactional
+    public void upsertToken(Long clientId, String token) {
+        Optional<FcmToken> existing = fcmTokenRepository.findByClientId(clientId);
+        if (existing.isPresent()) {
+            FcmToken entity = existing.get();
+            entity.setFcmToken(token);
+            entity.setUpdatedAt(Instant.now());
+            fcmTokenRepository.save(entity);
+            log.info("Updated FCM token for clientId={}", clientId);
+        } else {
+            FcmToken entity = FcmToken.builder()
+                    .clientId(clientId)
+                    .fcmToken(token)
+                    .updatedAt(Instant.now())
+                    .build();
+            fcmTokenRepository.save(entity);
+            log.info("Registered new FCM token for clientId={}", clientId);
+        }
+    }
+
+    /**
+     * Returns the currently registered FCM token for the given client, if any.
+     *
+     * <p>Used by {@link NotificationDeliveryService} when a verification OTP
+     * event must be mirrored to a mobile push: an empty {@link Optional} simply
+     * means the client has no mobile device registered and the push is skipped.
+     *
+     * @param clientId id of the client to look up
+     * @return the registered token or {@link Optional#empty()} when the client
+     *         has never registered a device or was explicitly deregistered
+     */
+    public Optional<String> findToken(Long clientId) {
+        return fcmTokenRepository.findByClientId(clientId)
+                .map(FcmToken::getFcmToken);
+    }
+
+    /**
+     * Removes the FCM token registration for the given client.
+     *
+     * <p>Called on explicit logout from the mobile app. Absent rows are a
+     * silent no-op — Spring Data's {@code deleteByClientId} translates to a
+     * single DELETE statement that affects zero rows when nothing is registered.
+     *
+     * @param clientId id of the client whose device is being deregistered
+     */
+    @Transactional
+    public void deleteToken(Long clientId) {
+        fcmTokenRepository.deleteByClientId(clientId);
+        log.info("Deleted FCM token for clientId={}", clientId);
+    }
+}

--- a/notification-service/src/main/java/app/service/NotificationDeliveryService.java
+++ b/notification-service/src/main/java/app/service/NotificationDeliveryService.java
@@ -77,6 +77,14 @@ public class NotificationDeliveryService {
      * In-memory scheduler optimization for due retries.
      */
     private final RetryTaskQueue retryTaskQueue;
+    /**
+     * FCM push service for verification code delivery.
+     */
+    private final FcmPushService fcmPushService;
+    /**
+     * FCM token lookup service.
+     */
+    private final FcmTokenService fcmTokenService;
 
     /**
      * Configured routing keys map.
@@ -182,6 +190,15 @@ public class NotificationDeliveryService {
         );
         notificationDeliveryTxService.createPendingDelivery(delivery);
         runAfterCommit(() -> attemptDelivery(deliveryId));
+
+        // FCM push for verification OTPs (fire-and-forget, email is authoritative)
+        if ("VERIFICATION_OTP".equals(notificationType) && req.getClientId() != null) {
+            String rawCode = req.getTemplateVariables().get("code");
+            Long clientId = req.getClientId();
+            String opType = req.getOperationType();
+            String sessId = req.getSessionId();
+            runAfterCommit(() -> attemptFcmPush(clientId, rawCode, opType, sessId));
+        }
     }
 
     /**
@@ -439,6 +456,25 @@ public class NotificationDeliveryService {
                 return;
             }
             pageNumber++;
+        }
+    }
+
+    /**
+     * Attempts to send an FCM push notification for a verification OTP.
+     * Fire-and-forget: if no token is registered or sending fails,
+     * email delivery remains the authoritative channel.
+     */
+    private void attemptFcmPush(Long clientId, String code,
+                                 String operationType, String sessionId) {
+        try {
+            Optional<String> token = fcmTokenService.findToken(clientId);
+            if (token.isEmpty()) {
+                log.debug("No FCM token for clientId={}, skipping push", clientId);
+                return;
+            }
+            fcmPushService.sendVerificationPush(token.get(), code, operationType, sessionId);
+        } catch (Exception e) {
+            log.warn("FCM push failed for clientId={}: {}", clientId, e.getMessage());
         }
     }
 

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -108,6 +108,9 @@ notification.routing-keys.card.request_failure=CARD_REQUEST_FAILURE
 notification.routing-keys.card.blocked=CARD_BLOCKED
 notification.routing-keys.card.unblocked=CARD_UNBLOCKED
 notification.routing-keys.card.deactivated=CARD_DEACTIVATED
+
+# Firebase Cloud Messaging
+firebase.credentials-path=${FIREBASE_CREDENTIALS_PATH:}
 notification.routing-keys.credit.approved=CREDIT_APPROVED
 notification.routing-keys.credit.declined=CREDIT_DECLINED
 notification.routing-keys.credit.installment_failed=CREDIT_INSTALLMENT_FAILED

--- a/notification-service/src/test/java/app/controller/FcmTokenControllerUnitTest.java
+++ b/notification-service/src/test/java/app/controller/FcmTokenControllerUnitTest.java
@@ -1,0 +1,133 @@
+package app.controller;
+
+import app.dto.FcmTestRequest;
+import app.dto.FcmTokenRequest;
+import app.service.FcmPushService;
+import app.service.FcmTokenService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link FcmTokenController}.
+ *
+ * <p>These tests use plain Mockito against the controller rather than the Spring MockMvc
+ * stack because notification-service has no security filter chain and the controller
+ * does nothing but parameter pass-through. The goal is to protect the narrow delegation
+ * contracts: register and deregister must forward straight to
+ * {@link FcmTokenService}, and the test-push endpoint must guard against missing token
+ * registrations before invoking {@link FcmPushService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class FcmTokenControllerUnitTest {
+
+    private static final Long CLIENT_ID = 1L;
+    private static final String FCM_TOKEN = "fcm-token-value";
+
+    @Mock
+    private FcmTokenService fcmTokenService;
+
+    @Mock
+    private FcmPushService fcmPushService;
+
+    @InjectMocks
+    private FcmTokenController fcmTokenController;
+
+    /**
+     * Verifies that the register endpoint upserts the supplied token on the service and
+     * returns a 200 response.
+     *
+     * <p>This protects the mobile-login flow that calls {@code PUT /notifications/fcm/token}
+     * on every successful authentication.
+     */
+    @Test
+    void registerTokenUpsertsAndReturnsOk() {
+        FcmTokenRequest request = new FcmTokenRequest();
+        request.setClientId(CLIENT_ID);
+        request.setFcmToken(FCM_TOKEN);
+
+        ResponseEntity<Void> response = fcmTokenController.registerToken(request);
+
+        verify(fcmTokenService).upsertToken(CLIENT_ID, FCM_TOKEN);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    /**
+     * Verifies that the deregister endpoint deletes the token for the given client id
+     * and returns a 200 response.
+     *
+     * <p>This protects the mobile-logout flow that stops the service from targeting a
+     * device the user has signed out of.
+     */
+    @Test
+    void deregisterTokenDeletesAndReturnsOk() {
+        ResponseEntity<Void> response = fcmTokenController.deregisterToken(CLIENT_ID);
+
+        verify(fcmTokenService).deleteToken(CLIENT_ID);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    /**
+     * Verifies that the test-push endpoint looks up the registered token, sends the push
+     * with the supplied payload fields, and returns a 200 confirmation.
+     *
+     * <p>This protects the manual-testing path used from Postman and Swagger while
+     * iterating on mobile display code.
+     */
+    @Test
+    void testPushSendsPushWhenTokenIsRegistered() {
+        FcmTestRequest request = new FcmTestRequest();
+        request.setClientId(CLIENT_ID);
+        request.setCode("123456");
+        request.setOperationType("PAYMENT");
+        request.setSessionId("42");
+        when(fcmTokenService.findToken(CLIENT_ID)).thenReturn(Optional.of(FCM_TOKEN));
+
+        ResponseEntity<String> response = fcmTokenController.testPush(request);
+
+        verify(fcmPushService).sendVerificationPush(FCM_TOKEN, "123456", "PAYMENT", "42");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().contains(String.valueOf(CLIENT_ID)));
+    }
+
+    /**
+     * Verifies that the test-push endpoint returns a 400 Bad Request and does not invoke
+     * the push service when no FCM token is registered for the given client.
+     *
+     * <p>This protects against silently losing test pushes that would otherwise look
+     * successful from Postman even though nothing was sent.
+     */
+    @Test
+    void testPushReturnsBadRequestWhenClientHasNoRegisteredToken() {
+        FcmTestRequest request = new FcmTestRequest();
+        request.setClientId(CLIENT_ID);
+        request.setCode("123456");
+        when(fcmTokenService.findToken(CLIENT_ID)).thenReturn(Optional.empty());
+
+        ResponseEntity<String> response = fcmTokenController.testPush(request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().contains(String.valueOf(CLIENT_ID)));
+        verify(fcmPushService, never()).sendVerificationPush(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+}

--- a/notification-service/src/test/java/app/service/FcmPushServiceUnitTest.java
+++ b/notification-service/src/test/java/app/service/FcmPushServiceUnitTest.java
@@ -1,0 +1,69 @@
+package app.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Unit tests for {@link FcmPushService}.
+ *
+ * <p>Since the test JVM never initializes a real {@link com.google.firebase.FirebaseApp},
+ * the service instance constructed here runs in its "email-only" degraded mode where
+ * {@code firebaseAvailable} is false. These tests protect that short-circuit path, which
+ * is the contract the rest of the delivery pipeline relies on: a missing Firebase
+ * configuration must never block email delivery or propagate exceptions up to
+ * {@link NotificationDeliveryService}.
+ *
+ * <p>The happy path that actually talks to {@code FirebaseMessaging} is deliberately
+ * not exercised here to keep the unit test hermetic — it is covered end-to-end through
+ * Postman against a running Firebase project.
+ */
+class FcmPushServiceUnitTest {
+
+    /**
+     * Verifies that constructing the service without an initialized Firebase SDK
+     * does not throw and leaves the service in a callable state.
+     *
+     * <p>This is the baseline guarantee for every environment where
+     * {@code FIREBASE_CREDENTIALS_PATH} is intentionally unset, such as CI.
+     */
+    @Test
+    void constructorSucceedsWhenFirebaseIsNotInitialized() {
+        assertDoesNotThrow((org.junit.jupiter.api.function.ThrowingSupplier<FcmPushService>) FcmPushService::new);
+    }
+
+    /**
+     * Verifies that sendVerificationPush short-circuits cleanly when Firebase is not
+     * available, accepting all parameters (including nulls for optional fields) without
+     * throwing.
+     *
+     * <p>This protects the fire-and-forget contract enforced by
+     * {@link NotificationDeliveryService#attemptFcmPush} — the email branch must stay
+     * authoritative even if FCM is fully disabled.
+     */
+    @Test
+    void sendVerificationPushDoesNothingWhenFirebaseIsUnavailable() {
+        FcmPushService service = new FcmPushService();
+
+        assertDoesNotThrow(() ->
+                service.sendVerificationPush("fcm-token", "123456", "PAYMENT", "42")
+        );
+    }
+
+    /**
+     * Verifies that sendVerificationPush tolerates null operationType and sessionId
+     * parameters even in the short-circuit path.
+     *
+     * <p>The message builder substitutes defaults for these fields, so callers are
+     * allowed to pass nulls. The test guards against a regression that would
+     * re-introduce an NPE for partial payloads.
+     */
+    @Test
+    void sendVerificationPushHandlesNullOptionalFieldsWithoutThrowing() {
+        FcmPushService service = new FcmPushService();
+
+        assertDoesNotThrow(() ->
+                service.sendVerificationPush("fcm-token", "123456", null, null)
+        );
+    }
+}

--- a/notification-service/src/test/java/app/service/FcmTokenServiceUnitTest.java
+++ b/notification-service/src/test/java/app/service/FcmTokenServiceUnitTest.java
@@ -1,0 +1,143 @@
+package app.service;
+
+import app.entities.FcmToken;
+import app.repository.FcmTokenRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link FcmTokenService}.
+ *
+ * <p>These tests cover the upsert, lookup, and delete lifecycle of FCM device
+ * tokens without touching a real database. The goal is to protect the narrow
+ * contract relied on by {@link NotificationDeliveryService} when mirroring
+ * verification OTP events to mobile pushes.
+ */
+@ExtendWith(MockitoExtension.class)
+class FcmTokenServiceUnitTest {
+
+    private static final Long CLIENT_ID = 42L;
+    private static final String NEW_TOKEN = "fcm-token-new";
+    private static final String OLD_TOKEN = "fcm-token-old";
+
+    @Mock
+    private FcmTokenRepository fcmTokenRepository;
+
+    @InjectMocks
+    private FcmTokenService fcmTokenService;
+
+    /**
+     * Verifies that calling upsert for a client that has no existing row inserts
+     * a fresh {@link FcmToken} with the supplied token and a populated
+     * {@code updatedAt} timestamp.
+     *
+     * <p>This protects the first-login path on the mobile app.
+     */
+    @Test
+    void upsertTokenInsertsNewRowWhenClientHasNoExistingRegistration() {
+        when(fcmTokenRepository.findByClientId(CLIENT_ID)).thenReturn(Optional.empty());
+
+        fcmTokenService.upsertToken(CLIENT_ID, NEW_TOKEN);
+
+        ArgumentCaptor<FcmToken> captor = ArgumentCaptor.forClass(FcmToken.class);
+        verify(fcmTokenRepository).save(captor.capture());
+        FcmToken saved = captor.getValue();
+
+        assertEquals(CLIENT_ID, saved.getClientId());
+        assertEquals(NEW_TOKEN, saved.getFcmToken());
+        assertNotNull(saved.getUpdatedAt());
+    }
+
+    /**
+     * Verifies that calling upsert for a client that already has a registration
+     * overwrites the token on the existing row rather than inserting a second
+     * one.
+     *
+     * <p>This protects the token-refresh path the mobile app hits on every
+     * login and whenever the Firebase SDK rotates the device token.
+     */
+    @Test
+    void upsertTokenOverwritesExistingRowInPlace() {
+        FcmToken existing = FcmToken.builder()
+                .id(1L)
+                .clientId(CLIENT_ID)
+                .fcmToken(OLD_TOKEN)
+                .updatedAt(java.time.Instant.parse("2026-01-01T00:00:00Z"))
+                .build();
+        when(fcmTokenRepository.findByClientId(CLIENT_ID)).thenReturn(Optional.of(existing));
+
+        fcmTokenService.upsertToken(CLIENT_ID, NEW_TOKEN);
+
+        ArgumentCaptor<FcmToken> captor = ArgumentCaptor.forClass(FcmToken.class);
+        verify(fcmTokenRepository).save(captor.capture());
+        FcmToken saved = captor.getValue();
+
+        assertEquals(1L, saved.getId());
+        assertEquals(NEW_TOKEN, saved.getFcmToken());
+        assertTrue(saved.getUpdatedAt().isAfter(java.time.Instant.parse("2026-01-01T00:00:00Z")));
+    }
+
+    /**
+     * Verifies that findToken returns the stored token when a row exists.
+     *
+     * <p>This is the lookup path used by {@link NotificationDeliveryService}
+     * before dispatching an FCM push.
+     */
+    @Test
+    void findTokenReturnsStoredTokenWhenPresent() {
+        FcmToken entity = FcmToken.builder()
+                .clientId(CLIENT_ID)
+                .fcmToken(NEW_TOKEN)
+                .updatedAt(java.time.Instant.now())
+                .build();
+        when(fcmTokenRepository.findByClientId(CLIENT_ID)).thenReturn(Optional.of(entity));
+
+        Optional<String> result = fcmTokenService.findToken(CLIENT_ID);
+
+        assertTrue(result.isPresent());
+        assertEquals(NEW_TOKEN, result.get());
+    }
+
+    /**
+     * Verifies that findToken returns an empty {@link Optional} when the
+     * client has no registered device.
+     *
+     * <p>This is the short-circuit signal that tells the delivery pipeline to
+     * skip the FCM branch without treating it as an error.
+     */
+    @Test
+    void findTokenReturnsEmptyWhenNoRegistrationExists() {
+        when(fcmTokenRepository.findByClientId(CLIENT_ID)).thenReturn(Optional.empty());
+
+        Optional<String> result = fcmTokenService.findToken(CLIENT_ID);
+
+        assertFalse(result.isPresent());
+        verify(fcmTokenRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    /**
+     * Verifies that deleteToken delegates directly to the repository.
+     *
+     * <p>This protects the logout flow on the mobile app.
+     */
+    @Test
+    void deleteTokenDelegatesToRepository() {
+        fcmTokenService.deleteToken(CLIENT_ID);
+
+        verify(fcmTokenRepository).deleteByClientId(CLIENT_ID);
+    }
+}

--- a/notification-service/src/test/java/app/service/NotificationDeliveryServiceUnitTest.java
+++ b/notification-service/src/test/java/app/service/NotificationDeliveryServiceUnitTest.java
@@ -73,6 +73,12 @@ class NotificationDeliveryServiceUnitTest {
     private RetryTaskQueue retryTaskQueue;
 
     @Mock
+    private FcmPushService fcmPushService;
+
+    @Mock
+    private FcmTokenService fcmTokenService;
+
+    @Mock
     private Map<String, String> routingKeysMap;
 
     @InjectMocks
@@ -635,6 +641,120 @@ class NotificationDeliveryServiceUnitTest {
         notificationDeliveryService.processDueRetries();
     }
 
+
+    /**
+     * Verifies that a VERIFICATION_OTP message with a populated clientId triggers the
+     * FCM push branch after the surrounding transaction commits.
+     *
+     * <p>This protects the new dual-channel contract: email remains the authoritative
+     * delivery path, and the FCM push must fire in addition to it for verification
+     * codes so the mobile app can display them to the user.
+     */
+    @Test
+    void handleIncomingMessageSendsFcmPushForVerificationOtpAfterCommit() {
+        NotificationRequest request = new NotificationRequest("Dimitrije", TEST_EMAIL,
+                new HashMap<>(Map.of("code", "123456")));
+        request.setClientId(42L);
+        request.setOperationType("PAYMENT");
+        request.setSessionId("99");
+        when(routingKeysMap.get("verification.generated")).thenReturn("VERIFICATION_OTP");
+        when(notificationService.resolveEmailContent(request, "VERIFICATION_OTP"))
+                .thenReturn(new ResolvedEmail(TEST_EMAIL, "OTP", "Body"));
+        when(fcmTokenService.findToken(42L)).thenReturn(Optional.of("device-token"));
+
+        runHandleIncomingMessageAndCommit(() ->
+                notificationDeliveryService.handleIncomingMessage(request, "verification.generated")
+        );
+
+        verify(fcmTokenService).findToken(42L);
+        verify(fcmPushService).sendVerificationPush("device-token", "123456", "PAYMENT", "99");
+    }
+
+    /**
+     * Verifies that a VERIFICATION_OTP message is still delivered via email when the
+     * target client has no FCM token registered, and that the FCM send is skipped
+     * silently.
+     *
+     * <p>This protects the fire-and-forget contract: the absence of a mobile device
+     * must never block the authoritative email channel.
+     */
+    @Test
+    void handleIncomingMessageSkipsFcmPushWhenNoTokenRegisteredForClient() {
+        NotificationRequest request = new NotificationRequest("Dimitrije", TEST_EMAIL,
+                new HashMap<>(Map.of("code", "654321")));
+        request.setClientId(7L);
+        request.setOperationType("TRANSFER");
+        request.setSessionId("11");
+        when(routingKeysMap.get("verification.generated")).thenReturn("VERIFICATION_OTP");
+        when(notificationService.resolveEmailContent(request, "VERIFICATION_OTP"))
+                .thenReturn(new ResolvedEmail(TEST_EMAIL, "OTP", "Body"));
+        when(fcmTokenService.findToken(7L)).thenReturn(Optional.empty());
+
+        runHandleIncomingMessageAndCommit(() ->
+                notificationDeliveryService.handleIncomingMessage(request, "verification.generated")
+        );
+
+        verify(fcmTokenService).findToken(7L);
+        verify(fcmPushService, never()).sendVerificationPush(
+                anyString(), anyString(), anyString(), anyString()
+        );
+        verify(notificationService).sendEmail(TEST_EMAIL, "OTP", "Body");
+    }
+
+    /**
+     * Verifies that FCM push failures do not propagate out of the delivery pipeline.
+     *
+     * <p>This protects the fire-and-forget guarantee: if the FCM SDK throws (for
+     * example, because the stored token has been revoked on the device), the email
+     * delivery must still succeed and the exception must not surface to the RabbitMQ
+     * consumer.
+     */
+    @Test
+    void handleIncomingMessageSwallowsFcmPushFailuresWithoutAffectingEmailDelivery() {
+        NotificationRequest request = new NotificationRequest("Dimitrije", TEST_EMAIL,
+                new HashMap<>(Map.of("code", "111222")));
+        request.setClientId(5L);
+        request.setOperationType("PAYMENT");
+        request.setSessionId("3");
+        when(routingKeysMap.get("verification.generated")).thenReturn("VERIFICATION_OTP");
+        when(notificationService.resolveEmailContent(request, "VERIFICATION_OTP"))
+                .thenReturn(new ResolvedEmail(TEST_EMAIL, "OTP", "Body"));
+        when(fcmTokenService.findToken(5L)).thenReturn(Optional.of("device-token"));
+        doThrow(new IllegalStateException("FCM transport down"))
+                .when(fcmPushService).sendVerificationPush(anyString(), anyString(), anyString(), anyString());
+
+        runHandleIncomingMessageAndCommit(() ->
+                notificationDeliveryService.handleIncomingMessage(request, "verification.generated")
+        );
+
+        verify(fcmPushService).sendVerificationPush("device-token", "111222", "PAYMENT", "3");
+        verify(notificationService).sendEmail(TEST_EMAIL, "OTP", "Body");
+    }
+
+    /**
+     * Verifies that non-verification notification types never consult the FCM token
+     * registry and never attempt a push.
+     *
+     * <p>This protects the scope boundary of the FCM branch: only
+     * {@code VERIFICATION_OTP} events are mirrored to mobile pushes.
+     */
+    @Test
+    void handleIncomingMessageDoesNotSendFcmPushForNonVerificationNotifications() {
+        NotificationRequest request = new NotificationRequest("Dimitrije", TEST_EMAIL, Map.of());
+        request.setClientId(42L);
+        when(routingKeysMap.get("EMPLOYEE_CREATED")).thenReturn("EMPLOYEE_CREATED");
+        when(notificationService.resolveEmailContent(request, "EMPLOYEE_CREATED"))
+                .thenReturn(new ResolvedEmail(TEST_EMAIL, "Hello", "Body"));
+
+        runHandleIncomingMessageAndCommit(() ->
+                notificationDeliveryService.handleIncomingMessage(request, "EMPLOYEE_CREATED")
+        );
+
+        verify(fcmTokenService, never()).findToken(org.mockito.ArgumentMatchers.anyLong());
+        verify(fcmPushService, never()).sendVerificationPush(
+                anyString(), anyString(), anyString(), anyString()
+        );
+    }
 
     /**
      * Runs code with active transaction synchronization enabled.

--- a/setup/.env.example
+++ b/setup/.env.example
@@ -219,3 +219,11 @@ LOG_LEVEL_APP=INFO
 # =========================
 
 SKIP_VERIFICATION=false
+
+# =========================
+# Firebase Config
+# =========================
+# Path inside the notification-service container where the Firebase service account JSON is mounted.
+# Place Firebase service account key JSON in the setup/ folder and it will be volume-mounted.
+# Leave empty to disable FCM push (email-only mode).
+FIREBASE_CREDENTIALS_PATH=/app/firebase-credentials.json

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -167,6 +167,7 @@ services:
       OTEL_LOGS_EXPORTER: none
       OTEL_SERVICE_NAME: notification-service
       LOGGING_FILE_PATH: /var/log/banka
+      FIREBASE_CREDENTIALS_PATH: ${FIREBASE_CREDENTIALS_PATH:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -180,6 +181,7 @@ services:
       - banka-network
     volumes:
       - notification-service-logs:/var/log/banka
+      - ./banka-1-firebase-firebase-adminsdk-fbsvc-e306452a8c.json:/app/firebase-credentials.json:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:${NOTIFICATION_SERVER_PORT:-8006}/actuator/health/liveness || exit 1"]
       interval: 15s
@@ -837,6 +839,7 @@ services:
       VERIFICATION_SERVER_PORT: ${VERIFICATION_SERVER_PORT:-8086}
       TRANSACTION_SERVER_PORT: ${TRANSACTION_SERVER_PORT:-8087}
       CARD_SERVICE_PORT: ${CARD_SERVER_PORT:-8087}
+      NOTIFICATION_SERVICE_PORT: ${NOTIFICATION_SERVER_PORT:-8006}
       ORDER_SERVER_PORT: ${ORDER_SERVER_PORT:-8088}
     depends_on:
       employee-service:
@@ -852,6 +855,8 @@ services:
       verification-service:
         condition: service_healthy
       transaction-service:
+        condition: service_healthy
+      notification-service:
         condition: service_healthy
       order-service:
         condition: service_healthy

--- a/verification-service/src/main/java/com/banka1/verificationService/service/VerificationService.java
+++ b/verification-service/src/main/java/com/banka1/verificationService/service/VerificationService.java
@@ -121,15 +121,17 @@ public class VerificationService {
             );
         }
 
+        final Long sessionId = session.getId();
+
         if (TransactionSynchronizationManager.isActualTransactionActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    publishGeneratedEvent(request, rawCode);
+                    publishGeneratedEvent(request, rawCode, sessionId);
                 }
             });
         } else {
-            publishGeneratedEvent(request, rawCode);
+            publishGeneratedEvent(request, rawCode, sessionId);
         }
 
         return new GenerateResponse(session.getId());
@@ -231,9 +233,12 @@ public class VerificationService {
      * @param request contains the clientEmail for the recipient
      * @param rawCode the 6-digit OTP code to send (before hashing)
      */
-    private void publishGeneratedEvent(GenerateRequest request, String rawCode) {
+    private void publishGeneratedEvent(GenerateRequest request, String rawCode, Long sessionId) {
         Map<String, Object> payload = new HashMap<>();
         payload.put("userEmail", request.getClientEmail());
+        payload.put("clientId", request.getClientId());
+        payload.put("operationType", request.getOperationType().name());
+        payload.put("sessionId", String.valueOf(sessionId));
         Map<String, String> templateVariables = new HashMap<>();
         templateVariables.put("code", rawCode);
         payload.put("templateVariables", templateVariables);


### PR DESCRIPTION
This pull request introduces several important improvements across multiple services, focusing on enhancing service-to-service communication, expanding internal API capabilities, and integrating Firebase push notification support. The most notable changes include the addition of a secure internal endpoint for fetching card details, updates to the account-service to consume this richer card data, expanded access to certain endpoints, and the initial setup for Firebase push notifications in the notification-service.

**Internal Service Communication & Card Data Enhancements:**

* Added a new internal endpoint `GET /internal/account/{accountNumber}` in `CardManagementController` (card-service) that returns detailed, masked card information for trusted service-to-service calls (SERVICE role only), using the new `CardInternalSummaryDTO`. [[1]](diffhunk://#diff-fd8d79cc197180d060a8ebfa7f9ad4e8eb2ede3a67507d07638e84fe6d9b2699R154-R173) [[2]](diffhunk://#diff-5b5d210db9b57047f3fe45e1febb9f9d433a4784fb3c6b513d875db085cc4c16R1-R33)
* Implemented `getInternalCardsByAccountNumber` in `CardLifecycleService` and its implementation, returning the new internal DTO. [[1]](diffhunk://#diff-0b96f3bde4c99118c5e46d82205ecbf0d8dc103fd3a8fb024c8c8b75c5eff406R51-R60) [[2]](diffhunk://#diff-ed5718718e3c0ad30ca21b0f35d9060e39100ab7e099a8a28159794e9b70969dR105-R112)
* Updated `CardServiceRestClient` in account-service to call the new internal endpoint.
* Modified account-service's `ClientServiceImplementation` so that account details responses now include the list of cards retrieved from the new internal endpoint, enriching the account details DTO.

**API Gateway and Notification Service Integration:**

* Updated the API gateway (`default.conf.template`) to add routing for the new notification-service, including a `/notifications/` location for FCM token registration and other notification-related endpoints. [[1]](diffhunk://#diff-cd49f53e9272f29538b59477796ebd6b64b1b8d9107220bd1e1467bc88f13b6cR42-R45) [[2]](diffhunk://#diff-cd49f53e9272f29538b59477796ebd6b64b1b8d9107220bd1e1467bc88f13b6cR194-R207)
* Added Firebase Admin SDK dependency and introduced a `FirebaseConfig` class in notification-service to initialize Firebase from a service account, with graceful fallback if credentials are missing (push notifications become no-ops, but email delivery continues). [[1]](diffhunk://#diff-4d35d8cec5be62506f1a64ac9dd276d4a6c7b6891db6aae96583408938feef04R44) [[2]](diffhunk://#diff-e11b65b201fb65ab88e83508a60e2141cdba378ebeac31422b7c739fde3d8962R1-R78)

**Security and Access Control Improvements:**

* Expanded access to client and exchange rate endpoints to include CLIENT_BASIC role, but ensured that clients can only fetch their own data by adding an explicit check in `ClientController` (`getInfoById`). [[1]](diffhunk://#diff-18194b7c6ca37039bd125bdfe85f3fcce61317e399355a1016987733130a9fd1L154-R170) [[2]](diffhunk://#diff-225ede5978a23671e4ebfca2907ebcc8fd3027c1a4ccca3e4c1c02035005b292L75-R75) [[3]](diffhunk://#diff-225ede5978a23671e4ebfca2907ebcc8fd3027c1a4ccca3e4c1c02035005b292L101-R101)

**Testing:**

* Added and updated tests to cover the new internal card summary endpoint and service logic in card-service. [[1]](diffhunk://#diff-a3d2f121e0b6e931627a1311aa1dffa694f5060ca16b8b30e43a95c15150208eR126-R140) [[2]](diffhunk://#diff-4669b0ca02843706ad4042231b97574558c070989dea19f289e263b32aa7ddafR292-R308)

These changes collectively improve internal data sharing, security, and notification capabilities across the platform.