### PR TITLE
Card service updated to use ID instead of card number

### DIFF
--- a/card-service/.gitignore
+++ b/card-service/.gitignore
@@ -5,6 +5,16 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### Gradle
+/.gradle/
+/gradle/
+/gradlew
+/gradlew.bat
+out/
+/.gradle-local/
+/.gradle-user-home
+/.gradle-cache
+
 ### STS ###
 .apt_generated
 .classpath

--- a/card-service/README.md
+++ b/card-service/README.md
@@ -28,14 +28,16 @@ Implemented now:
 - CVV generation plus hashing
 - card-creation orchestration
 - REST endpoints for card creation flows
+- lifecycle management endpoints for block, unblock, deactivate, and limit updates
+- list responses with masked card numbers plus card IDs
+- single-card detail lookup by card ID
 - account ownership checks against `account-service`
 - verification checks against `verification-service`
 - exception model for business validation failures
 
 Planned later:
 
-- block, unblock, and deactivate flows
-- masked card responses for clients
+- additional product-specific card features beyond the current debit-card scope
 
 ## Business Model
 
@@ -130,52 +132,98 @@ Generated plain CVV: 123
 Stored CVV hash:     $argon2id$v=19$...
 ```
 
-## Card Creation Flow
+## Card Creation Endpoints
 
-When a new card is created, the service does the following:
+`card-service` currently exposes three create flows:
 
-1. validates that the account number is not blank
-2. validates that the limit is not negative
-3. generates a unique brand-compliant card number
-4. generates a random three-digit CVV
-5. hashes the CVV before persistence
-6. sets `cardType` to `DEBIT`
-7. derives `cardName`, for example `MasterCard Debit`
-8. sets `creationDate` to the current date
-9. sets `expirationDate` to five years after `creationDate`
-10. sets `status` to `ACTIVE`
-11. saves the entity and returns the one-time plain CVV to the caller
+- `POST /auto` for automatic system-driven issuance
+- `POST /request` for personal-account card requests
+- `POST /request/business` for business-account card requests
 
-Example creation result:
+All three flows end in the same core card-creation step. Once all preconditions pass, the service:
 
-```text
-Persisted card:
-  cardNumber:     378282246310005
-  cardType:       DEBIT
-  cardName:       AmEx Debit
-  creationDate:   2026-03-23
-  expirationDate: 2031-03-23
-  accountNumber:  265000000000001234
-  cvv:            $argon2id$v=19$...
-  cardLimit:      12000.00
-  status:         ACTIVE
+1. generates a unique brand-compliant card number
+2. generates a random three-digit CVV
+3. hashes the CVV before persistence
+4. sets `cardType` to `DEBIT`
+5. derives `cardName`, for example `Visa Debit`
+6. sets `creationDate` to the current date
+7. sets `expirationDate` to five years after `creationDate`
+8. sets `status` to `ACTIVE`
+9. saves the card and returns the new `cardId`
 
-One-time return value:
-  plainCvv:       123
+Important response rule:
+
+- the full `cardNumber` is returned in the create response
+- the plain `CVV` is returned only once, in the create response
+- later list endpoints mask the card number
+- later card details are fetched by `cardId`
+
+Common create response shape:
+
+```json
+{
+  "cardId": 42,
+  "cardNumber": "4111111111111111",
+  "plainCvv": "123",
+  "expirationDate": "2031-03-23",
+  "cardName": "Visa Debit"
+}
 ```
 
-## Manual Request Flow
+### Automatic Card Creation
 
-Manual card creation is now a single-step flow for both personal and business accounts.
-
-The caller must first complete the external verification flow in `verification-service`.
-`card-service` then receives the final request together with `verificationId` and calls:
+Endpoint:
 
 ```text
-GET /{verificationId}/status
+POST /auto
 ```
 
-Only verification sessions with status `VERIFIED` are accepted. Any other status causes a business error response.
+Who calls it:
+
+- internal service caller or admin
+- intended for the automatic account-created flow
+
+What the request must contain:
+
+```json
+{
+  "clientId": 123,
+  "accountNumber": "265000000000123456",
+  "accountCurrency": "RSD",
+  "accountCategory": "PERSONAL",
+  "accountType": "CURRENT",
+  "accountSubtype": "STANDARD",
+  "ownerFirstName": "Pera",
+  "ownerLastName": "Peric",
+  "ownerEmail": "pera@example.com",
+  "ownerUsername": "pperic",
+  "accountExpirationDate": "2030-12-31"
+}
+```
+
+What is actually required for card creation in the current implementation:
+
+- `clientId` must exist
+- `accountNumber` must be non-blank
+
+What the service does:
+
+1. validates `clientId` and `accountNumber`
+2. picks a random brand from the supported brands
+3. applies the configured automatic default card limit
+4. creates a personal card for the provided account owner
+5. returns the created card immediately
+
+Response:
+
+- HTTP `201 Created`
+- body is the common create response shown above
+
+Notes:
+
+- this endpoint does not require `verificationId`
+- the extra account-owner fields in the request are currently carried by the internal DTO, but the card creation itself uses `clientId` and `accountNumber`
 
 ### Personal Card Request
 
@@ -185,7 +233,12 @@ Endpoint:
 POST /request
 ```
 
-Example request:
+Who calls it:
+
+- authenticated client for their own personal account
+- admin can also call it, but the created card still belongs to the actual owner of the account
+
+What the request must contain:
 
 ```json
 {
@@ -196,14 +249,43 @@ Example request:
 }
 ```
 
-Behavior:
+What must be true before creation:
 
-1. validate the request payload
-2. verify that the authenticated client owns the account
-3. reject business accounts on this endpoint
-4. require `verification-service` status `VERIFIED`
-5. enforce the personal rule: at most 2 active cards per account for the owner
-6. create the card and send the success notification after commit
+- `accountNumber` must be present
+- `cardBrand` must be present
+- `cardLimit` must be `0` or greater
+- the target account must be a personal account
+- if the caller is a client, they must own that account
+- `verification-service` must return status `VERIFIED` for the provided `verificationId`
+- the account owner must have fewer than 2 non-deactivated personal cards on that account
+
+What the service does:
+
+1. loads account context from `account-service`
+2. checks ownership in the controller for client callers
+3. checks verification status in `verification-service`
+4. creates the card for the real owner of the account
+5. sends a success notification after the transaction commits
+
+Response:
+
+- HTTP `201 Created`
+- body:
+
+```json
+{
+  "status": "COMPLETED",
+  "message": "Card created successfully.",
+  "verificationRequestId": null,
+  "createdCard": {
+    "cardId": 42,
+    "cardNumber": "4111111111111111",
+    "plainCvv": "123",
+    "expirationDate": "2031-03-23",
+    "cardName": "Visa Debit"
+  }
+}
+```
 
 ### Business Card Request
 
@@ -212,6 +294,21 @@ Endpoint:
 ```text
 POST /request/business
 ```
+
+Who calls it:
+
+- authenticated business-account owner
+- admin can also call it, but the card is still created under the real owner of the business account
+
+What the request must contain:
+
+- `accountNumber`
+- `recipientType`
+- `cardBrand`
+- `cardLimit`
+- `verificationId`
+
+If `recipientType` is `OWNER`, the card is issued to the business owner.
 
 Owner example:
 
@@ -224,6 +321,11 @@ Owner example:
   "verificationId": 88
 }
 ```
+
+If `recipientType` is `AUTHORIZED_PERSON`, the request must identify that person either by:
+
+- `authorizedPersonId`, or
+- inline `authorizedPerson` data
 
 Authorized person example:
 
@@ -246,14 +348,62 @@ Authorized person example:
 }
 ```
 
-Behavior:
+What must be true before creation:
 
-1. validate the request payload and recipient type
-2. verify that the authenticated client owns a business account
-3. require `verification-service` status `VERIFIED`
-4. resolve an existing authorized person when identity matches or create one from the inline payload
-5. enforce the business rule: at most 1 active card per person on the same account
-6. create the card and notify the owner, plus the authorized person when applicable
+- `accountNumber` must be present
+- `recipientType` must be present
+- `cardBrand` must be present
+- `cardLimit` must be `0` or greater
+- the target account must be a business account
+- if the caller is a client, they must own that business account
+- `verification-service` must return status `VERIFIED`
+- each person may have at most 1 non-deactivated business card on the same account
+
+How the recipient is resolved:
+
+1. if `recipientType = OWNER`, no authorized person is used
+2. if `recipientType = AUTHORIZED_PERSON` and `authorizedPersonId` is sent, that person must already exist
+3. otherwise the service tries to find an existing authorized person by identity fields
+4. if no match exists, a new authorized person is created from the inline payload
+
+What the service does:
+
+1. loads account context from `account-service`
+2. checks ownership in the controller for client callers
+3. checks verification status in `verification-service`
+4. resolves or creates the target authorized person when needed
+5. enforces the one-card-per-person business rule
+6. creates the card under the business owner, with optional `authorizedPersonId`
+7. sends a success notification to the owner and, when applicable, to the authorized person
+
+Response:
+
+- HTTP `201 Created`
+- body has the same wrapper shape as `/request`
+- `createdCard` contains `cardId`, full `cardNumber`, one-time `plainCvv`, `expirationDate`, and `cardName`
+
+## Card Retrieval Flow
+
+Client and employee retrieval uses two different payload shapes:
+
+- list endpoints return a masked card number together with the card `id`
+- creation endpoints return the new `cardId` immediately, together with the real `cardNumber` and one-time `plainCvv`
+- the single-card details endpoint uses that `id` and returns the full card number
+
+Current management routes:
+
+- `GET /client/{clientId}` returns the caller's cards with `id`, `maskedCardNumber`, and `accountNumber`
+- `GET /account/{accountNumber}` returns the same masked summaries for employee callers
+- `GET /id/{cardId}` returns the full card details, including the real `cardNumber`
+- `PUT /id/{cardId}/block` blocks the selected card without exposing the PAN in the route
+- `PUT /id/{cardId}/limit` updates the selected card limit without exposing the PAN in the route
+- `GET /internal/account/{accountNumber}` is used by `account-service` and keeps card numbers masked
+
+This means the normal client flow is:
+
+1. load the card list
+2. pick a card by `id`
+3. call `GET /id/{cardId}` to see the full card details
 
 ## Running Locally
 

--- a/card-service/src/main/java/com/banka1/card_service/controller/CardControllerSupport.java
+++ b/card-service/src/main/java/com/banka1/card_service/controller/CardControllerSupport.java
@@ -17,10 +17,25 @@ public class CardControllerSupport {
     @Value("${banka.security.id}")
     private String jwtIdClaim;
 
-    public void verifyOwnership(Jwt jwt, Long cardClientId) {
+    public void verifyOwnership(Jwt jwt, Long resourceOwnerClientId) {
+        verifyOwnership(jwt, resourceOwnerClientId, "You do not own this resource.");
+    }
+
+    public void verifyOwnership(Jwt jwt, Long resourceOwnerClientId, String message) {
         Long requestingClientId = extractClientId(jwt);
-        if (!requestingClientId.equals(cardClientId)) {
-            throw new BusinessException(ErrorCode.ACCESS_DENIED, "You do not own this card.");
+        if (!requestingClientId.equals(resourceOwnerClientId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED, message);
+        }
+    }
+
+    public void verifyOwnershipIfClient(
+            Authentication authentication,
+            Jwt jwt,
+            Long resourceOwnerClientId,
+            String message
+    ) {
+        if (isClient(authentication)) {
+            verifyOwnership(jwt, resourceOwnerClientId, message);
         }
     }
 

--- a/card-service/src/main/java/com/banka1/card_service/controller/CardCreationController.java
+++ b/card-service/src/main/java/com/banka1/card_service/controller/CardCreationController.java
@@ -5,12 +5,15 @@ import com.banka1.card_service.dto.card_creation.request.BusinessCardRequestDto;
 import com.banka1.card_service.dto.card_creation.request.ClientCardRequestDto;
 import com.banka1.card_service.dto.card_creation.response.CardCreationResponseDto;
 import com.banka1.card_service.dto.card_creation.response.CardRequestResponseDto;
+import com.banka1.card_service.rest_client.AccountNotificationContextDto;
+import com.banka1.card_service.rest_client.AccountService;
 import com.banka1.card_service.service.CardRequestService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,12 +33,13 @@ public class CardCreationController {
 
     private final CardRequestService cardRequestService;
     private final CardControllerSupport controllerSupport;
+    private final AccountService accountService;
 
     /**
      * A card is AUTOMATICALLY created for the user, when the user account has been CREATED.
      *
      * @param body internal request payload
-     * @return created card
+     * @return created card, including the stable card ID for follow-up management calls
      */
     @PostMapping("/auto")
     @PreAuthorize("hasAnyRole('SERVICE', 'ADMIN')")
@@ -49,16 +53,18 @@ public class CardCreationController {
      *
      * @param jwt JWT of the authenticated client
      * @param body request payload including {@code verificationId}
-     * @return created card response
+     * @return created card response with the new card ID and one-time sensitive card data
      */
     @PostMapping("/request")
     @PreAuthorize("hasAnyRole('CLIENT_BASIC', 'ADMIN')")
     public ResponseEntity<CardRequestResponseDto> requestBasicCard(
+            Authentication authentication,
             @AuthenticationPrincipal Jwt jwt,
             @RequestBody @Valid ClientCardRequestDto body
     ) {
-        CardRequestResponseDto response = cardRequestService.processManualCardRequest(
-                controllerSupport.extractClientId(jwt), body);
+        AccountNotificationContextDto accountContext = loadAccountContext(body.getAccountNumber());
+        verifyOwnershipIfClient(authentication, jwt, accountContext);
+        CardRequestResponseDto response = cardRequestService.processManualCardRequest(accountContext, body);
         return ResponseEntity.status(resolveRequestStatus(response)).body(response);
     }
 
@@ -67,20 +73,44 @@ public class CardCreationController {
      *
      * @param jwt JWT of the authenticated client
      * @param body request payload including {@code verificationId}
-     * @return created card response
+     * @return created card response with the new card ID and one-time sensitive card data
      */
     @PostMapping("/request/business")
     @PreAuthorize("hasAnyRole('CLIENT_BASIC', 'ADMIN')")
     public ResponseEntity<CardRequestResponseDto> requestBusinessCard(
+            Authentication authentication,
             @AuthenticationPrincipal Jwt jwt,
             @RequestBody @Valid BusinessCardRequestDto body
     ) {
-        CardRequestResponseDto response = cardRequestService.processBusinessCardRequest(
-                controllerSupport.extractClientId(jwt), body);
+        AccountNotificationContextDto accountContext = loadAccountContext(body.getAccountNumber());
+        verifyOwnershipIfClient(authentication, jwt, accountContext);
+        CardRequestResponseDto response = cardRequestService.processBusinessCardRequest(accountContext, body);
         return ResponseEntity.status(resolveRequestStatus(response)).body(response);
     }
 
     private HttpStatus resolveRequestStatus(CardRequestResponseDto response) {
         return response.createdCard() == null ? HttpStatus.ACCEPTED : HttpStatus.CREATED;
+    }
+
+    private AccountNotificationContextDto loadAccountContext(String accountNumber) {
+        if (accountNumber == null || accountNumber.isBlank()) {
+            return new AccountNotificationContextDto(null, null);
+        }
+        return accountService.getAccountContext(accountNumber.strip());
+    }
+
+    private void verifyOwnershipIfClient(
+            Authentication authentication,
+            Jwt jwt,
+            AccountNotificationContextDto accountContext
+    ) {
+        if (accountContext.ownerClientId() != null) {
+            controllerSupport.verifyOwnershipIfClient(
+                    authentication,
+                    jwt,
+                    accountContext.ownerClientId(),
+                    "You do not own this account."
+            );
+        }
     }
 }

--- a/card-service/src/main/java/com/banka1/card_service/controller/CardManagementController.java
+++ b/card-service/src/main/java/com/banka1/card_service/controller/CardManagementController.java
@@ -46,9 +46,12 @@ public class CardManagementController {
 
     /**
      * Returns all cards owned by the authenticated client.
-     * Card numbers in the response are masked.
+     * Card numbers in the response are masked, while card IDs stay visible
+     * so clients can fetch the full details of a specific card later.
      * The {@code clientId} in the path must match the authenticated client's ID.
-     * Employee can see anybody's cards; Clients can see only their own.
+
+     * Employee can see anybody's cards;
+     * Clients can see only their own.
      *
      * @param jwt JWT of the authenticated client
      * @param clientId client ID path variable
@@ -68,44 +71,44 @@ public class CardManagementController {
     }
 
     /**
-     * Returns full details for a single card identified by card number.
+     * Returns full details for a single card identified by card ID.
      * Clients may access only their own cards, while employees may access any card.
      *
      * @param jwt JWT of the authenticated caller
      * @param authentication current Spring Security authentication
-     * @param cardNumber card number to look up
+     * @param cardId card ID to look up
      * @return full card details
      */
-    @GetMapping("/{cardNumber}")
+    @GetMapping("/id/{cardId}")
     @PreAuthorize("hasAnyRole('CLIENT_BASIC', 'BASIC')")
     public ResponseEntity<CardDetailDTO> getCardDetails(
             @AuthenticationPrincipal Jwt jwt,
             Authentication authentication,
-            @PathVariable String cardNumber
+            @PathVariable Long cardId
     ) {
-        verifyOwnershipIfClient(authentication, jwt, cardNumber);
-        return ResponseEntity.ok(cardLifecycleService.getCardByCardNumber(cardNumber));
+        verifyOwnershipIfClient(authentication, jwt, cardId);
+        return ResponseEntity.ok(cardLifecycleService.getCardById(cardId));
     }
 
     /**
-     * Blocks the card identified by card number.
+     * Blocks the card identified by card ID.
      * Clients may block only their own cards, while employees may block any card.
      * Allowed transition: ACTIVE {@code ->} BLOCKED.
      *
      * @param jwt JWT of the authenticated caller
      * @param authentication current Spring Security authentication
-     * @param cardNumber card number to block
+     * @param cardId card ID to block
      * @return 200 OK on success
      */
-    @PutMapping("/{cardNumber}/block")
+    @PutMapping("/id/{cardId}/block")
     @PreAuthorize("hasAnyRole('CLIENT_BASIC', 'BASIC')")
     public ResponseEntity<Void> blockCard(
             @AuthenticationPrincipal Jwt jwt,
             Authentication authentication,
-            @PathVariable String cardNumber
+            @PathVariable Long cardId
     ) {
-        verifyOwnershipIfClient(authentication, jwt, cardNumber);
-        cardLifecycleService.blockCard(cardNumber);
+        verifyOwnershipIfClient(authentication, jwt, cardId);
+        cardLifecycleService.blockCard(cardId);
         return ResponseEntity.ok().build();
     }
 
@@ -115,20 +118,20 @@ public class CardManagementController {
      *
      * @param jwt JWT of the authenticated caller
      * @param authentication current Spring Security authentication
-     * @param cardNumber card number to update
+     * @param cardId card ID to update
      * @param body request body containing the new limit
      * @return 200 OK on success
      */
-    @PutMapping("/{cardNumber}/limit")
+    @PutMapping("/id/{cardId}/limit")
     @PreAuthorize("hasAnyRole('CLIENT_BASIC', 'BASIC')")
     public ResponseEntity<Void> updateCardLimit(
             @AuthenticationPrincipal Jwt jwt,
             Authentication authentication,
-            @PathVariable String cardNumber,
+            @PathVariable Long cardId,
             @RequestBody @Valid UpdateCardLimitDTO body
     ) {
-        verifyOwnershipIfClient(authentication, jwt, cardNumber);
-        cardLifecycleService.updateCardLimit(cardNumber, body.getCardLimit());
+        verifyOwnershipIfClient(authentication, jwt, cardId);
+        cardLifecycleService.updateCardLimit(cardId, body.getCardLimit());
         return ResponseEntity.ok().build();
     }
 
@@ -139,7 +142,7 @@ public class CardManagementController {
 
     /**
      * Returns all cards associated with the given bank account number.
-     * Card numbers in the response are masked.
+     * Card numbers in the response are masked, while card IDs stay visible.
      * This endpoint is available only to employees.
      *
      * @param accountNumber bank account number
@@ -202,17 +205,13 @@ public class CardManagementController {
         return ResponseEntity.ok().build();
     }
 
-    /**
-     * Applies ownership validation only for client callers.
-     * Employee callers are allowed to operate on any card and therefore skip this check.
-     *
-     * @param authentication current Spring Security authentication
-     * @param jwt JWT of the authenticated caller
-     * @param cardNumber card number whose owner should be checked
-     */
-    private void verifyOwnershipIfClient(Authentication authentication, Jwt jwt, String cardNumber) {
+    private void verifyOwnershipIfClient(Authentication authentication, Jwt jwt, Long cardId) {
         if (controllerSupport.isClient(authentication)) {
-            controllerSupport.verifyOwnership(jwt, cardLifecycleService.getClientIdByCardNumber(cardNumber));
+            controllerSupport.verifyOwnership(
+                    jwt,
+                    cardLifecycleService.getClientIdByCardId(cardId),
+                    "You do not own this card."
+            );
         }
     }
 }

--- a/card-service/src/main/java/com/banka1/card_service/dto/card_creation/response/CardCreationResponseDto.java
+++ b/card-service/src/main/java/com/banka1/card_service/dto/card_creation/response/CardCreationResponseDto.java
@@ -5,12 +5,14 @@ import java.time.LocalDate;
 /**
  * API response returned after a card has been created successfully.
  *
+ * @param cardId stable card ID for subsequent card-management calls
  * @param cardNumber full card number
  * @param plainCvv one-time plain CVV
  * @param expirationDate expiration date of the new card
  * @param cardName display name of the product
  */
 public record CardCreationResponseDto(
+        Long cardId,
         String cardNumber,
         String plainCvv,
         LocalDate expirationDate,

--- a/card-service/src/main/java/com/banka1/card_service/dto/card_creation/response/CardRequestResponseDto.java
+++ b/card-service/src/main/java/com/banka1/card_service/dto/card_creation/response/CardRequestResponseDto.java
@@ -6,7 +6,7 @@ package com.banka1.card_service.dto.card_creation.response;
  * @param status current flow status
  * @param message human-readable result message
  * @param verificationRequestId legacy field, unused in the current externally verified flow
- * @param createdCard created card payload for completed requests
+ * @param createdCard created card payload for completed requests, including the stable card ID
  */
 public record CardRequestResponseDto(
         String status,

--- a/card-service/src/main/java/com/banka1/card_service/dto/card_management/response/CardDetailDTO.java
+++ b/card-service/src/main/java/com/banka1/card_service/dto/card_management/response/CardDetailDTO.java
@@ -11,8 +11,9 @@ import java.time.LocalDate;
 
 /**
  * Full card details returned for a single-card lookup.
+ * The card ID is included so clients can correlate this payload with list responses.
  * The full card number is exposed here, so this response must only be returned
- * to the card owner or an authorized employee — never in bulk list responses.
+ * to the card owner or an authorized employee - never in bulk list responses.
  *
  * The CVV hash is intentionally excluded from all API responses.
  * The plain CVV is available only at card creation time via {@link CardCreationResult}.
@@ -20,6 +21,7 @@ import java.time.LocalDate;
 @Getter
 public class CardDetailDTO {
 
+    private final Long id;
     private final String cardNumber;
     private final CardType cardType;
     private final String cardName;
@@ -30,6 +32,7 @@ public class CardDetailDTO {
     private final CardStatus status;
 
     public CardDetailDTO(Card card) {
+        this.id = card.getId();
         this.cardNumber = card.getCardNumber();
         this.cardType = card.getCardType();
         this.cardName = card.getCardName();

--- a/card-service/src/main/java/com/banka1/card_service/dto/card_management/response/CardSummaryDTO.java
+++ b/card-service/src/main/java/com/banka1/card_service/dto/card_management/response/CardSummaryDTO.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 
 /**
  * Compact card representation used in list responses.
- * The card number is masked to protect sensitive data — only the first four
+ * The card ID is included so callers can fetch full details later
+ * without using the sensitive card number as a lookup key.
+ * The card number is masked to protect sensitive data - only the first four
  * and last four digits are visible, with asterisks replacing the middle digits.
  *
  * Example:
@@ -18,6 +20,11 @@ import lombok.Getter;
 public class CardSummaryDTO {
 
     /**
+     * Stable card identifier safe to use in follow-up API calls.
+     */
+    private final Long id;
+
+    /**
      * Masked card number safe for display in lists.
      * Format: first 4 digits + 8 asterisks + last 4 digits.
      */
@@ -26,6 +33,7 @@ public class CardSummaryDTO {
     private final String accountNumber;
 
     public CardSummaryDTO(Card card) {
+        this.id = card.getId();
         this.maskedCardNumber = SensitiveDataMasker.maskCardNumber(card.getCardNumber());
         this.accountNumber = card.getAccountNumber();
     }

--- a/card-service/src/main/java/com/banka1/card_service/mapper/CardCreationResponseMapper.java
+++ b/card-service/src/main/java/com/banka1/card_service/mapper/CardCreationResponseMapper.java
@@ -14,6 +14,7 @@ public class CardCreationResponseMapper {
     public CardCreationResponseDto toDto(CardCreationResult result) {
         Card card = result.card();
         return new CardCreationResponseDto(
+                card.getId(),
                 card.getCardNumber(),
                 result.plainCvv(),
                 card.getExpirationDate(),

--- a/card-service/src/main/java/com/banka1/card_service/service/CardLifecycleService.java
+++ b/card-service/src/main/java/com/banka1/card_service/service/CardLifecycleService.java
@@ -8,27 +8,27 @@ import java.math.BigDecimal;
 import java.util.List;
 
 /**
- * Manages the lifecycle of existing cards — status transitions, limit changes, and retrieval.
+ * Manages the lifecycle of existing cards - status transitions, limit changes, and retrieval.
  * Card creation is handled separately by {@link CardCreationService}.
  */
 public interface CardLifecycleService {
 
     /**
-     * Returns full details for a single card identified by its card number.
+     * Returns full details for a single card identified by its database ID.
      *
-     * @param cardNumber card number to look up
+     * @param cardId card ID to look up
      * @return full card details
      */
-    CardDetailDTO getCardByCardNumber(String cardNumber);
+    CardDetailDTO getCardById(Long cardId);
 
     /**
      * Returns the client ID of the owner of the given card.
      * Used to verify ownership before performing client-initiated operations.
      *
-     * @param cardNumber card number to look up
+     * @param cardId card ID to look up
      * @return client ID of the card owner
      */
-    Long getClientIdByCardNumber(String cardNumber);
+    Long getClientIdByCardId(Long cardId);
 
     /**
      * Returns all cards owned by the given client.
@@ -59,16 +59,17 @@ public interface CardLifecycleService {
     List<CardInternalSummaryDTO> getInternalCardsByAccountNumber(String accountNumber);
 
     /**
-     * Blocks an active card. Both clients and employees may call this.
-     * Allowed transition: ACTIVE → BLOCKED.
+     * Blocks an active card identified by database ID.
+     * Both clients and employees may call this.
+     * Allowed transition: ACTIVE -> BLOCKED.
      *
-     * @param cardNumber card number to block
+     * @param cardId card ID to block
      */
-    void blockCard(String cardNumber);
+    void blockCard(Long cardId);
 
     /**
      * Unblocks a blocked card. Only employees may call this.
-     * Allowed transition: BLOCKED → ACTIVE.
+     * Allowed transition: BLOCKED -> ACTIVE.
      *
      * @param cardNumber card number to unblock
      */
@@ -76,18 +77,18 @@ public interface CardLifecycleService {
 
     /**
      * Permanently deactivates a card. Only employees may call this.
-     * Allowed transition: ACTIVE → DEACTIVATED or BLOCKED → DEACTIVATED.
-     * Deactivation is irreversible — a deactivated card cannot be reactivated.
+     * Allowed transition: ACTIVE -> DEACTIVATED or BLOCKED -> DEACTIVATED.
+     * Deactivation is irreversible - a deactivated card cannot be reactivated.
      *
      * @param cardNumber card number to deactivate
      */
     void deactivateCard(String cardNumber);
 
     /**
-     * Updates the spending limit on an existing card.
+     * Updates the spending limit on an existing card identified by database ID.
      *
-     * @param cardNumber card number to update
+     * @param cardId card ID to update
      * @param newLimit new limit value, must be zero or greater
      */
-    void updateCardLimit(String cardNumber, BigDecimal newLimit);
+    void updateCardLimit(Long cardId, BigDecimal newLimit);
 }

--- a/card-service/src/main/java/com/banka1/card_service/service/CardRequestService.java
+++ b/card-service/src/main/java/com/banka1/card_service/service/CardRequestService.java
@@ -5,6 +5,7 @@ import com.banka1.card_service.dto.card_creation.request.BusinessCardRequestDto;
 import com.banka1.card_service.dto.card_creation.request.ClientCardRequestDto;
 import com.banka1.card_service.dto.card_creation.response.CardCreationResponseDto;
 import com.banka1.card_service.dto.card_creation.response.CardRequestResponseDto;
+import com.banka1.card_service.rest_client.AccountNotificationContextDto;
 
 /**
  * Orchestrates automatic and client-initiated card creation flows.
@@ -22,19 +23,24 @@ public interface CardRequestService {
     /**
      * Creates a personal-account card after verification was completed externally.
      *
-     * @param authenticatedClientId authenticated client ID
+     * @param accountContext resolved account owner and ownership type
      * @param request request payload
      * @return completed flow response
      */
-    CardRequestResponseDto processManualCardRequest(Long authenticatedClientId, ClientCardRequestDto request);
+    CardRequestResponseDto processManualCardRequest(
+            AccountNotificationContextDto accountContext,
+            ClientCardRequestDto request
+    );
 
     /**
      * Starts or completes a business-account card request.
      *
-     * @param authenticatedClientId authenticated client ID
+     * @param accountContext resolved account owner and ownership type
      * @param request request payload
      * @return pending or completed flow response
      */
-    CardRequestResponseDto processBusinessCardRequest(Long authenticatedClientId, BusinessCardRequestDto request);
-
+    CardRequestResponseDto processBusinessCardRequest(
+            AccountNotificationContextDto accountContext,
+            BusinessCardRequestDto request
+    );
 }

--- a/card-service/src/main/java/com/banka1/card_service/service/implementation/CardLifecycleServiceImpl.java
+++ b/card-service/src/main/java/com/banka1/card_service/service/implementation/CardLifecycleServiceImpl.java
@@ -48,28 +48,28 @@ public class CardLifecycleServiceImpl implements CardLifecycleService {
     private final RabbitClient rabbitClient;
 
     /**
-     * Loads the card by card number and maps it to a full detail response.
+     * Loads the card by ID and maps it to a full detail response.
      * The CVV hash is never included in the returned DTO.
      *
-     * @param cardNumber card number to look up
+     * @param cardId card ID to look up
      * @return full card details
      */
     @Override
-    public CardDetailDTO getCardByCardNumber(String cardNumber) {
-        return new CardDetailDTO(findCardOrThrow(cardNumber));
+    public CardDetailDTO getCardById(Long cardId) {
+        return new CardDetailDTO(findCardByIdOrThrow(cardId));
     }
 
     /**
-     * Loads the card by card number and returns the owner's client ID.
+     * Loads the card by ID and returns the owner's client ID.
      * Used by controllers to verify that the requesting client owns the card
      * before allowing client-initiated operations.
      *
-     * @param cardNumber card number to look up
+     * @param cardId card ID to look up
      * @return client ID of the card owner
      */
     @Override
-    public Long getClientIdByCardNumber(String cardNumber) {
-        return findCardOrThrow(cardNumber).getClientId();
+    public Long getClientIdByCardId(Long cardId) {
+        return findCardByIdOrThrow(cardId).getClientId();
     }
 
     /**
@@ -115,12 +115,12 @@ public class CardLifecycleServiceImpl implements CardLifecycleService {
      * Both clients and employees may block a card.
      * Allowed transition: ACTIVE → BLOCKED.
      *
-     * @param cardNumber card number to block
+     * @param cardId card ID to block
      */
     @Override
     @Transactional
-    public void blockCard(String cardNumber) {
-        Card card = findCardOrThrow(cardNumber);
+    public void blockCard(Long cardId) {
+        Card card = findCardByIdOrThrow(cardId);
         transitionStatus(card, CardStatus.BLOCKED);
         cardRepository.save(card);
         registerAfterCommitNotification(card, CardNotificationType.CARD_BLOCKED);
@@ -163,16 +163,16 @@ public class CardLifecycleServiceImpl implements CardLifecycleService {
      * Validates the new limit and updates the card.
      * The limit must be zero or greater — zero effectively disables spending on the card.
      *
-     * @param cardNumber card number to update
+     * @param cardId card ID to update
      * @param newLimit new limit value, must be zero or greater
      */
     @Override
     @Transactional
-    public void updateCardLimit(String cardNumber, BigDecimal newLimit) {
+    public void updateCardLimit(Long cardId, BigDecimal newLimit) {
         if (newLimit == null || newLimit.signum() < 0) {
             throw new BusinessException(ErrorCode.INVALID_LIMIT, "Card limit must be zero or greater.");
         }
-        Card card = findCardOrThrow(cardNumber);
+        Card card = findCardByIdOrThrow(cardId);
         card.setCardLimit(newLimit);
         cardRepository.save(card);
     }
@@ -216,6 +216,21 @@ public class CardLifecycleServiceImpl implements CardLifecycleService {
                 .orElseThrow(() -> new BusinessException(
                         ErrorCode.CARD_NOT_FOUND,
                         "Card with number " + cardNumber + " was not found."
+                ));
+    }
+
+    /**
+     * Looks up a card by its database ID or throws a {@link BusinessException} if not found.
+     *
+     * @param cardId card ID to look up
+     * @return the matching card entity
+     * @throws BusinessException with {@link ErrorCode#CARD_NOT_FOUND} when no card matches
+     */
+    private Card findCardByIdOrThrow(Long cardId) {
+        return cardRepository.findById(cardId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.CARD_NOT_FOUND,
+                        "Card with ID " + cardId + " was not found."
                 ));
     }
 

--- a/card-service/src/main/java/com/banka1/card_service/service/implementation/CardRequestServiceImpl.java
+++ b/card-service/src/main/java/com/banka1/card_service/service/implementation/CardRequestServiceImpl.java
@@ -22,7 +22,6 @@ import com.banka1.card_service.rabbitMQ.RabbitClient;
 import com.banka1.card_service.repository.AuthorizedPersonRepository;
 import com.banka1.card_service.repository.CardRepository;
 import com.banka1.card_service.rest_client.AccountNotificationContextDto;
-import com.banka1.card_service.rest_client.AccountService;
 import com.banka1.card_service.rest_client.ClientNotificationRecipientDto;
 import com.banka1.card_service.rest_client.ClientService;
 import com.banka1.card_service.rest_client.VerificationService;
@@ -57,7 +56,6 @@ public class CardRequestServiceImpl implements CardRequestService {
     private final CardCreationService cardCreationService;
     private final CardRepository cardRepository;
     private final AuthorizedPersonRepository authorizedPersonRepository;
-    private final AccountService accountService;
     private final ClientService clientService;
     private final VerificationService verificationService;
     private final RabbitClient rabbitClient;
@@ -90,18 +88,20 @@ public class CardRequestServiceImpl implements CardRequestService {
      * <p>The request must contain full card data together with a verification session ID.
      * Card-service no longer stores or validates a local personal verification code.
      *
-     * @param authenticatedClientId ID extracted from the authenticated JWT
+     * @param accountContext resolved account owner and ownership type
      * @param request personal-card request DTO
      * @return completed response with the newly created card
      */
     @Override
     @Transactional
-    public CardRequestResponseDto processManualCardRequest(Long authenticatedClientId, ClientCardRequestDto request) {
+    public CardRequestResponseDto processManualCardRequest(
+            AccountNotificationContextDto accountContext,
+            ClientCardRequestDto request
+    ) {
         validateInitiationRequest(request.getAccountNumber(), request.getCardBrand(), request.getCardLimit());
         String accountNumber = request.getAccountNumber().strip();
+        Long ownerClientId = requireOwnerClientId(accountContext);
 
-        AccountNotificationContextDto accountContext = accountService.getAccountContext(accountNumber);
-        assertOwner(authenticatedClientId, accountContext.ownerClientId());
         if (accountContext.isBusinessAccount()) {
             throw new BusinessException(
                     ErrorCode.INVALID_ACCOUNT_TYPE,
@@ -111,15 +111,15 @@ public class CardRequestServiceImpl implements CardRequestService {
         ensureVerificationIsVerified(request.getVerificationId());
 
         try {
-            enforcePersonalLimitOf2Accounts(accountNumber, authenticatedClientId);
+            enforcePersonalLimitOf2Accounts(accountNumber, ownerClientId);
             CardCreationResult result = cardCreationService.createCard(new CreateCardCommand(
                     accountNumber,
                     request.getCardBrand(),
                     request.getCardLimit(),
-                    authenticatedClientId,
+                    ownerClientId,
                     null
             ));
-            ClientNotificationRecipientDto ownerRecipient = clientService.getNotificationRecipient(authenticatedClientId);
+            ClientNotificationRecipientDto ownerRecipient = clientService.getNotificationRecipient(ownerClientId);
             registerAfterCommitRequestSuccess(ownerRecipient, null, result.card());
 
             return new CardRequestResponseDto(
@@ -145,27 +145,29 @@ public class CardRequestServiceImpl implements CardRequestService {
      * <p>The request must contain full card data together with a verification session ID.
      * Card-service no longer stores or validates a local business verification request.
      *
-     * @param authenticatedClientId ID extracted from the authenticated JWT of the business owner
+     * @param accountContext resolved account owner and ownership type
      * @param request business-card request DTO
      * @return completed response with the newly created card
      */
     @Override
     @Transactional
-    public CardRequestResponseDto processBusinessCardRequest(Long authenticatedClientId, BusinessCardRequestDto request) {
+    public CardRequestResponseDto processBusinessCardRequest(
+            AccountNotificationContextDto accountContext,
+            BusinessCardRequestDto request
+    ) {
         validateInitiationRequest(request.getAccountNumber(), request.getCardBrand(), request.getCardLimit());
         String accountNumber = request.getAccountNumber().strip();
+        Long ownerClientId = requireOwnerClientId(accountContext);
         if (request.getRecipientType() == null) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST_STATE, "Recipient type must be provided.");
         }
 
-        AccountNotificationContextDto accountContext = accountService.getAccountContext(accountNumber);
         if (!accountContext.isBusinessAccount()) {
             throw new BusinessException(
                     ErrorCode.INVALID_ACCOUNT_TYPE,
                     "Personal accounts must use the /request endpoint."
             );
         }
-        assertOwner(authenticatedClientId, accountContext.ownerClientId());
         ensureVerificationIsVerified(request.getVerificationId());
 
         try {
@@ -176,13 +178,13 @@ public class CardRequestServiceImpl implements CardRequestService {
             Long authorizedPersonId = request.getRecipientType() == CardRequestRecipientType.AUTHORIZED_PERSON
                     ? authorizedPerson == null ? null : authorizedPerson.getId()
                     : null;
-            enforceBusinessLimit(accountNumber, authenticatedClientId, authorizedPersonId);
+            enforceBusinessLimit(accountNumber, ownerClientId, authorizedPersonId);
 
             CardCreationResult result = cardCreationService.createCard(new CreateCardCommand(
                     accountNumber,
                     request.getCardBrand(),
                     request.getCardLimit(),
-                    authenticatedClientId,
+                    ownerClientId,
                     authorizedPersonId
             ));
 
@@ -191,7 +193,7 @@ public class CardRequestServiceImpl implements CardRequestService {
                 authorizedPersonRepository.save(authorizedPerson);
             }
 
-            ClientNotificationRecipientDto ownerRecipient = clientService.getNotificationRecipient(authenticatedClientId);
+            ClientNotificationRecipientDto ownerRecipient = clientService.getNotificationRecipient(ownerClientId);
             NotificationRecipient authorizedRecipient = authorizedPerson == null ? null : toNotificationRecipient(authorizedPerson);
             registerAfterCommitRequestSuccess(ownerRecipient, authorizedRecipient, result.card());
 
@@ -249,16 +251,11 @@ public class CardRequestServiceImpl implements CardRequestService {
         }
     }
 
-    /**
-     * Verifies that the authenticated client is the owner of the referenced account.
-     *
-     * @param authenticatedClientId client ID extracted from authentication
-     * @param ownerClientId expected owner client ID
-     */
-    private void assertOwner(Long authenticatedClientId, Long ownerClientId) {
-        if (ownerClientId == null || !ownerClientId.equals(authenticatedClientId)) {
-            throw new BusinessException(ErrorCode.ACCESS_DENIED, "You do not own this account.");
+    private Long requireOwnerClientId(AccountNotificationContextDto accountContext) {
+        if (accountContext == null || accountContext.ownerClientId() == null) {
+            throw new BusinessException(ErrorCode.INVALID_CLIENT_ID, "Account owner client ID is missing.");
         }
+        return accountContext.ownerClientId();
     }
 
     /**

--- a/card-service/src/test/java/com/banka1/card_service/controller/CardCreationControllerWebMvcTest.java
+++ b/card-service/src/test/java/com/banka1/card_service/controller/CardCreationControllerWebMvcTest.java
@@ -4,6 +4,9 @@ import com.banka1.card_service.advice.GlobalExceptionHandler;
 import com.banka1.card_service.dto.card_creation.request.AutoCardCreationRequestDto;
 import com.banka1.card_service.dto.card_creation.response.CardCreationResponseDto;
 import com.banka1.card_service.dto.card_creation.response.CardRequestResponseDto;
+import com.banka1.card_service.domain.enums.AccountOwnershipType;
+import com.banka1.card_service.rest_client.AccountNotificationContextDto;
+import com.banka1.card_service.rest_client.AccountService;
 import com.banka1.card_service.service.CardRequestService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -16,10 +19,12 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
 import java.time.LocalDate;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -41,6 +46,9 @@ class CardCreationControllerWebMvcTest {
     @MockitoBean
     private CardRequestService cardRequestService;
 
+    @MockitoBean
+    private AccountService accountService;
+
     @Test
     void autoCreateCardReturnsCreatedForInternalCaller() throws Exception {
         AutoCardCreationRequestDto request = new AutoCardCreationRequestDto();
@@ -48,6 +56,7 @@ class CardCreationControllerWebMvcTest {
         request.setClientId(1L);
 
         CardCreationResponseDto response = new CardCreationResponseDto(
+                15L,
                 "5798123456785571",
                 "123",
                 LocalDate.of(2031, 3, 20),
@@ -58,9 +67,10 @@ class CardCreationControllerWebMvcTest {
         mockMvc.perform(post("/auto")
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_SERVICE"))
                                 .jwt(jwt -> jwt.claim("id", 999L)))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.cardId").value(15))
                 .andExpect(jsonPath("$.cardNumber").value("5798123456785571"));
 
         verify(cardRequestService).createAutomaticCard(any(AutoCardCreationRequestDto.class));
@@ -82,14 +92,19 @@ class CardCreationControllerWebMvcTest {
                 "Card created.",
                 null,
                 new CardCreationResponseDto(
+                        15L,
                         "5798123456785571",
                         "123",
                         LocalDate.of(2031, 3, 20),
                         "Visa Debit"
                 )
         );
-        when(cardRequestService.processManualCardRequest(eq(1L), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(response);
+        when(accountService.getAccountContext("265000000000123456"))
+                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 1L));
+        when(cardRequestService.processManualCardRequest(
+                eq(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 1L)),
+                org.mockito.ArgumentMatchers.any()
+        )).thenReturn(response);
 
         mockMvc.perform(post("/request")
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_CLIENT_BASIC"))
@@ -97,9 +112,83 @@ class CardCreationControllerWebMvcTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.createdCard.cardId").value(15))
                 .andExpect(jsonPath("$.createdCard.cardNumber").value("5798123456785571"));
 
-        verify(cardRequestService).processManualCardRequest(eq(1L), org.mockito.ArgumentMatchers.any());
+        verify(cardRequestService).processManualCardRequest(
+                eq(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 1L)),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    void requestCardReturnsForbiddenWhenClientDoesNotOwnAccount() throws Exception {
+        String requestBody = """
+                {
+                  "accountNumber": "265000000000123456",
+                  "cardBrand": "VISA",
+                  "cardLimit": 1500,
+                  "verificationId": 77
+                }
+                """;
+
+        when(accountService.getAccountContext("265000000000123456"))
+                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 2L));
+
+        mockMvc.perform(post("/request")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_CLIENT_BASIC"))
+                                .jwt(jwt -> jwt.claim("id", 1L)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("ERR_CARD_007"));
+
+        verify(cardRequestService, never()).processManualCardRequest(any(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void requestCardAllowsAdminForForeignOwnerAccount() throws Exception {
+        String requestBody = """
+                {
+                  "accountNumber": "265000000000123456",
+                  "cardBrand": "VISA",
+                  "cardLimit": 1500,
+                  "verificationId": 77
+                }
+                """;
+
+        CardRequestResponseDto response = new CardRequestResponseDto(
+                "COMPLETED",
+                "Card created.",
+                null,
+                new CardCreationResponseDto(
+                        15L,
+                        "5798123456785571",
+                        "123",
+                        LocalDate.of(2031, 3, 20),
+                        "Visa Debit"
+                )
+        );
+        when(accountService.getAccountContext("265000000000123456"))
+                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 55L));
+        when(cardRequestService.processManualCardRequest(
+                eq(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 55L)),
+                org.mockito.ArgumentMatchers.any()
+        )).thenReturn(response);
+
+        mockMvc.perform(post("/request")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))
+                                .jwt(jwt -> jwt.claim("id", 999L)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.createdCard.cardId").value(15))
+                .andExpect(jsonPath("$.createdCard.cardNumber").value("5798123456785571"));
+
+        verify(cardRequestService).processManualCardRequest(
+                eq(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 55L)),
+                org.mockito.ArgumentMatchers.any()
+        );
     }
 
     @Test
@@ -119,14 +208,19 @@ class CardCreationControllerWebMvcTest {
                 "Card created.",
                 null,
                 new CardCreationResponseDto(
+                        15L,
                         "5798123456785571",
                         "123",
                         LocalDate.of(2031, 3, 20),
                         "Visa Debit"
                 )
         );
-        when(cardRequestService.processBusinessCardRequest(eq(1L), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(response);
+        when(accountService.getAccountContext("265000000000999999"))
+                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.BUSINESS, 1L));
+        when(cardRequestService.processBusinessCardRequest(
+                eq(new AccountNotificationContextDto(AccountOwnershipType.BUSINESS, 1L)),
+                org.mockito.ArgumentMatchers.any()
+        )).thenReturn(response);
 
         mockMvc.perform(post("/request/business")
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_CLIENT_BASIC"))
@@ -134,8 +228,12 @@ class CardCreationControllerWebMvcTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.createdCard.cardId").value(15))
                 .andExpect(jsonPath("$.createdCard.cardNumber").value("5798123456785571"));
 
-        verify(cardRequestService).processBusinessCardRequest(eq(1L), org.mockito.ArgumentMatchers.any());
+        verify(cardRequestService).processBusinessCardRequest(
+                eq(new AccountNotificationContextDto(AccountOwnershipType.BUSINESS, 1L)),
+                org.mockito.ArgumentMatchers.any()
+        );
     }
 }

--- a/card-service/src/test/java/com/banka1/card_service/controller/CardManagementControllerWebMvcTest.java
+++ b/card-service/src/test/java/com/banka1/card_service/controller/CardManagementControllerWebMvcTest.java
@@ -57,6 +57,7 @@ class CardManagementControllerWebMvcTest {
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_CLIENT_BASIC"))
                                 .jwt(jwt -> jwt.claim("id", 1L))))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(15))
                 .andExpect(jsonPath("$[0].maskedCardNumber").value("5798********5571"));
     }
 
@@ -68,6 +69,7 @@ class CardManagementControllerWebMvcTest {
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_BASIC"))
                                 .jwt(jwt -> jwt.claim("id", 100L))))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(15))
                 .andExpect(jsonPath("$[0].maskedCardNumber").value("5798********5571"));
 
         verify(cardLifecycleService).getCardsForClient(2L);
@@ -86,29 +88,30 @@ class CardManagementControllerWebMvcTest {
 
     @Test
     void getCardDetailsReturnsForbiddenForDifferentClient() throws Exception {
-        when(cardLifecycleService.getClientIdByCardNumber("5798123456785571")).thenReturn(2L);
+        when(cardLifecycleService.getClientIdByCardId(15L)).thenReturn(2L);
 
-        mockMvc.perform(get("/5798123456785571")
+        mockMvc.perform(get("/id/15")
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_CLIENT_BASIC"))
                                 .jwt(jwt -> jwt.claim("id", 1L))))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.errorCode").value("ERR_CARD_007"));
 
-        verify(cardLifecycleService, never()).getCardByCardNumber(any());
+        verify(cardLifecycleService, never()).getCardById(any());
     }
 
     @Test
     void getCardDetailsAllowsEmployeeOnSharedRoute() throws Exception {
-        when(cardLifecycleService.getCardByCardNumber("5798123456785571"))
+        when(cardLifecycleService.getCardById(15L))
                 .thenReturn(new CardDetailDTO(card()));
 
-        mockMvc.perform(get("/5798123456785571")
+        mockMvc.perform(get("/id/15")
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_BASIC"))
                                 .jwt(jwt -> jwt.claim("id", 100L))))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(15))
                 .andExpect(jsonPath("$.cardNumber").value("5798123456785571"));
 
-        verify(cardLifecycleService, never()).getClientIdByCardNumber(any());
+        verify(cardLifecycleService, never()).getClientIdByCardId(any());
     }
 
     @Test
@@ -120,6 +123,7 @@ class CardManagementControllerWebMvcTest {
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_BASIC"))
                                 .jwt(jwt -> jwt.claim("id", 100L))))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(15))
                 .andExpect(jsonPath("$[0].maskedCardNumber").value("5798********5571"));
     }
 
@@ -140,13 +144,13 @@ class CardManagementControllerWebMvcTest {
 
     @Test
     void blockCardAllowsEmployeeOnSharedRoute() throws Exception {
-        mockMvc.perform(put("/5798123456785571/block")
+        mockMvc.perform(put("/id/15/block")
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_BASIC"))
                                 .jwt(jwt -> jwt.claim("id", 100L))))
                 .andExpect(status().isOk());
 
-        verify(cardLifecycleService).blockCard("5798123456785571");
-        verify(cardLifecycleService, never()).getClientIdByCardNumber(any());
+        verify(cardLifecycleService).blockCard(15L);
+        verify(cardLifecycleService, never()).getClientIdByCardId(any());
     }
 
     @Test
@@ -154,20 +158,21 @@ class CardManagementControllerWebMvcTest {
         UpdateCardLimitDTO request = new UpdateCardLimitDTO();
         request.setCardLimit(BigDecimal.valueOf(2500));
 
-        when(cardLifecycleService.getClientIdByCardNumber("5798123456785571")).thenReturn(1L);
+        when(cardLifecycleService.getClientIdByCardId(15L)).thenReturn(1L);
 
-        mockMvc.perform(put("/5798123456785571/limit")
+        mockMvc.perform(put("/id/15/limit")
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_CLIENT_BASIC"))
                                 .jwt(jwt -> jwt.claim("id", 1L)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
 
-        verify(cardLifecycleService).updateCardLimit("5798123456785571", BigDecimal.valueOf(2500));
+        verify(cardLifecycleService).updateCardLimit(15L, BigDecimal.valueOf(2500));
     }
 
     private Card card() {
         Card card = new Card();
+        card.setId(15L);
         card.setCardNumber("5798123456785571");
         card.setCardType(CardType.DEBIT);
         card.setCardName("Visa Debit");

--- a/card-service/src/test/java/com/banka1/card_service/integration/CardCreationControllerIntegrationTest.java
+++ b/card-service/src/test/java/com/banka1/card_service/integration/CardCreationControllerIntegrationTest.java
@@ -102,9 +102,10 @@ class CardCreationControllerIntegrationTest {
 
         String responseBody = mockMvc.perform(post("/auto")
                         .with(serviceJwt())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.cardId").exists())
                 .andExpect(jsonPath("$.cardNumber").exists())
                 .andExpect(jsonPath("$.plainCvv").exists())
                 .andExpect(jsonPath("$.expirationDate").exists())
@@ -125,6 +126,7 @@ class CardCreationControllerIntegrationTest {
         assertThat(persistedCard.getCardLimit()).isEqualByComparingTo(automaticDefaultLimit);
         assertThat(persistedCard.getStatus()).isEqualTo(CardStatus.ACTIVE);
         assertThat(ChronoUnit.YEARS.between(persistedCard.getCreationDate(), persistedCard.getExpirationDate())).isEqualTo(5);
+        assertThat(responseJson.get("cardId").asLong()).isEqualTo(persistedCard.getId());
         assertThat(responseJson.get("cardNumber").asText()).isEqualTo(persistedCard.getCardNumber());
         assertThat(responseJson.get("cardName").asText()).isEqualTo(persistedCard.getCardName());
         assertThat(responseJson.get("plainCvv").asText()).matches("\\d{3}");
@@ -157,6 +159,7 @@ class CardCreationControllerIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("COMPLETED"))
                 .andExpect(jsonPath("$.message").value("Card created successfully."))
+                .andExpect(jsonPath("$.createdCard.cardId").exists())
                 .andExpect(jsonPath("$.createdCard.cardNumber").exists())
                 .andExpect(jsonPath("$.createdCard.plainCvv").exists())
                 .andReturn()
@@ -171,6 +174,50 @@ class CardCreationControllerIntegrationTest {
         assertThat(persistedCard.getAccountNumber()).isEqualTo(PERSONAL_ACCOUNT_NUMBER);
         assertThat(persistedCard.getAuthorizedPersonId()).isNull();
         assertThat(persistedCard.getCardLimit()).isEqualByComparingTo("1500.00");
+        assertThat(responseJson.get("createdCard").get("cardId").asLong()).isEqualTo(persistedCard.getId());
+        assertThat(responseJson.get("createdCard").get("cardNumber").asText()).isEqualTo(persistedCard.getCardNumber());
+
+        verify(rabbitClient, times(1)).sendCardNotification(eq(CardNotificationType.CARD_REQUEST_SUCCESS), eqNotificationForOwner());
+    }
+
+    @Test
+    @DisplayName("POST /request allows ADMIN callers while still assigning the card to the real account owner")
+    void manualPersonalCardRequest_byAdminAssignsCardToAccountOwner() throws Exception {
+        when(accountService.getAccountContext(PERSONAL_ACCOUNT_NUMBER))
+                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, OWNER_CLIENT_ID));
+        when(verificationService.getStatus(77L))
+                .thenReturn(new VerificationStatusResponse(77L, VerificationStatus.VERIFIED));
+        when(clientService.getNotificationRecipient(OWNER_CLIENT_ID))
+                .thenReturn(ownerRecipient());
+
+        String requestPayload = """
+                {
+                  "accountNumber": "265000000000123456",
+                  "cardBrand": "VISA",
+                  "cardLimit": 1500.00,
+                  "verificationId": 77
+                }
+                """;
+
+        String responseBody = mockMvc.perform(post("/request")
+                        .with(adminJwt(999L))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestPayload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.createdCard.cardId").exists())
+                .andExpect(jsonPath("$.createdCard.cardNumber").exists())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode responseJson = objectMapper.readTree(responseBody);
+        List<Card> persistedCards = cardRepository.findByClientId(OWNER_CLIENT_ID);
+
+        assertThat(persistedCards).hasSize(1);
+        Card persistedCard = persistedCards.get(0);
+        assertThat(persistedCard.getClientId()).isEqualTo(OWNER_CLIENT_ID);
+        assertThat(responseJson.get("createdCard").get("cardId").asLong()).isEqualTo(persistedCard.getId());
         assertThat(responseJson.get("createdCard").get("cardNumber").asText()).isEqualTo(persistedCard.getCardNumber());
 
         verify(rabbitClient, times(1)).sendCardNotification(eq(CardNotificationType.CARD_REQUEST_SUCCESS), eqNotificationForOwner());
@@ -198,10 +245,11 @@ class CardCreationControllerIntegrationTest {
 
         String responseBody = mockMvc.perform(post("/request/business")
                         .with(clientJwt(OWNER_CLIENT_ID))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestPayload))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestPayload))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.createdCard.cardId").exists())
                 .andExpect(jsonPath("$.createdCard.cardNumber").exists())
                 .andReturn()
                 .getResponse()
@@ -216,6 +264,7 @@ class CardCreationControllerIntegrationTest {
         Card persistedCard = persistedCards.get(0);
         assertThat(persistedCard.getAuthorizedPersonId()).isNull();
         assertThat(persistedCard.getCardLimit()).isEqualByComparingTo("2500.00");
+        assertThat(responseJson.get("createdCard").get("cardId").asLong()).isEqualTo(persistedCard.getId());
         assertThat(responseJson.get("createdCard").get("cardNumber").asText()).isEqualTo(persistedCard.getCardNumber());
 
         verify(rabbitClient, times(1)).sendCardNotification(eq(CardNotificationType.CARD_REQUEST_SUCCESS), eqNotificationForOwner());
@@ -252,10 +301,11 @@ class CardCreationControllerIntegrationTest {
 
         String responseBody = mockMvc.perform(post("/request/business")
                         .with(clientJwt(OWNER_CLIENT_ID))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestPayload))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestPayload))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.createdCard.cardId").exists())
                 .andExpect(jsonPath("$.createdCard.cardNumber").exists())
                 .andReturn()
                 .getResponse()
@@ -277,6 +327,7 @@ class CardCreationControllerIntegrationTest {
         assertThat(authorizedPerson.getEmail()).isEqualTo("ana@example.com");
         assertThat(persistedCard.getAuthorizedPersonId()).isEqualTo(authorizedPerson.getId());
         assertThat(authorizedPerson.getCardIds()).containsExactly(persistedCard.getId());
+        assertThat(responseJson.get("createdCard").get("cardId").asLong()).isEqualTo(persistedCard.getId());
         assertThat(responseJson.get("createdCard").get("cardNumber").asText()).isEqualTo(persistedCard.getCardNumber());
 
         var notificationCaptor = org.mockito.ArgumentCaptor.forClass(CardNotificationDto.class);
@@ -308,5 +359,10 @@ class CardCreationControllerIntegrationTest {
     private RequestPostProcessor serviceJwt() {
         return jwt().authorities(new SimpleGrantedAuthority("ROLE_SERVICE"))
                 .jwt(token -> token.claim("id", 999L));
+    }
+
+    private RequestPostProcessor adminJwt(Long adminId) {
+        return jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))
+                .jwt(token -> token.claim("id", adminId));
     }
 }

--- a/card-service/src/test/java/com/banka1/card_service/service/implementation/CardLifecycleServiceImplTest.java
+++ b/card-service/src/test/java/com/banka1/card_service/service/implementation/CardLifecycleServiceImplTest.java
@@ -80,12 +80,12 @@ class CardLifecycleServiceImplTest {
     @Test
     void blockCard_activeCard_transitionsToBlocked() {
         Card card = cardWithStatus(CardStatus.ACTIVE);
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(accountService.getNotificationContext("265000000000123456")).thenReturn(personalAccount());
         when(clientService.getNotificationRecipient(1L)).thenReturn(recipient());
 
-        service.blockCard("1234");
+        service.blockCard(15L);
 
         assertEquals(CardStatus.BLOCKED, card.getStatus());
         verify(cardRepository).save(card);
@@ -97,13 +97,13 @@ class CardLifecycleServiceImplTest {
     @Test
     void blockCard_businessAccount_sendsToAuthorizedPersonAndOwner() {
         Card card = cardWithStatus(CardStatus.ACTIVE);
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(accountService.getNotificationContext("265000000000123456")).thenReturn(businessAccount(2L));
         when(clientService.getNotificationRecipient(1L)).thenReturn(recipient());
         when(clientService.getNotificationRecipient(2L)).thenReturn(ownerRecipient());
 
-        service.blockCard("1234");
+        service.blockCard(15L);
 
         TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
 
@@ -116,12 +116,12 @@ class CardLifecycleServiceImplTest {
     @Test
     void blockCard_businessAccountWithSameOwnerAndCardHolder_sendsSingleEmail() {
         Card card = cardWithStatus(CardStatus.ACTIVE);
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(accountService.getNotificationContext("265000000000123456")).thenReturn(businessAccount(1L));
         when(clientService.getNotificationRecipient(1L)).thenReturn(recipient());
 
-        service.blockCard("1234");
+        service.blockCard(15L);
 
         TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
 
@@ -133,18 +133,18 @@ class CardLifecycleServiceImplTest {
     @Test
     void blockCard_blockedCard_throwsBusinessException() {
         Card card = cardWithStatus(CardStatus.BLOCKED);
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
 
-        assertThrows(BusinessException.class, () -> service.blockCard("1234"));
+        assertThrows(BusinessException.class, () -> service.blockCard(15L));
         verify(cardRepository, never()).save(any());
     }
 
     @Test
     void blockCard_deactivatedCard_throwsBusinessException() {
         Card card = cardWithStatus(CardStatus.DEACTIVATED);
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
 
-        assertThrows(BusinessException.class, () -> service.blockCard("1234"));
+        assertThrows(BusinessException.class, () -> service.blockCard(15L));
         verify(cardRepository, never()).save(any());
     }
 
@@ -233,10 +233,10 @@ class CardLifecycleServiceImplTest {
     void updateCardLimit_validLimit_updatesCard() {
         Card card = cardWithStatus(CardStatus.ACTIVE);
         card.setCardLimit(BigDecimal.valueOf(1000));
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        service.updateCardLimit("1234", BigDecimal.valueOf(2000));
+        service.updateCardLimit(15L, BigDecimal.valueOf(2000));
 
         assertEquals(BigDecimal.valueOf(2000), card.getCardLimit());
         verify(cardRepository).save(card);
@@ -245,10 +245,10 @@ class CardLifecycleServiceImplTest {
     @Test
     void updateCardLimit_zeroLimit_allowed() {
         Card card = cardWithStatus(CardStatus.ACTIVE);
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        service.updateCardLimit("1234", BigDecimal.ZERO);
+        service.updateCardLimit(15L, BigDecimal.ZERO);
 
         assertEquals(BigDecimal.ZERO, card.getCardLimit());
     }
@@ -256,14 +256,14 @@ class CardLifecycleServiceImplTest {
     @Test
     void updateCardLimit_negativeLimit_throwsBusinessException() {
         assertThrows(BusinessException.class,
-                () -> service.updateCardLimit("1234", BigDecimal.valueOf(-1)));
+                () -> service.updateCardLimit(15L, BigDecimal.valueOf(-1)));
         verify(cardRepository, never()).save(any());
     }
 
     @Test
     void updateCardLimit_nullLimit_throwsBusinessException() {
         assertThrows(BusinessException.class,
-                () -> service.updateCardLimit("1234", null));
+                () -> service.updateCardLimit(15L, null));
         verify(cardRepository, never()).save(any());
     }
 
@@ -271,9 +271,9 @@ class CardLifecycleServiceImplTest {
 
     @Test
     void blockCard_cardNotFound_throwsBusinessException() {
-        when(cardRepository.findByCardNumber("9999")).thenReturn(Optional.empty());
+        when(cardRepository.findById(9999L)).thenReturn(Optional.empty());
 
-        assertThrows(BusinessException.class, () -> service.blockCard("9999"));
+        assertThrows(BusinessException.class, () -> service.blockCard(9999L));
     }
 
     @Test
@@ -306,24 +306,25 @@ class CardLifecycleServiceImplTest {
         assertEquals("265000000000123456", result.get(0).getAccountNumber());
     }
 
-    // --- getCardByCardNumber ---
+    // --- getCardById ---
 
     @Test
-    void getCardByCardNumber_returnsCardDetail() {
+    void getCardById_returnsCardDetail() {
         Card card = cardWithStatus(CardStatus.ACTIVE);
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
 
-        var result = service.getCardByCardNumber("1234");
+        var result = service.getCardById(15L);
 
+        assertEquals(15L, result.getId());
         assertEquals("1234", result.getCardNumber());
         assertEquals(CardStatus.ACTIVE, result.getStatus());
     }
 
     @Test
-    void getCardByCardNumber_cardNotFound_throwsBusinessException() {
-        when(cardRepository.findByCardNumber("9999")).thenReturn(Optional.empty());
+    void getCardById_cardNotFound_throwsBusinessException() {
+        when(cardRepository.findById(9999L)).thenReturn(Optional.empty());
 
-        assertThrows(BusinessException.class, () -> service.getCardByCardNumber("9999"));
+        assertThrows(BusinessException.class, () -> service.getCardById(9999L));
     }
 
     // --- getCardsForClient ---
@@ -337,6 +338,7 @@ class CardLifecycleServiceImplTest {
         var result = service.getCardsForClient(1L);
 
         assertEquals(1, result.size());
+        assertEquals(15L, result.get(0).getId());
         assertEquals("5798********5571", result.get(0).getMaskedCardNumber());
     }
 
@@ -349,28 +351,29 @@ class CardLifecycleServiceImplTest {
         assertEquals(0, result.size());
     }
 
-    // --- getClientIdByCardNumber ---
+    // --- getClientIdByCardId ---
 
     @Test
-    void getClientIdByCardNumber_cardNotFound_throwsBusinessException() {
-        when(cardRepository.findByCardNumber("9999")).thenReturn(Optional.empty());
+    void getClientIdByCardId_cardNotFound_throwsBusinessException() {
+        when(cardRepository.findById(9999L)).thenReturn(Optional.empty());
 
-        assertThrows(BusinessException.class, () -> service.getClientIdByCardNumber("9999"));
+        assertThrows(BusinessException.class, () -> service.getClientIdByCardId(9999L));
     }
 
     @Test
-    void getClientIdByCardNumber_returnsCorrectClientId() {
+    void getClientIdByCardId_returnsCorrectClientId() {
         Card card = cardWithStatus(CardStatus.ACTIVE);
         card.setClientId(42L);
-        when(cardRepository.findByCardNumber("1234")).thenReturn(Optional.of(card));
+        when(cardRepository.findById(15L)).thenReturn(Optional.of(card));
 
-        Long clientId = service.getClientIdByCardNumber("1234");
+        Long clientId = service.getClientIdByCardId(15L);
 
         assertEquals(42L, clientId);
     }
 
     private Card cardWithStatus(CardStatus status) {
         Card card = new Card();
+        card.setId(15L);
         card.setCardNumber("1234");
         card.setAccountNumber("265000000000123456");
         card.setClientId(1L);

--- a/card-service/src/test/java/com/banka1/card_service/service/implementation/CardRequestServiceImplTest.java
+++ b/card-service/src/test/java/com/banka1/card_service/service/implementation/CardRequestServiceImplTest.java
@@ -20,7 +20,6 @@ import com.banka1.card_service.rabbitMQ.RabbitClient;
 import com.banka1.card_service.repository.AuthorizedPersonRepository;
 import com.banka1.card_service.repository.CardRepository;
 import com.banka1.card_service.rest_client.AccountNotificationContextDto;
-import com.banka1.card_service.rest_client.AccountService;
 import com.banka1.card_service.rest_client.ClientNotificationRecipientDto;
 import com.banka1.card_service.rest_client.ClientService;
 import com.banka1.card_service.rest_client.VerificationService;
@@ -46,6 +45,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -67,9 +67,6 @@ class CardRequestServiceImplTest {
     private AuthorizedPersonRepository authorizedPersonRepository;
 
     @Mock
-    private AccountService accountService;
-
-    @Mock
     private ClientService clientService;
 
     @Mock
@@ -87,7 +84,6 @@ class CardRequestServiceImplTest {
                 cardCreationService,
                 cardRepository,
                 authorizedPersonRepository,
-                accountService,
                 clientService,
                 verificationService,
                 rabbitClient,
@@ -113,8 +109,6 @@ class CardRequestServiceImplTest {
 
         Card createdCard = card(501L, 1L, null);
 
-        when(accountService.getAccountContext("265000000000123456"))
-                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 1L));
         when(verificationService.getStatus(77L))
                 .thenReturn(new VerificationStatusResponse(77L, VerificationStatus.VERIFIED));
         when(cardRepository.countByAccountNumberAndClientIdAndAuthorizedPersonIdIsNullAndStatusNot(
@@ -124,9 +118,13 @@ class CardRequestServiceImplTest {
                 .thenReturn(new CardCreationResult(createdCard, "555"));
         when(clientService.getNotificationRecipient(1L)).thenReturn(ownerRecipient());
 
-        var response = service.processManualCardRequest(1L, request);
+        var response = service.processManualCardRequest(
+                new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 1L),
+                request
+        );
 
         assertEquals("COMPLETED", response.status());
+        assertEquals(501L, response.createdCard().cardId());
         assertEquals("4111111111111111", response.createdCard().cardNumber());
         assertEquals("555", response.createdCard().plainCvv());
         verify(rabbitClient, never()).sendCardNotification(any(), any());
@@ -147,18 +145,49 @@ class CardRequestServiceImplTest {
         request.setCardLimit(BigDecimal.valueOf(1200));
         request.setVerificationId(10L);
 
-        when(accountService.getAccountContext("265000000000123456"))
-                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 1L));
         when(verificationService.getStatus(10L))
                 .thenReturn(new VerificationStatusResponse(10L, VerificationStatus.PENDING));
 
         BusinessException exception = assertThrows(
                 BusinessException.class,
-                () -> service.processManualCardRequest(1L, request)
+                () -> service.processManualCardRequest(
+                        new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 1L),
+                        request
+                )
         );
 
         assertEquals(ErrorCode.INVALID_REQUEST_STATE, exception.getErrorCode());
         verifyNoMoreInteractions(cardCreationService, clientService, rabbitClient);
+    }
+
+    @Test
+    void handleClientRequestUsesOwnerFromAccountContextForCardCreationAndNotification() {
+        ClientCardRequestDto request = new ClientCardRequestDto();
+        request.setAccountNumber("265000000000123456");
+        request.setCardBrand(CardBrand.VISA);
+        request.setCardLimit(BigDecimal.valueOf(1200));
+        request.setVerificationId(88L);
+
+        Card createdCard = card(600L, 55L, null);
+
+        when(verificationService.getStatus(88L))
+                .thenReturn(new VerificationStatusResponse(88L, VerificationStatus.VERIFIED));
+        when(cardRepository.countByAccountNumberAndClientIdAndAuthorizedPersonIdIsNullAndStatusNot(
+                "265000000000123456", 55L, CardStatus.DEACTIVATED
+        )).thenReturn(0L);
+        when(cardCreationService.createCard(any(CreateCardCommand.class)))
+                .thenReturn(new CardCreationResult(createdCard, "444"));
+        when(clientService.getNotificationRecipient(55L))
+                .thenReturn(new ClientNotificationRecipientDto(55L, "Owner", "User", "owner@example.com"));
+
+        service.processManualCardRequest(new AccountNotificationContextDto(AccountOwnershipType.PERSONAL, 55L), request);
+
+        verify(cardCreationService).createCard(argThat(command ->
+                command != null
+                        && Long.valueOf(55L).equals(command.clientId())
+                        && "265000000000123456".equals(command.accountNumber())
+        ));
+        verify(clientService).getNotificationRecipient(55L);
     }
 
     @Test
@@ -173,8 +202,6 @@ class CardRequestServiceImplTest {
 
         Card createdCard = card(777L, 1L, 7L);
 
-        when(accountService.getAccountContext("265000000000999999"))
-                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.BUSINESS, 1L));
         when(verificationService.getStatus(15L))
                 .thenReturn(new VerificationStatusResponse(15L, VerificationStatus.VERIFIED));
         when(authorizedPersonRepository.findByEmailIgnoreCaseAndFirstNameIgnoreCaseAndLastNameIgnoreCaseAndDateOfBirth(
@@ -197,7 +224,10 @@ class CardRequestServiceImplTest {
         });
         when(clientService.getNotificationRecipient(1L)).thenReturn(ownerRecipient());
 
-        var response = service.processBusinessCardRequest(1L, request);
+        var response = service.processBusinessCardRequest(
+                new AccountNotificationContextDto(AccountOwnershipType.BUSINESS, 1L),
+                request
+        );
 
         assertEquals("COMPLETED", response.status());
 
@@ -234,8 +264,6 @@ class CardRequestServiceImplTest {
 
         Card createdCard = card(880L, 1L, 20L);
 
-        when(accountService.getAccountContext("265000000000999999"))
-                .thenReturn(new AccountNotificationContextDto(AccountOwnershipType.BUSINESS, 1L));
         when(verificationService.getStatus(33L))
                 .thenReturn(new VerificationStatusResponse(33L, VerificationStatus.VERIFIED));
         when(authorizedPersonRepository.findByEmailIgnoreCaseAndFirstNameIgnoreCaseAndLastNameIgnoreCaseAndDateOfBirth(
@@ -252,7 +280,10 @@ class CardRequestServiceImplTest {
         when(authorizedPersonRepository.save(any(AuthorizedPerson.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(clientService.getNotificationRecipient(1L)).thenReturn(ownerRecipient());
 
-        var response = service.processBusinessCardRequest(1L, request);
+        var response = service.processBusinessCardRequest(
+                new AccountNotificationContextDto(AccountOwnershipType.BUSINESS, 1L),
+                request
+        );
 
         assertEquals("COMPLETED", response.status());
         ArgumentCaptor<CreateCardCommand> commandCaptor = ArgumentCaptor.forClass(CreateCardCommand.class);


### PR DESCRIPTION
Card service changed so now it uses CARD_ID (instead of card_number) for every manipulation with the CARD. Also, updated the security, so admins can do whatever they want