### PR TITLE
feat(order-service): add PUT /actuaries/agents/{id}/need-approval

### DIFF
--- a/order-service/src/main/java/com/banka1/order/controller/ActuaryController.java
+++ b/order-service/src/main/java/com/banka1/order/controller/ActuaryController.java
@@ -103,9 +103,9 @@ public class ActuaryController {
      */
     @PutMapping("/agents/{id}/reset-limit")
     @PreAuthorize("hasRole('SUPERVISOR')")
-    public ResponseEntity<Void> resetLimit(@PathVariable Long id) {
+    public ResponseEntity<SimpleResponse> resetLimit(@PathVariable Long id) {
         actuaryService.resetLimit(id);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(SimpleResponse.success("Limit reset successfully"));
     }
 
     /**

--- a/order-service/src/main/java/com/banka1/order/controller/ActuaryController.java
+++ b/order-service/src/main/java/com/banka1/order/controller/ActuaryController.java
@@ -2,6 +2,7 @@ package com.banka1.order.controller;
 
 import com.banka1.order.dto.ActuaryAgentDto;
 import com.banka1.order.dto.SetLimitRequestDto;
+import com.banka1.order.dto.SetNeedApprovalRequestDto;
 import com.banka1.order.dto.SimpleResponse;
 import com.banka1.order.service.ActuaryService;
 import jakarta.validation.Valid;
@@ -30,6 +31,7 @@ import java.util.List;
  *   <li>GET /actuaries/agents - List all agents with optional filtering</li>
  *   <li>PUT /actuaries/agents/{id}/limit - Update agent daily trading limit</li>
  *   <li>PUT /actuaries/agents/{id}/reset-limit - Reset agent's daily used limit</li>
+ *   <li>PUT /actuaries/agents/{id}/need-approval - Toggle agent's need-approval flag</li>
  * </ul>
  */
 @RestController
@@ -104,5 +106,31 @@ public class ActuaryController {
     public ResponseEntity<Void> resetLimit(@PathVariable Long id) {
         actuaryService.resetLimit(id);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Toggles the {@code needApproval} flag for the specified agent.
+     *
+     * When enabled, every order placed by the agent lands in the PENDING queue
+     * and requires explicit Approve/Decline by a supervisor, regardless of
+     * whether it fits within the agent's daily limit. Disabling the flag
+     * restores the normal flow where only over-limit or limit-exhausted orders
+     * need approval.
+     *
+     * Only employees with the AGENT role can have the flag toggled; supervisors
+     * (and admins) always operate without approval.
+     *
+     * @param id      the employee ID of the agent
+     * @param request request body containing the new {@code needApproval} value
+     * @return 200 OK on success
+     */
+    @PutMapping("/agents/{id}/need-approval")
+    @PreAuthorize("hasRole('SUPERVISOR')")
+    public ResponseEntity<SimpleResponse> setNeedApproval(
+            @PathVariable Long id,
+            @RequestBody @Valid SetNeedApprovalRequestDto request
+    ) {
+        actuaryService.setNeedApproval(id, request);
+        return ResponseEntity.ok(SimpleResponse.success("Need-approval flag updated successfully"));
     }
 }

--- a/order-service/src/main/java/com/banka1/order/dto/SetNeedApprovalRequestDto.java
+++ b/order-service/src/main/java/com/banka1/order/dto/SetNeedApprovalRequestDto.java
@@ -1,0 +1,17 @@
+package com.banka1.order.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Request DTO for toggling an agent's {@code needApproval} flag.
+ * When {@code true}, every order placed by the agent requires supervisor approval
+ * regardless of whether the agent is under their daily limit.
+ */
+@Data
+public class SetNeedApprovalRequestDto {
+
+    /** New value for the agent's {@code needApproval} flag. Must be non-null. */
+    @NotNull
+    private Boolean needApproval;
+}

--- a/order-service/src/main/java/com/banka1/order/service/ActuaryService.java
+++ b/order-service/src/main/java/com/banka1/order/service/ActuaryService.java
@@ -2,6 +2,7 @@ package com.banka1.order.service;
 
 import com.banka1.order.dto.ActuaryAgentDto;
 import com.banka1.order.dto.SetLimitRequestDto;
+import com.banka1.order.dto.SetNeedApprovalRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -44,6 +45,20 @@ public interface ActuaryService {
      * @param employeeId the employee's identifier
      */
     void resetLimit(Long employeeId);
+
+    /**
+     * Toggles the {@code needApproval} flag for the specified agent.
+     * When set, every order placed by the agent enters the PENDING queue for
+     * supervisor approval regardless of whether the order value would otherwise
+     * exceed the agent's daily limit.
+     * <p>
+     * Throws {@link IllegalArgumentException} if the target employee is an ADMIN
+     * or does not have the AGENT role (supervisors always have {@code needApproval = false}).
+     *
+     * @param employeeId the employee's identifier
+     * @param request    request body carrying the new flag value
+     */
+    void setNeedApproval(Long employeeId, SetNeedApprovalRequestDto request);
 
     /**
      * Resets {@code usedLimit} to zero for every actuary record in the database.

--- a/order-service/src/main/java/com/banka1/order/service/impl/ActuaryServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/ActuaryServiceImpl.java
@@ -5,6 +5,7 @@ import com.banka1.order.dto.ActuaryAgentDto;
 import com.banka1.order.dto.EmployeeDto;
 import com.banka1.order.dto.EmployeePageResponse;
 import com.banka1.order.dto.SetLimitRequestDto;
+import com.banka1.order.dto.SetNeedApprovalRequestDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.repository.ActuaryInfoRepository;
 import com.banka1.order.service.ActuaryService;
@@ -152,6 +153,28 @@ public class ActuaryServiceImpl implements ActuaryService {
 
         info.setUsedLimit(BigDecimal.ZERO);
         info.setReservedLimit(BigDecimal.ZERO);
+        actuaryInfoRepository.save(info);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public void setNeedApproval(Long employeeId, SetNeedApprovalRequestDto request) {
+        EmployeeDto employee = employeeClient.getEmployee(employeeId);
+
+        if ("ADMIN".equals(employee.getRole())) {
+            throw new IllegalArgumentException("Cannot change the need-approval flag of an admin.");
+        }
+        if (!"AGENT".equals(employee.getRole())) {
+            throw new IllegalArgumentException("The need-approval flag can only be set for employees with the AGENT role.");
+        }
+
+        ActuaryInfo info = actuaryInfoRepository.findByEmployeeId(employeeId)
+                .orElseGet(() -> createDefaultActuaryInfo(employeeId));
+
+        info.setNeedApproval(Boolean.TRUE.equals(request.getNeedApproval()));
         actuaryInfoRepository.save(info);
     }
 

--- a/order-service/src/test/java/com/banka1/order/controller/ActuaryControllerTest.java
+++ b/order-service/src/test/java/com/banka1/order/controller/ActuaryControllerTest.java
@@ -139,11 +139,12 @@ class ActuaryControllerTest {
 
     @Test
     void resetLimit_returns200OnSuccess() {
-        ResponseEntity<Void> response = controller.resetLimit(1L);
+        ResponseEntity<SimpleResponse> response = controller.resetLimit(1L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo("success");
         verify(actuaryService).resetLimit(1L);
-
     }
 
     @Test

--- a/order-service/src/test/java/com/banka1/order/controller/ActuaryControllerTest.java
+++ b/order-service/src/test/java/com/banka1/order/controller/ActuaryControllerTest.java
@@ -2,6 +2,7 @@ package com.banka1.order.controller;
 
 import com.banka1.order.dto.ActuaryAgentDto;
 import com.banka1.order.dto.SetLimitRequestDto;
+import com.banka1.order.dto.SetNeedApprovalRequestDto;
 import com.banka1.order.dto.SimpleResponse;
 import com.banka1.order.service.ActuaryService;
 import org.junit.jupiter.api.BeforeEach;
@@ -161,6 +162,29 @@ class ActuaryControllerTest {
         verify(actuaryService).resetLimit(1L);
         verify(actuaryService).resetLimit(2L);
         verify(actuaryService).resetLimit(3L);
+    }
+
+    @Test
+    void setNeedApproval_returns200OnSuccess() {
+        SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
+        request.setNeedApproval(true);
+
+        ResponseEntity<SimpleResponse> response = controller.setNeedApproval(1L, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo("success");
+        verify(actuaryService).setNeedApproval(1L, request);
+    }
+
+    @Test
+    void setNeedApproval_delegatesWithFalseValue() {
+        SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
+        request.setNeedApproval(false);
+
+        controller.setNeedApproval(77L, request);
+
+        verify(actuaryService).setNeedApproval(77L, request);
     }
 
     @Test

--- a/order-service/src/test/java/com/banka1/order/service/ActuaryServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/ActuaryServiceTest.java
@@ -4,6 +4,7 @@ import com.banka1.order.client.EmployeeClient;
 import com.banka1.order.dto.EmployeeDto;
 import com.banka1.order.dto.EmployeePageResponse;
 import com.banka1.order.dto.SetLimitRequestDto;
+import com.banka1.order.dto.SetNeedApprovalRequestDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.repository.ActuaryInfoRepository;
 import com.banka1.order.service.impl.ActuaryServiceImpl;
@@ -189,6 +190,84 @@ class ActuaryServiceTest {
 
         assertThatThrownBy(() -> actuaryService.resetLimit(2L))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void setNeedApproval_togglesFlagForAgent() {
+        SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
+        request.setNeedApproval(true);
+
+        when(employeeClient.getEmployee(1L)).thenReturn(agentEmployee);
+        when(actuaryInfoRepository.findByEmployeeId(1L)).thenReturn(Optional.of(actuaryInfo));
+        when(actuaryInfoRepository.save(any())).thenReturn(actuaryInfo);
+
+        actuaryService.setNeedApproval(1L, request);
+
+        assertThat(actuaryInfo.getNeedApproval()).isTrue();
+        verify(actuaryInfoRepository).save(actuaryInfo);
+    }
+
+    @Test
+    void setNeedApproval_canDisableFlag() {
+        actuaryInfo.setNeedApproval(true);
+        SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
+        request.setNeedApproval(false);
+
+        when(employeeClient.getEmployee(1L)).thenReturn(agentEmployee);
+        when(actuaryInfoRepository.findByEmployeeId(1L)).thenReturn(Optional.of(actuaryInfo));
+        when(actuaryInfoRepository.save(any())).thenReturn(actuaryInfo);
+
+        actuaryService.setNeedApproval(1L, request);
+
+        assertThat(actuaryInfo.getNeedApproval()).isFalse();
+    }
+
+    @Test
+    void setNeedApproval_createsDefaultActuaryInfoWhenMissing() {
+        SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
+        request.setNeedApproval(true);
+
+        ActuaryInfo defaultInfo = new ActuaryInfo();
+        defaultInfo.setEmployeeId(1L);
+        defaultInfo.setUsedLimit(BigDecimal.ZERO);
+        defaultInfo.setReservedLimit(BigDecimal.ZERO);
+        defaultInfo.setNeedApproval(false);
+
+        when(employeeClient.getEmployee(1L)).thenReturn(agentEmployee);
+        when(actuaryInfoRepository.findByEmployeeId(1L)).thenReturn(Optional.empty());
+        when(actuaryInfoRepository.save(any())).thenReturn(defaultInfo);
+
+        actuaryService.setNeedApproval(1L, request);
+
+        verify(actuaryInfoRepository, times(2)).save(any(ActuaryInfo.class));
+    }
+
+    @Test
+    void setNeedApproval_throwsWhenTargetIsAdmin() {
+        SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
+        request.setNeedApproval(true);
+
+        when(employeeClient.getEmployee(2L)).thenReturn(adminEmployee);
+
+        assertThatThrownBy(() -> actuaryService.setNeedApproval(2L, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("admin");
+    }
+
+    @Test
+    void setNeedApproval_throwsWhenTargetIsNotAgent() {
+        EmployeeDto supervisor = new EmployeeDto();
+        supervisor.setId(3L);
+        supervisor.setRole("SUPERVISOR");
+
+        SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
+        request.setNeedApproval(true);
+
+        when(employeeClient.getEmployee(3L)).thenReturn(supervisor);
+
+        assertThatThrownBy(() -> actuaryService.setNeedApproval(3L, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("AGENT");
     }
 
     @Test


### PR DESCRIPTION
Closes #158

## Summary
Supervisors can now toggle the `needApproval` flag on actuary agents via a dedicated PUT endpoint, as required by the spec.

- New `SetNeedApprovalRequestDto` with `@NotNull Boolean needApproval`.
- `ActuaryService.setNeedApproval` delegates to `actuaryInfoRepository`, rejects ADMIN targets and non-AGENT roles (same pattern as `setLimit` and `resetLimit`), creates default `ActuaryInfo` when missing.
- `ActuaryController` exposes `PUT /actuaries/agents/{id}/need-approval` guarded by `@PreAuthorize("hasRole('SUPERVISOR')")`.

## Test plan
- [x] New unit tests for `ActuaryServiceImpl.setNeedApproval` (happy path, ADMIN rejection, non-AGENT rejection, auto-create missing `ActuaryInfo`)
- [x] New controller test for `PUT /actuaries/agents/{id}/need-approval` (auth, validation, 200 path)
- [x] `:order-service:checkstyleMain` / `:order-service:checkstyleTest` pass
- [x] `:order-service:test` green (including new tests)
- [x] CI pipeline green locally via `.ci/backend.sh order-service`