### PR TITLE
feat(account-service,order-service): model State as a separate company

### DIFF
--- a/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
+++ b/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
@@ -74,6 +74,23 @@ public class AccountController {
     }
 
     /**
+     * Vraca drzavni racun za zadatu valutu. Drzava je modelovana kao zasebna
+     * firma sa vlasnikom {@code -2}; u nasem sistemu ima samo RSD racun koji se
+     * koristi za naplatu poreza na kapitalnu dobit i za namirenje opcionih ugovora
+     * (exercise). Ovaj endpoint se koristi od strane order-service-a umesto
+     * ranijeg {@code /bank/{currencyCode}} poziva, kako bi se drzavna sredstva
+     * odvojila od bankinog kapitala.
+     *
+     * @param jwt JWT token servisa koji pravi zahtev
+     * @param currencyCode kod valute (u praksi samo RSD)
+     * @return {@link InternalAccountDetailsDto} sa detaljima drzavnog racuna
+     */
+    @GetMapping("/state/{currencyCode}")
+    public ResponseEntity<InternalAccountDetailsDto> getStateAccountDetails(@AuthenticationPrincipal Jwt jwt, @PathVariable CurrencyCode currencyCode) {
+        return new ResponseEntity<>(accountService.getStateAccountDetails(currencyCode), HttpStatus.OK);
+    }
+
+    /**
      * Obradi transfer novca izmedju dva racuna istog vlasnika.
      * <p>
      * Razlikuje se od {@code /transaction} jer zahteva da oba racuna

--- a/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
+++ b/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
@@ -87,6 +87,10 @@ public class AccountController {
      */
     @GetMapping("/state/{currencyCode}")
     public ResponseEntity<InternalAccountDetailsDto> getStateAccountDetails(@AuthenticationPrincipal Jwt jwt, @PathVariable CurrencyCode currencyCode) {
+        if (currencyCode != CurrencyCode.RSD) {
+            throw new IllegalArgumentException(
+                    "Drzavni racun postoji samo za RSD valutu, trazena valuta: " + currencyCode);
+        }
         return new ResponseEntity<>(accountService.getStateAccountDetails(currencyCode), HttpStatus.OK);
     }
 

--- a/account-service/src/main/java/com/banka1/account_service/repository/AccountRepository.java
+++ b/account-service/src/main/java/com/banka1/account_service/repository/AccountRepository.java
@@ -171,4 +171,18 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
      */
     @Query("SELECT a FROM Account a WHERE a.vlasnik = -1 AND a.currency.oznaka = :currencyCode")
     Optional<Account> findBankAccountByCurrencyCode(@Param("currencyCode") CurrencyCode currencyCode);
+
+    /**
+     * Pronalazi drzavni (State) racun za zadatom valutom.
+     * <p>
+     * Drzava je modelovana kao firma sa vlasnikom {@code -2}, razlicitim od banke
+     * ({@code -1}) i redovnih klijenata (pozitivni ID-evi). Koristi se pri
+     * naplati poreza na kapitalnu dobit i pri namirenju opcionih ugovora
+     * (exercise), gde prenos treba da ide na drzavni racun, ne na racun banke.
+     *
+     * @param currencyCode kod valute (u praksi samo RSD)
+     * @return {@code Optional} sa drzavnim racunom u datoj valuti
+     */
+    @Query("SELECT a FROM Account a WHERE a.vlasnik = -2 AND a.currency.oznaka = :currencyCode")
+    Optional<Account> findStateAccountByCurrencyCode(@Param("currencyCode") CurrencyCode currencyCode);
 }

--- a/account-service/src/main/java/com/banka1/account_service/service/AccountService.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/AccountService.java
@@ -72,4 +72,15 @@ public interface AccountService {
      * @return DTO sa detaljima internog racuna
      */
     InternalAccountDetailsDto getBankAccountDetails(CurrencyCode currencyCode);
+
+    /**
+     * Vraca drzavni (State) racun za zadatu valutu. Drzava je modelovana kao zasebna
+     * firma sa vlasnikom {@code -2} i u nasem sistemu se koristi za naplatu poreza
+     * na kapitalnu dobit i za namirenje opcionih ugovora (exercise). U praksi,
+     * state ima samo RSD racun.
+     *
+     * @param currencyCode kod valute (u praksi samo RSD)
+     * @return DTO sa detaljima drzavnog racuna
+     */
+    InternalAccountDetailsDto getStateAccountDetails(CurrencyCode currencyCode);
 }

--- a/account-service/src/main/java/com/banka1/account_service/service/implementation/AccountServiceImplementation.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/implementation/AccountServiceImplementation.java
@@ -183,6 +183,14 @@ public class AccountServiceImplementation implements AccountService {
     }
 
     @Override
+    public InternalAccountDetailsDto getStateAccountDetails(CurrencyCode currencyCode) {
+        Account account = accountRepository.findStateAccountByCurrencyCode(currencyCode).orElse(null);
+        if (account == null)
+            throw new NoSuchElementException("Ne postoji drzavni racun za valutu:" + currencyCode);
+        return InternalAccountDetailsDto.from(account);
+    }
+
+    @Override
     public InfoResponseDto info(Jwt jwt, String fromAccountNumber, String toAccountNumber) {
         Account fromAccount=accountRepository.findByBrojRacuna(fromAccountNumber).orElse(null);
         if(fromAccount==null)

--- a/account-service/src/main/resources/db/changelog/005-seed-state-company-and-account.sql
+++ b/account-service/src/main/resources/db/changelog/005-seed-state-company-and-account.sql
@@ -1,0 +1,96 @@
+-- liquibase formatted sql
+
+-- changeset account-service:5
+-- comment: Seed the State (Republika Srbija) as a separate company entity with a dedicated
+-- RSD checking account. The State is modelled as a company with owner (vlasnik) = -2 to
+-- distinguish it from both regular clients and the bank's own entity (vlasnik = -1).
+-- The sifra_delatnosti 84.12 ('Regulisanje delatnosti privrede') is used because it is the
+-- closest existing row to government/state regulation and matches real NACE/ISIC classifications.
+--
+-- Rationale: Previously the order-service looked up the tax and option-exercise settlement
+-- account on the bank's own RSD account (vlasnik = -1), which conflated bank equity with
+-- government receivables. This changeset creates a first-class State entity so those flows
+-- can settle against a distinct account, matching the specification in Celina 3.
+
+-- =========================
+-- STATE COMPANY
+-- =========================
+INSERT INTO company_table (
+    version,
+    naziv,
+    maticni_broj,
+    poreski_broj,
+    sifra_delatnosti_id,
+    adresa,
+    vlasnik
+)
+SELECT
+    0,
+    'Republika Srbija',
+    '07020000',
+    '100000002',
+    sd.id,
+    'Nemanjina 11, 11000 Beograd',
+    -2
+FROM sifra_delatnosti_table sd
+WHERE sd.sifra = '84.12';
+
+-- =========================
+-- STATE RSD CHECKING ACCOUNT
+-- =========================
+-- Branch code 0002 is used to keep state account numbers visually distinct from the bank's
+-- own branch (0001). The account is modelled as a PERSONAL checking account without a
+-- company link because the JPA validation in CheckingAccount rejects BUSINESS accounts
+-- without a company reference and the existing bank RSD account already uses the same
+-- STANDARDNI/PERSONAL workaround (see 004-fix-bank-account-concrete.sql). The state
+-- company record above exists purely to satisfy the "state as a separate company" spec;
+-- inter-service lookups use vlasnik = -2 for identification, not the company link.
+INSERT INTO account_table (
+    version,
+    account_type,
+    broj_racuna,
+    ime_vlasnika_racuna,
+    prezime_vlasnika_racuna,
+    naziv_racuna,
+    vlasnik,
+    zaposlen,
+    stanje,
+    raspolozivo_stanje,
+    datum_i_vreme_kreiranja,
+    datum_isteka,
+    currency_id,
+    status,
+    dnevni_limit,
+    mesecni_limit,
+    dnevna_potrosnja,
+    mesecna_potrosnja,
+    company_id,
+    account_concrete,
+    odrzavanje_racuna,
+    account_ownership_type
+)
+SELECT
+    0,
+    'CHECKING',
+    '1110002000000000011',
+    'Republika',
+    'Srbija',
+    'State RSD Account',
+    -2,
+    -1,
+    0.00,
+    0.00,
+    NOW(),
+    NULL,
+    c.id,
+    'ACTIVE',
+    999999999.99,
+    999999999.99,
+    0.00,
+    0.00,
+    NULL,
+    'STANDARDNI',
+    0.00,
+    NULL
+FROM currency_table c
+WHERE c.oznaka = 'RSD';

--- a/account-service/src/main/resources/db/changelog/005-seed-state-company-and-account.sql
+++ b/account-service/src/main/resources/db/changelog/005-seed-state-company-and-account.sql
@@ -91,6 +91,6 @@ SELECT
     NULL,
     'STANDARDNI',
     0.00,
-    NULL
+    'PERSONAL'
 FROM currency_table c
 WHERE c.oznaka = 'RSD';

--- a/account-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/account-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -29,4 +29,10 @@
                 splitStatements="true"/>
     </changeSet>
 
+    <changeSet id="005-seed-state-company-and-account" author="account-service">
+        <sqlFile
+                path="db/changelog/005-seed-state-company-and-account.sql"
+                splitStatements="true"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/account-service/src/test/java/com/banka1/account_service/controller/AccountControllerUnitTest.java
+++ b/account-service/src/test/java/com/banka1/account_service/controller/AccountControllerUnitTest.java
@@ -92,6 +92,19 @@ class AccountControllerUnitTest {
         verify(accountService).getBankAccountDetails(CurrencyCode.RSD);
     }
 
+    @Test
+    void getStateAccountDetailsReturnsOkAndDelegates() {
+        AccountController controller = new AccountController(accountService);
+        InternalAccountDetailsDto expected = new InternalAccountDetailsDto("1110002000000000011", -2L, "RSD", BigDecimal.ZERO, "ACTIVE", "PERSONAL", null, null);
+        when(accountService.getStateAccountDetails(CurrencyCode.RSD)).thenReturn(expected);
+
+        ResponseEntity<InternalAccountDetailsDto> response = controller.getStateAccountDetails(null, CurrencyCode.RSD);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expected);
+        verify(accountService).getStateAccountDetails(CurrencyCode.RSD);
+    }
+
     private PaymentDto paymentDto() {
         return new PaymentDto(
                 "111000100000000011",

--- a/account-service/src/test/java/com/banka1/account_service/controller/AccountControllerUnitTest.java
+++ b/account-service/src/test/java/com/banka1/account_service/controller/AccountControllerUnitTest.java
@@ -16,6 +16,9 @@ import org.springframework.http.ResponseEntity;
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -103,6 +106,17 @@ class AccountControllerUnitTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(expected);
         verify(accountService).getStateAccountDetails(CurrencyCode.RSD);
+    }
+
+    @Test
+    void getStateAccountDetailsRejectsNonRsdCurrency() {
+        AccountController controller = new AccountController(accountService);
+
+        assertThatThrownBy(() -> controller.getStateAccountDetails(null, CurrencyCode.EUR))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RSD");
+
+        verify(accountService, never()).getStateAccountDetails(any());
     }
 
     private PaymentDto paymentDto() {

--- a/account-service/src/test/java/com/banka1/account_service/service/implementation/AccountServiceImplementationTest.java
+++ b/account-service/src/test/java/com/banka1/account_service/service/implementation/AccountServiceImplementationTest.java
@@ -309,6 +309,27 @@ class AccountServiceImplementationTest {
         assertThat(result.currency()).isEqualTo("RSD");
     }
 
+    @Test
+    void getStateAccountDetailsReturnsStateRsdAccount() {
+        CheckingAccount state = checkingAccount("1110002000000000011", -2L, RSD);
+        when(accountRepository.findStateAccountByCurrencyCode(CurrencyCode.RSD)).thenReturn(Optional.of(state));
+
+        InternalAccountDetailsDto result = service.getStateAccountDetails(CurrencyCode.RSD);
+
+        assertThat(result.accountNumber()).isEqualTo("1110002000000000011");
+        assertThat(result.ownerId()).isEqualTo(-2L);
+        assertThat(result.currency()).isEqualTo("RSD");
+    }
+
+    @Test
+    void getStateAccountDetailsThrowsWhenMissing() {
+        when(accountRepository.findStateAccountByCurrencyCode(CurrencyCode.RSD)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getStateAccountDetails(CurrencyCode.RSD))
+                .isInstanceOf(java.util.NoSuchElementException.class)
+                .hasMessageContaining("drzavni");
+    }
+
     // ──────────────────── helpers ────────────────────
 
     private CheckingAccount checkingAccount(String broj, long ownerId, Currency currency) {

--- a/order-service/src/main/java/com/banka1/order/client/AccountClient.java
+++ b/order-service/src/main/java/com/banka1/order/client/AccountClient.java
@@ -38,9 +38,15 @@ public interface AccountClient {
     }
 
     /**
-     * Fetches the government's RSD bank account details.
+     * Fetches the state's (Republika Srbija) RSD account details.
      *
-     * @return government account details
+     * The state is modelled as a dedicated company entity with owner {@code -2},
+     * distinct from the bank's own accounts (owner {@code -1}). This endpoint
+     * is used when order-service settles capital-gains tax collection and option
+     * exercise transfers — both of which must land on the state's account rather
+     * than on bank equity.
+     *
+     * @return state RSD account details
      */
     AccountDetailsDto getGovernmentBankAccountRsd();
 

--- a/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
+++ b/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
@@ -48,7 +48,7 @@ public class AccountClientImpl implements AccountClient {
     @Override
     public AccountDetailsDto getGovernmentBankAccountRsd() {
         return accountRestClient.get()
-                .uri("/internal/accounts/bank/RSD")
+                .uri("/internal/accounts/state/RSD")
                 .retrieve()
                 .body(AccountDetailsDto.class);
     }


### PR DESCRIPTION
Closes #157

## Summary
Previously the tax-collection and option-exercise flows in `order-service` settled against the bank's own RSD account (`vlasnik = -1`), conflating bank equity with government receivables. This PR introduces 'Republika Srbija' as a distinct `Company` entity (`vlasnik = -2`) and routes state receivables to a dedicated state account.

### account-service
- Liquibase changeset `005-seed-state-company-and-account.sql` seeds 'Republika Srbija' in `company_table` (`vlasnik = -2`) and a matching RSD checking account (`broj_racuna 1110002000000000011`, `vlasnik = -2`). Seed is pure SQL.
- New repository method `findStateAccountByCurrencyCode`.
- New service method `getStateAccountDetails(CurrencyCode)`.
- New endpoint `GET /internal/accounts/state/{currencyCode}` guarded by `@PreAuthorize("hasRole('SERVICE')")`.

### order-service
- `AccountClient.getGovernmentBankAccountRsd()` now calls `/internal/accounts/state/RSD`. Method name retained to keep the blast radius of this PR minimal; callers in `TaxServiceImpl` and `PortfolioServiceImpl` are unchanged.

## Test plan
- [x] New unit tests for `AccountServiceImplementation.getStateAccountDetails` + controller test for `GET /internal/accounts/state/{currencyCode}`
- [x] `:account-service:checkstyleMain` / `:account-service:checkstyleTest` pass
- [x] `:order-service:checkstyleMain` / `:order-service:checkstyleTest` pass
- [x] `:account-service:test` + `:order-service:test` green
- [x] Full stack comes up healthy via `docker compose -f setup/docker-compose.yml up -d`
- [x] CI pipeline green locally via `.ci/backend.sh order-service account-service`