### PR TITLE
Toggle endpoint fixed to return 404 instead of 500 if id doesnt exist

### DIFF
--- a/stock-service/src/main/java/com/banka1/stock_service/controller/StockExchangeController.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/controller/StockExchangeController.java
@@ -6,12 +6,14 @@ import com.banka1.stock_service.dto.StockExchangeToggleResponse;
 import com.banka1.stock_service.service.StockExchangeService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -65,7 +67,14 @@ public class StockExchangeController {
     @PutMapping("/api/stock-exchanges/{id}/toggle-active")
     @PreAuthorize("hasAnyRole('ADMIN', 'SUPERVISOR')")
     public ResponseEntity<StockExchangeToggleResponse> toggleStockExchangeActive(@PathVariable Long id) {
-        StockExchangeToggleResponse response = stockExchangeService.toggleStockExchangeActive(id);
-        return ResponseEntity.ok(response);
+        try {
+            StockExchangeToggleResponse response = stockExchangeService.toggleStockExchangeActive(id);
+            return ResponseEntity.ok(response);
+        } catch (ResponseStatusException exception) {
+            if (exception.getStatusCode().value() == HttpStatus.NOT_FOUND.value()) {
+                return ResponseEntity.notFound().build();
+            }
+            throw exception;
+        }
     }
 }

--- a/stock-service/src/test/java/com/banka1/stock_service/controller/StockExchangeControllerWebMvcTest.java
+++ b/stock-service/src/test/java/com/banka1/stock_service/controller/StockExchangeControllerWebMvcTest.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -30,6 +31,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -135,6 +137,19 @@ class StockExchangeControllerWebMvcTest {
                 .andExpect(jsonPath("$.isActive").value(false));
 
         verify(stockExchangeService).toggleStockExchangeActive(1L);
+    }
+
+    @Test
+    void toggleStockExchangeActiveReturnsNotFoundForUnknownId() throws Exception {
+        when(stockExchangeService.toggleStockExchangeActive(290000L))
+                .thenThrow(new ResponseStatusException(NOT_FOUND, "Stock exchange with id 290000 was not found."));
+
+        mockMvc.perform(put("/api/stock-exchanges/290000/toggle-active")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))
+                                .jwt(token -> token.claim("id", 13L))))
+                .andExpect(status().isNotFound());
+
+        verify(stockExchangeService).toggleStockExchangeActive(290000L);
     }
 
     @TestConfiguration

--- a/stock-service/src/test/java/com/banka1/stock_service/service/implementation/StockExchangeServiceImplTest.java
+++ b/stock-service/src/test/java/com/banka1/stock_service/service/implementation/StockExchangeServiceImplTest.java
@@ -133,6 +133,15 @@ class StockExchangeServiceImplTest {
     }
 
     @Test
+    void toggleStockExchangeActiveThrowsNotFoundWhenExchangeDoesNotExist() {
+        when(stockExchangeRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> serviceAt("2026-04-06T14:30:00Z").toggleStockExchangeActive(404L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("404 NOT_FOUND");
+    }
+
+    @Test
     void getStockExchangeStatusThrowsNotFoundWhenExchangeDoesNotExist() {
         when(stockExchangeRepository.findById(404L)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
Toggle endpoint fixed to return 404 instead of 500 if id doesnt exist