### PR TITLE
fix(order-service): correct HTTP status codes for actuary endpoints (#185)

### DIFF
--- a/order-service/src/main/java/com/banka1/order/advice/OrderServiceExceptionHandler.java
+++ b/order-service/src/main/java/com/banka1/order/advice/OrderServiceExceptionHandler.java
@@ -8,6 +8,7 @@ import com.banka1.order.exception.ResourceNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -70,6 +71,20 @@ public class OrderServiceExceptionHandler {
     @ExceptionHandler(ForbiddenOperationException.class)
     public ResponseEntity<ApiErrorResponse> handleForbidden(ForbiddenOperationException ex, HttpServletRequest request) {
         return build(HttpStatus.FORBIDDEN, ex.getMessage(), request);
+    }
+
+    /**
+     * Handles AccessDeniedException (403 Forbidden).
+     * Thrown by Spring Security when @PreAuthorize / method security rejects the caller's role.
+     * Without this explicit handler the catch-all Exception handler maps it to 500.
+     *
+     * @param ex the AccessDeniedException
+     * @param request the HTTP request
+     * @return ResponseEntity with 403 status and error details
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+        return build(HttpStatus.FORBIDDEN, "Access denied", request);
     }
 
     /**

--- a/order-service/src/main/java/com/banka1/order/controller/ActuaryController.java
+++ b/order-service/src/main/java/com/banka1/order/controller/ActuaryController.java
@@ -97,6 +97,9 @@ public class ActuaryController {
      * This allows supervisors to manually reset an agent's daily consumption at any time,
      * not just at the scheduled 23:59 reset. Useful for special circumstances or corrections.
      *
+     * Only employees with the AGENT role can have their limit reset; supervisors and admins
+     * have no daily limit and are rejected with 400 Bad Request.
+     *
      * @param id the employee ID of the agent
      * @return 200 OK on success
      * @throws ResourceNotFoundException if employee not found

--- a/order-service/src/main/java/com/banka1/order/service/impl/ActuaryServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/ActuaryServiceImpl.java
@@ -7,6 +7,7 @@ import com.banka1.order.dto.EmployeePageResponse;
 import com.banka1.order.dto.SetLimitRequestDto;
 import com.banka1.order.dto.SetNeedApprovalRequestDto;
 import com.banka1.order.entity.ActuaryInfo;
+import com.banka1.order.exception.ResourceNotFoundException;
 import com.banka1.order.repository.ActuaryInfoRepository;
 import com.banka1.order.service.ActuaryService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -113,7 +115,7 @@ public class ActuaryServiceImpl implements ActuaryService {
     @Override
     @Transactional
     public void setLimit(Long employeeId, SetLimitRequestDto request) {
-        EmployeeDto employee = employeeClient.getEmployee(employeeId);
+        EmployeeDto employee = fetchEmployeeOrNotFound(employeeId);
 
         if ("ADMIN".equals(employee.getRole())) {
             throw new IllegalArgumentException("Cannot change the limit of an admin.");
@@ -142,10 +144,13 @@ public class ActuaryServiceImpl implements ActuaryService {
     @Override
     @Transactional
     public void resetLimit(Long employeeId) {
-        EmployeeDto employee = employeeClient.getEmployee(employeeId);
+        EmployeeDto employee = fetchEmployeeOrNotFound(employeeId);
 
         if ("ADMIN".equals(employee.getRole())) {
             throw new IllegalArgumentException("Cannot reset the limit of an admin.");
+        }
+        if (!"AGENT".equals(employee.getRole())) {
+            throw new IllegalArgumentException("Limit can only be reset for employees with the AGENT role.");
         }
 
         ActuaryInfo info = actuaryInfoRepository.findByEmployeeId(employeeId)
@@ -162,7 +167,7 @@ public class ActuaryServiceImpl implements ActuaryService {
     @Override
     @Transactional
     public void setNeedApproval(Long employeeId, SetNeedApprovalRequestDto request) {
-        EmployeeDto employee = employeeClient.getEmployee(employeeId);
+        EmployeeDto employee = fetchEmployeeOrNotFound(employeeId);
 
         if ("ADMIN".equals(employee.getRole())) {
             throw new IllegalArgumentException("Cannot change the need-approval flag of an admin.");
@@ -200,6 +205,14 @@ public class ActuaryServiceImpl implements ActuaryService {
      * @param employeeId the employee's identifier
      * @return the newly saved actuary record
      */
+    private EmployeeDto fetchEmployeeOrNotFound(Long employeeId) {
+        try {
+            return employeeClient.getEmployee(employeeId);
+        } catch (HttpClientErrorException.NotFound ex) {
+            throw new ResourceNotFoundException("Employee with ID " + employeeId + " not found.");
+        }
+    }
+
     private ActuaryInfo createDefaultActuaryInfo(Long employeeId) {
         ActuaryInfo info = new ActuaryInfo();
         info.setEmployeeId(employeeId);

--- a/order-service/src/test/java/com/banka1/order/service/ActuaryServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/ActuaryServiceTest.java
@@ -7,6 +7,7 @@ import com.banka1.order.dto.SetLimitRequestDto;
 import com.banka1.order.dto.SetNeedApprovalRequestDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.repository.ActuaryInfoRepository;
+import com.banka1.order.exception.ResourceNotFoundException;
 import com.banka1.order.service.impl.ActuaryServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -193,6 +197,20 @@ class ActuaryServiceTest {
     }
 
     @Test
+    void resetLimit_throwsWhenTargetIsNotAgent() {
+        EmployeeDto supervisor = new EmployeeDto();
+        supervisor.setId(3L);
+        supervisor.setRole("SUPERVISOR");
+
+        when(employeeClient.getEmployee(3L)).thenReturn(supervisor);
+
+        assertThatThrownBy(() -> actuaryService.resetLimit(3L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("AGENT");
+        verify(actuaryInfoRepository, never()).save(any());
+    }
+
+    @Test
     void setNeedApproval_togglesFlagForAgent() {
         SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
         request.setNeedApproval(true);
@@ -268,6 +286,45 @@ class ActuaryServiceTest {
         assertThatThrownBy(() -> actuaryService.setNeedApproval(3L, request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("AGENT");
+    }
+
+    @Test
+    void setLimit_throwsResourceNotFoundWhenEmployeeMissing() {
+        SetLimitRequestDto request = new SetLimitRequestDto();
+        request.setLimit(new BigDecimal("50000.00"));
+
+        when(employeeClient.getEmployee(999999L))
+                .thenThrow(HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", HttpHeaders.EMPTY, new byte[0], null));
+
+        assertThatThrownBy(() -> actuaryService.setLimit(999999L, request))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("999999");
+        verify(actuaryInfoRepository, never()).save(any());
+    }
+
+    @Test
+    void resetLimit_throwsResourceNotFoundWhenEmployeeMissing() {
+        when(employeeClient.getEmployee(999999L))
+                .thenThrow(HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", HttpHeaders.EMPTY, new byte[0], null));
+
+        assertThatThrownBy(() -> actuaryService.resetLimit(999999L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("999999");
+        verify(actuaryInfoRepository, never()).save(any());
+    }
+
+    @Test
+    void setNeedApproval_throwsResourceNotFoundWhenEmployeeMissing() {
+        SetNeedApprovalRequestDto request = new SetNeedApprovalRequestDto();
+        request.setNeedApproval(true);
+
+        when(employeeClient.getEmployee(999999L))
+                .thenThrow(HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", HttpHeaders.EMPTY, new byte[0], null));
+
+        assertThatThrownBy(() -> actuaryService.setNeedApproval(999999L, request))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("999999");
+        verify(actuaryInfoRepository, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
Sub-issues addressed:
- #1 GET /actuaries/agents now returns 403 (not 500) for non-supervisors: added AccessDeniedException handler so Spring Security's @PreAuthorize rejection no longer falls through to the catch-all 500 mapping.
- #2/#3/#5 setLimit / resetLimit / setNeedApproval now return 404 (not 500) when the target employee id does not exist: wrap employeeClient.getEmployee and translate HttpClientErrorException.NotFound to ResourceNotFoundException.
- #4 resetLimit now returns 400 (not 200) when called with a non-AGENT id (supervisor / non-agent employee): mirror the role guard already present in setLimit and setNeedApproval. Previously a default ActuaryInfo row was silently created for non-agents.

Tests: added not-agent and not-found cases to ActuaryServiceTest.