### PR TITLE
fix(order-service,stock-service): resolve 500 on POST /order/orders/buy

### DIFF
--- a/order-service/src/main/java/com/banka1/order/dto/StockListingDto.java
+++ b/order-service/src/main/java/com/banka1/order/dto/StockListingDto.java
@@ -28,7 +28,8 @@ public class StockListingDto {
     private BigDecimal bid;
     /** Currency code of the listing's exchange. */
     private String currency;
-    /** Identifier of the exchange this listing belongs to. */
+    /** Identifier of the exchange this listing belongs to. Stock-service serializes this field as "stockExchangeId". */
+    @JsonProperty("stockExchangeId")
     private Long exchangeId;
     /** Number of units per contract. */
     private Integer contractSize;

--- a/stock-service/src/main/java/com/banka1/stock_service/controller/StockExchangeController.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/controller/StockExchangeController.java
@@ -1,5 +1,7 @@
 package com.banka1.stock_service.controller;
 
+import com.banka1.stock_service.dto.ExchangeRuntimeStatusResponse;
+import com.banka1.stock_service.dto.StockExchangeMarketPhase;
 import com.banka1.stock_service.dto.StockExchangeResponse;
 import com.banka1.stock_service.dto.StockExchangeStatusResponse;
 import com.banka1.stock_service.dto.StockExchangeToggleResponse;
@@ -55,6 +57,22 @@ public class StockExchangeController {
     public ResponseEntity<StockExchangeStatusResponse> getStockExchangeStatus(@PathVariable Long id) {
         StockExchangeStatusResponse response = stockExchangeService.getStockExchangeStatus(id);
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Compact runtime status for service-to-service callers (e.g. order-service).
+     * Mirrors {@code /is-open} but returns only open / closed / after-hours flags.
+     *
+     * @param id exchange identifier
+     * @return runtime flags suitable for trading-window decisions
+     */
+    @Operation(summary = "Get compact stock exchange runtime status")
+    @GetMapping("/api/stock-exchanges/{id}/status")
+    @PreAuthorize("hasAnyRole('CLIENT_BASIC', 'BASIC', 'AGENT', 'SUPERVISOR', 'ADMIN', 'SERVICE')")
+    public ResponseEntity<ExchangeRuntimeStatusResponse> getStockExchangeRuntimeStatus(@PathVariable Long id) {
+        StockExchangeStatusResponse status = stockExchangeService.getStockExchangeStatus(id);
+        boolean afterHours = status.marketPhase() == StockExchangeMarketPhase.POST_MARKET;
+        return ResponseEntity.ok(new ExchangeRuntimeStatusResponse(status.open(), afterHours, !status.open()));
     }
 
     /**

--- a/stock-service/src/main/java/com/banka1/stock_service/dto/ExchangeRuntimeStatusResponse.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/dto/ExchangeRuntimeStatusResponse.java
@@ -1,0 +1,12 @@
+package com.banka1.stock_service.dto;
+
+/**
+ * Lightweight runtime status payload consumed by service-to-service callers
+ * (e.g. order-service) that only need open/closed/after-hours flags.
+ */
+public record ExchangeRuntimeStatusResponse(
+        boolean open,
+        boolean afterHours,
+        boolean closed
+) {
+}


### PR DESCRIPTION
## Summary

Fixes #188. `POST /order/orders/buy` was returning HTTP 500 because of two
stacked bugs in the service-to-service call chain between `order-service`
and `stock-service`. This PR resolves both with minimal, targeted changes.

## Root cause

1. **Missing endpoint.** `order-service` `StockClientImpl#getExchangeStatus`
   calls `GET /api/stock-exchanges/{id}/status`, which did not exist in
   `stock-service` (only `/is-open`). The 404 surfaced as a 500
   `Unexpected server error`.
2. **DTO field name mismatch.** Even with the route in place, `order-service`
   `StockListingDto` mapped the exchange id from a field named `exchangeId`,
   while `stock-service`'s `ListingDetailsResponse` serializes it as
   `stockExchangeId`. Jackson left it `null`, producing the URL
   `/api/stock-exchanges//status` (double slash), which Spring
   `StrictHttpFirewall` rejects.

## Changes

- `stock-service`
  - **new** `dto/ExchangeRuntimeStatusResponse.java` — compact record
    `(open, afterHours, closed)` matching `order-service`'s
    `ExchangeStatusDto`.
  - **modified** `controller/StockExchangeController.java` — adds
    `GET /api/stock-exchanges/{id}/status` that wraps
    `getStockExchangeStatus` and maps `marketPhase == POST_MARKET` to
    `afterHours`.
- `order-service`
  - **modified** `dto/StockListingDto.java` — adds
    `@JsonProperty("stockExchangeId")` on the existing `exchangeId`
    field; no behavior change beyond correct deserialization.

No public API was changed; the new `/status` route is additive and the
existing `/is-open` route is untouched.