### PR TITLE
fix(order-service): correct supervisor JWT id parsing and client confirm flow (#191)

### DIFF
--- a/order-service/src/main/java/com/banka1/order/controller/OrderController.java
+++ b/order-service/src/main/java/com/banka1/order/controller/OrderController.java
@@ -105,13 +105,13 @@ public class OrderController {
     @PutMapping("/{id}/approve")
     @PreAuthorize("hasRole('SUPERVISOR')")
     public ResponseEntity<OrderResponse> approveOrder(@AuthenticationPrincipal Jwt jwt, @PathVariable Long id) {
-        return ResponseEntity.ok(orderCreationService.approveOrder(Long.valueOf(jwt.getSubject()), id));
+        return ResponseEntity.ok(orderCreationService.approveOrder(toAuthenticatedUser(jwt).userId(), id));
     }
 
     @PutMapping("/{id}/decline")
     @PreAuthorize("hasRole('SUPERVISOR')")
     public ResponseEntity<OrderResponse> declineOrder(@AuthenticationPrincipal Jwt jwt, @PathVariable Long id) {
-        return ResponseEntity.ok(orderCreationService.declineOrder(Long.valueOf(jwt.getSubject()), id));
+        return ResponseEntity.ok(orderCreationService.declineOrder(toAuthenticatedUser(jwt).userId(), id));
     }
 
     private AuthenticatedUser toAuthenticatedUser(Jwt jwt) {

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
@@ -231,7 +231,9 @@ public class OrderCreationServiceImpl implements OrderCreationService {
         } else if (order.getDirection() == OrderDirection.BUY) {
             checkFunds(fundingAccountId, approximatePrice.add(fee));
         }
-        ApprovalReservationDecision decision = determineOrderStatusAndReserveExposure(user.userId(), approximatePrice, listing.getCurrency());
+        ApprovalReservationDecision decision = user.isClient()
+                ? new ApprovalReservationDecision(OrderStatus.PENDING, BigDecimal.ZERO)
+                : determineOrderStatusAndReserveExposure(user.userId(), approximatePrice, listing.getCurrency());
         reserveSellQuantityIfNeeded(order);
         if (decision.status() == OrderStatus.APPROVED) {
             transferFee(user, fundingAccountId, fee, listing.getCurrency());

--- a/order-service/src/test/java/com/banka1/order/controller/OrderControllerTest.java
+++ b/order-service/src/test/java/com/banka1/order/controller/OrderControllerTest.java
@@ -108,6 +108,34 @@ class OrderControllerTest {
     }
 
     @Test
+    void approveAndDeclineUseIdClaimNotEmailSubject() {
+        OrderResponse approved = new OrderResponse();
+        approved.setId(7L);
+        approved.setStatus(OrderStatus.APPROVED);
+        OrderResponse declined = new OrderResponse();
+        declined.setId(7L);
+        declined.setStatus(OrderStatus.DECLINED);
+        when(orderCreationService.approveOrder(eq(99L), eq(7L))).thenReturn(approved);
+        when(orderCreationService.declineOrder(eq(99L), eq(7L))).thenReturn(declined);
+
+        Jwt jwt = Jwt.withTokenValue("token")
+                .subject("supervisor@banka.com")
+                .claim("id", 99L)
+                .claim("roles", List.of("SUPERVISOR"))
+                .claim("permissions", List.of())
+                .header("alg", "none")
+                .build();
+
+        ResponseEntity<OrderResponse> approveResponse = controller.approveOrder(jwt, 7L);
+        ResponseEntity<OrderResponse> declineResponse = controller.declineOrder(jwt, 7L);
+
+        assertThat(approveResponse.getBody().getStatus()).isEqualTo(OrderStatus.APPROVED);
+        assertThat(declineResponse.getBody().getStatus()).isEqualTo(OrderStatus.DECLINED);
+        verify(orderCreationService).approveOrder(99L, 7L);
+        verify(orderCreationService).declineOrder(99L, 7L);
+    }
+
+    @Test
     void buyAndSellRequestsUseBeanValidation() throws Exception {
         Method createBuyOrder = OrderController.class.getDeclaredMethod("createBuyOrder", Jwt.class, com.banka1.order.dto.CreateBuyOrderRequest.class);
         assertThat(createBuyOrder.getParameters()[1].getAnnotation(Valid.class)).isNotNull();

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java
@@ -222,19 +222,15 @@ class OrderCreationServiceTest {
 //    }
 
     @Test
-    void confirmBuyOrder_forClientApprovesTransfersFeeAndStartsExecution() {
+    void confirmBuyOrder_forClientMovesToPendingAndAwaitsSupervisorApproval() {
         service.createBuyOrder(clientUser, buyRequest);
 
         OrderResponse response = service.confirmOrder(clientUser, 100L);
 
-        assertThat(response.getStatus()).isEqualTo(OrderStatus.APPROVED);
-        assertThat(response.getApprovedBy()).isEqualTo(OrderCreationServiceImpl.NO_APPROVAL_REQUIRED);
-        verify(accountClient).transfer(any(AccountTransactionRequest.class));
-        verify(orderExecutionService).executeOrderAsync(100L);
-
-        ArgumentCaptor<AccountTransactionRequest> captor = ArgumentCaptor.forClass(AccountTransactionRequest.class);
-        verify(accountClient).transfer(captor.capture());
-        assertThat(captor.getValue().getCurrency()).isEqualTo("USD");
+        assertThat(response.getStatus()).isEqualTo(OrderStatus.PENDING);
+        assertThat(response.getApprovedBy()).isNull();
+        verify(accountClient, never()).transfer(any(AccountTransactionRequest.class));
+        verify(orderExecutionService, never()).executeOrderAsync(any());
     }
 
     @Test
@@ -493,7 +489,7 @@ class OrderCreationServiceTest {
         service.createBuyOrder(marginClient, buyRequest);
         OrderResponse response = service.confirmOrder(marginClient, 100L);
 
-        assertThat(response.getStatus()).isEqualTo(OrderStatus.APPROVED);
+        assertThat(response.getStatus()).isEqualTo(OrderStatus.PENDING);
     }
 
     @Test
@@ -524,7 +520,7 @@ class OrderCreationServiceTest {
         OrderResponse confirmed = service.confirmOrder(clientUser, 100L);
 
         assertThat(created.getStatus()).isEqualTo(OrderStatus.PENDING_CONFIRMATION);
-        assertThat(confirmed.getStatus()).isEqualTo(OrderStatus.APPROVED);
+        assertThat(confirmed.getStatus()).isEqualTo(OrderStatus.PENDING);
     }
 
     @Test
@@ -569,7 +565,7 @@ class OrderCreationServiceTest {
         service.createSellOrder(marginClient, sellRequest);
         OrderResponse response = service.confirmOrder(marginClient, 100L);
 
-        assertThat(response.getStatus()).isEqualTo(OrderStatus.APPROVED);
+        assertThat(response.getStatus()).isEqualTo(OrderStatus.PENDING);
     }
 
     @Test
@@ -588,7 +584,7 @@ class OrderCreationServiceTest {
         service.createSellOrder(marginClient, sellRequest);
         OrderResponse response = service.confirmOrder(marginClient, 100L);
 
-        assertThat(response.getStatus()).isEqualTo(OrderStatus.APPROVED);
+        assertThat(response.getStatus()).isEqualTo(OrderStatus.PENDING);
     }
 
     @Test


### PR DESCRIPTION
# fix(order-service): order confirm/approve/decline failures for clients and supervisors (#191)

Closes #191.

## Summary

Issue #191 reported two distinct controller-level failures in `order-service`:

- `PUT /orders/{id}/approve` and `PUT /orders/{id}/decline` returned **HTTP 400** for every supervisor request.
- `POST /orders/{id}/confirm` returned **HTTP 500** specifically for `CLIENT_TRADING` users (worked for `AGENT` / `SUPERVISOR`).

Both bugs are addressed in this PR.

## Root causes

### 1. approve / decline → 400

`OrderController.approveOrder` and `OrderController.declineOrder` extracted the supervisor id with `Long.valueOf(jwt.getSubject())`. In Banka-1, the JWT `sub` claim carries the user's **email**; the numeric id lives in the `id` claim. Parsing the email throws `NumberFormatException`, which Spring MVC surfaces as HTTP 400.

### 2. client confirm → 500

`OrderCreationServiceImpl.confirmOrder` derives the next status from `determineOrderStatusAndReserveExposure(...)`. For users without an `ActuaryInfo` row (i.e. clients) this method short-circuits to `OrderStatus.APPROVED`. That has two consequences:

1. The client's order skips `PENDING`, so it never lands on the supervisor's approval queue (mismatch with the workflow described in the issue).
2. With status `APPROVED`, `confirmOrder` immediately calls `transferFee(user, fundingAccountId, fee, currency)`. For a client, `fundingAccountId` is the client's own account (not the bank account), so the call falls through to `transferWithConversionIfNeeded(...)` and hits account/exchange services. In production this transfer fails for the client path and the exception propagates as HTTP 500. For `AGENT`/`SUPERVISOR`, `fundingAccountId` is already the bank account, so `transferFee` returns early — that is exactly why those roles were unaffected.

## Fixes

### `order-service/.../OrderController.java`

```java
// before
.approveOrder(Long.valueOf(jwt.getSubject()), id)
.declineOrder(Long.valueOf(jwt.getSubject()), id)

// after
.approveOrder(toAuthenticatedUser(jwt).userId(), id)
.declineOrder(toAuthenticatedUser(jwt).userId(), id)
```

`toAuthenticatedUser` already reads the `id` claim with a numeric-`sub` fallback, so existing unit tests using numeric subjects keep working.

### `order-service/.../OrderCreationServiceImpl.java`

```java
ApprovalReservationDecision decision = user.isClient()
        ? new ApprovalReservationDecision(OrderStatus.PENDING, BigDecimal.ZERO)
        : determineOrderStatusAndReserveExposure(user.userId(), approximatePrice, listing.getCurrency());
```

For client users the confirm step now lands the order in `PENDING`. The downstream `if (decision.status() == OrderStatus.APPROVED)` block (which contains `transferFee` and `executeOrderAsync`) is therefore skipped — no failing transfer, no premature execution. The supervisor's `/{id}/approve` (or `/{id}/decline`) endpoint then runs the existing fee transfer and execution logic when the order is approved.

`AGENT` and `SUPERVISOR` flows are unchanged: they still go through `determineOrderStatusAndReserveExposure`, which respects `ActuaryInfo.needApproval` and limit accruals.

## Behavior after the fix

| Role            | `/buy`                  | `/confirm`               | `/approve` / `/decline`         |
| --------------- | ----------------------- | ------------------------ | ------------------------------- |
| CLIENT_TRADING  | `PENDING_CONFIRMATION`  | `PENDING`                | `APPROVED` / `DECLINED` (200)   |
| AGENT (need)    | `PENDING_CONFIRMATION`  | `PENDING`                | `APPROVED` / `DECLINED` (200)   |
| AGENT (no need) | `PENDING_CONFIRMATION`  | `APPROVED`               | n/a                             |
| SUPERVISOR      | `PENDING_CONFIRMATION`  | `APPROVED`               | n/a                             |

## Files changed

- `order-service/src/main/java/com/banka1/order/controller/OrderController.java`
- `order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java`
- `order-service/src/test/java/com/banka1/order/controller/OrderControllerTest.java`
- `order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java`

## Test plan

- [x] `./gradlew :order-service:test --rerun-tasks` — **209 tests pass, 0 failures, 0 errors, 0 skipped**.
- [x] Updated client-confirm tests assert `PENDING`, no `accountClient.transfer(...)` invocation, and no `orderExecutionService.executeOrderAsync(...)` invocation.
- [x] New `OrderControllerTest#approveAndDeclineUseIdClaimNotEmailSubject` builds a JWT with `sub = "supervisor@banka.com"` and `id = 99L` and verifies both endpoints delegate with `99L`.
- [ ] Manual smoke test against the deployed environment:
    - Client creates a `/buy` order, confirms → expect `PENDING`.
    - Supervisor `/approve` and `/decline` against pending orders → expect `200` with `APPROVED` / `DECLINED`.
