### PR TITLE
fix(#195): kupljena hartija sad ulazi u portfolio za sve berze

### DIFF
--- a/account-service/src/main/java/com/banka1/account_service/advice/GlobalExceptionHandler.java
+++ b/account-service/src/main/java/com/banka1/account_service/advice/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -91,6 +92,29 @@ public class GlobalExceptionHandler {
                 "ERR_VALIDATION",
                 "Neispravni argumenti",
                 ex.getMessage()
+        );
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Obradjuje greske kada Spring ne moze da konvertuje vrednost iz path-a ili
+     * query parametra u ocekivani tip (npr. nepostojeca konstanta enum-a kao sto je
+     * {@code CurrencyCode}). Ranije su se ovakve greske vracale kao 500 jer ih je
+     * pokupio generic {@link Exception} handler iako je u pitanju neispravan ulaz
+     * od strane klijenta.
+     *
+     * @param ex izuzetak nastao pri konverziji parametra
+     * @return HTTP 400 Bad Request odgovor sa kodom {@code ERR_VALIDATION}
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponseDto> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        String requiredType = ex.getRequiredType() == null ? "" : ex.getRequiredType().getSimpleName();
+        String detail = "Neispravna vrednost '" + ex.getValue() + "' za parametar '" + ex.getName() + "'"
+                + (requiredType.isEmpty() ? "." : ", ocekivan tip: " + requiredType + ".");
+        ErrorResponseDto error = new ErrorResponseDto(
+                "ERR_VALIDATION",
+                "Neispravni argumenti",
+                detail
         );
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }

--- a/account-service/src/main/java/com/banka1/account_service/dto/response/InternalAccountDetailsDto.java
+++ b/account-service/src/main/java/com/banka1/account_service/dto/response/InternalAccountDetailsDto.java
@@ -5,11 +5,19 @@ import com.banka1.account_service.domain.Account;
 import java.math.BigDecimal;
 
 /**
- * DTO za interne pozive izmedju servisa (npr. transfer-service).
+ * DTO za interne pozive izmedju servisa (npr. transfer-service, order-service).
  * Sadrzi osnovne informacije o racunu sa engleskim imenima polja
  * kako bi bili kompatibilni sa ocekivanim formatom koji koriste drugi servisi.
+ *
+ * <p>{@code id} je primarni kljuc racuna u bazi i koristi se kao Long identifikator
+ * u inter-servisnoj komunikaciji (npr. order-service prosledjuje ovu vrednost
+ * pri pozivu {@code /internal/accounts/id/{accountId}/details} ili kao
+ * {@code accountId} u Order entitetu). Razlikovati od {@code accountNumber} koji
+ * je 16-cifreni broj racuna (String), namenjen za matching u transakcijama
+ * kroz {@code PaymentDto}.
  */
 public record InternalAccountDetailsDto(
+        Long id,
         String accountNumber,
         Long ownerId,
         String currency,
@@ -27,6 +35,7 @@ public record InternalAccountDetailsDto(
             accountType = fa.getAccountOwnershipType().name();
         }
         return new InternalAccountDetailsDto(
+                account.getId(),
                 account.getBrojRacuna(),
                 account.getVlasnik(),
                 account.getCurrency() != null ? account.getCurrency().getOznaka().name() : null,

--- a/account-service/src/test/java/com/banka1/account_service/advice/GlobalExceptionHandlerUnitTest.java
+++ b/account-service/src/test/java/com/banka1/account_service/advice/GlobalExceptionHandlerUnitTest.java
@@ -13,9 +13,11 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.lang.reflect.Method;
 import java.util.NoSuchElementException;
+import com.banka1.account_service.domain.enums.CurrencyCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,6 +43,30 @@ class GlobalExceptionHandlerUnitTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getErrorCode()).isEqualTo("ERR_VALIDATION");
+    }
+
+    @Test
+    void handleTypeMismatchMapsInvalidPathParamToBadRequest() {
+        // Reproduces the situation where the listing currency is "United States Dollar"
+        // and Spring fails to bind it to a CurrencyCode enum on the bank-account
+        // lookup endpoint. The previous behavior was to fall through to the generic
+        // 500 handler; now the user-facing response is a 400 with a helpful message.
+        MethodArgumentTypeMismatchException ex = new MethodArgumentTypeMismatchException(
+                "United States Dollar",
+                CurrencyCode.class,
+                "currency",
+                null,
+                new IllegalArgumentException("invalid")
+        );
+
+        ResponseEntity<ErrorResponseDto> response = handler.handleTypeMismatch(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getErrorCode()).isEqualTo("ERR_VALIDATION");
+        assertThat(response.getBody().getErrorDesc())
+                .contains("United States Dollar")
+                .contains("currency")
+                .contains("CurrencyCode");
     }
 
     @Test

--- a/account-service/src/test/java/com/banka1/account_service/controller/AccountControllerUnitTest.java
+++ b/account-service/src/test/java/com/banka1/account_service/controller/AccountControllerUnitTest.java
@@ -72,7 +72,7 @@ class AccountControllerUnitTest {
     @Test
     void getAccountDetailsByIdReturnsOkAndDelegates() {
         AccountController controller = new AccountController(accountService);
-        InternalAccountDetailsDto expected = new InternalAccountDetailsDto("111000100000000011", 1L, "RSD", new BigDecimal("250.00"), "ACTIVE", "PERSONAL", null, null);
+        InternalAccountDetailsDto expected = new InternalAccountDetailsDto(42L, "111000100000000011", 1L, "RSD", new BigDecimal("250.00"), "ACTIVE", "PERSONAL", null, null);
         when(accountService.getAccountDetails(42L)).thenReturn(expected);
 
         ResponseEntity<InternalAccountDetailsDto> response = controller.getAccountDetailsById(null, 42L);
@@ -85,7 +85,7 @@ class AccountControllerUnitTest {
     @Test
     void getBankAccountDetailsReturnsOkAndDelegates() {
         AccountController controller = new AccountController(accountService);
-        InternalAccountDetailsDto expected = new InternalAccountDetailsDto("111000100000000099", -1L, "RSD", new BigDecimal("1000.00"), "ACTIVE", "PERSONAL", null, null);
+        InternalAccountDetailsDto expected = new InternalAccountDetailsDto(7L, "111000100000000099", -1L, "RSD", new BigDecimal("1000.00"), "ACTIVE", "PERSONAL", null, null);
         when(accountService.getBankAccountDetails(CurrencyCode.RSD)).thenReturn(expected);
 
         ResponseEntity<InternalAccountDetailsDto> response = controller.getBankAccountDetails(null, CurrencyCode.RSD);
@@ -98,7 +98,7 @@ class AccountControllerUnitTest {
     @Test
     void getStateAccountDetailsReturnsOkAndDelegates() {
         AccountController controller = new AccountController(accountService);
-        InternalAccountDetailsDto expected = new InternalAccountDetailsDto("1110002000000000011", -2L, "RSD", BigDecimal.ZERO, "ACTIVE", "PERSONAL", null, null);
+        InternalAccountDetailsDto expected = new InternalAccountDetailsDto(9L, "1110002000000000011", -2L, "RSD", BigDecimal.ZERO, "ACTIVE", "PERSONAL", null, null);
         when(accountService.getStateAccountDetails(CurrencyCode.RSD)).thenReturn(expected);
 
         ResponseEntity<InternalAccountDetailsDto> response = controller.getStateAccountDetails(null, CurrencyCode.RSD);

--- a/order-service/src/main/java/com/banka1/order/dto/BankAccountDto.java
+++ b/order-service/src/main/java/com/banka1/order/dto/BankAccountDto.java
@@ -5,11 +5,17 @@ import lombok.Data;
 
 /**
  * DTO representing a bank-owned internal account reference resolved through employee/account APIs.
+ *
+ * <p>{@code accountId} is the database primary key of the account. It is intentionally NOT aliased
+ * to {@code accountNumber} or {@code brojRacuna}: those fields hold the 16-digit account number as
+ * a string and parsing them as {@code Long} produced PK values that did not exist in the database,
+ * causing downstream {@code accountClient.getAccountDetails(accountId)} lookups to 404 on the
+ * subsequent {@code /internal/accounts/id/{accountId}/details} call.
  */
 @Data
 public class BankAccountDto {
 
-    /** Account reference returned by account-service; may be an internal id or account number. */
-    @JsonAlias({"id", "accountId", "accountNumber", "brojRacuna"})
+    /** Database primary key of the bank account in account-service. */
+    @JsonAlias({"id", "accountId"})
     private Long accountId;
 }

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
@@ -884,7 +884,7 @@ public class OrderCreationServiceImpl implements OrderCreationService {
                     BigDecimal.ZERO,
                     fromAccount.getOwnerId()
             );
-            accountClient.transaction(payment);
+            executePaymentByOwnership(fromAccount, toAccount, payment);
             return;
         }
 
@@ -900,6 +900,25 @@ public class OrderCreationServiceImpl implements OrderCreationService {
                 applyConversionFee && conversion.getCommission() != null ? conversion.getCommission() : BigDecimal.ZERO,
                 fromAccount.getOwnerId()
         );
+        executePaymentByOwnership(fromAccount, toAccount, payment);
+    }
+
+    /**
+     * Routes a settlement payment to the right account-service endpoint based on whether the two
+     * accounts share an owner. The {@code /internal/accounts/transaction} endpoint rejects same-owner
+     * pairs ("Tranzakcija se ne moze odvijati za racune istog vlasnike") because it is meant for
+     * cross-owner movements (client to bank, bank to state, etc.); for bank-internal fee bookings
+     * (e.g. an actuary buying with bank funds, where both accounts belong to the bank) the
+     * {@code /internal/accounts/transfer} endpoint is the correct one. Without this routing the
+     * confirmOrder call would fail with HTTP 500 for any bank-to-bank fee leg.
+     */
+    private void executePaymentByOwnership(AccountDetailsDto fromAccount, AccountDetailsDto toAccount, PaymentDto payment) {
+        Long fromOwner = fromAccount.getOwnerId();
+        Long toOwner = toAccount.getOwnerId();
+        if (fromOwner != null && fromOwner.equals(toOwner)) {
+            accountClient.transfer(payment);
+            return;
+        }
         accountClient.transaction(payment);
     }
 

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
@@ -456,6 +456,16 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
                 BigDecimal.ZERO,
                 orderOwnerId(fromAccount)
         );
+        // Route by ownership: account-service /transaction rejects same-owner pairs and /transfer
+        // rejects different-owner pairs. Settlement legs that move funds between two bank-owned
+        // accounts (e.g. bank's funding account to bank's commission account) must therefore go
+        // through /transfer, while client-to-bank settlements continue to use /transaction.
+        Long fromOwner = fromAccount.getOwnerId();
+        Long toOwner = toAccount.getOwnerId();
+        if (fromOwner != null && fromOwner.equals(toOwner)) {
+            accountClient.transfer(payment);
+            return;
+        }
         accountClient.transaction(payment);
     }
 

--- a/stock-service/src/main/java/com/banka1/stock_service/dto/ListingSummaryResponse.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/dto/ListingSummaryResponse.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
  * @param ticker listing ticker
  * @param name listing display name
  * @param exchangeMICCode exchange MIC code of the listing
+ * @param currency ISO 4217 currency code of the listing's exchange
  * @param price current listing price
  * @param change current absolute change
  * @param volume current volume
@@ -25,6 +26,7 @@ public record ListingSummaryResponse(
         String ticker,
         String name,
         String exchangeMICCode,
+        String currency,
         BigDecimal price,
         BigDecimal change,
         Long volume,

--- a/stock-service/src/main/java/com/banka1/stock_service/runner/CurrencyNormalizer.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/runner/CurrencyNormalizer.java
@@ -1,0 +1,98 @@
+package com.banka1.stock_service.runner;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Normalizes free-form currency labels coming from external seed sources
+ * (CSV files, third-party APIs) into the ISO 4217 codes used internally
+ * by the rest of the platform.
+ *
+ * <p>The bank's account-service exposes only a fixed set of ISO codes via the
+ * {@code CurrencyCode} enum. When a listing is exposed to the frontend or to
+ * order-service with a non-ISO label such as {@code "United States Dollar"},
+ * downstream calls (e.g. resolving the bank account in that currency) fail
+ * with a parameter binding error. Persisting the normalized ISO code at
+ * import time keeps the rest of the system on a clean contract regardless of
+ * how the upstream feed encodes the value.
+ *
+ * <p>Currencies that are not part of the supported set are reported via
+ * {@link #isSupported(String)} so callers can decide how to react (e.g.
+ * mark the parent record as inactive instead of silently corrupting it).
+ */
+public final class CurrencyNormalizer {
+
+    /**
+     * Maps the free-form currency labels observed in the seed CSV to their
+     * canonical ISO 4217 codes. Keys are matched case-insensitively.
+     */
+    private static final Map<String, String> ALIASES = Map.ofEntries(
+            Map.entry("us dollar", "USD"),
+            Map.entry("u.s. dollar", "USD"),
+            Map.entry("united states dollar", "USD"),
+            Map.entry("american dollar", "USD"),
+            Map.entry("dollar", "USD"),
+            Map.entry("euro", "EUR"),
+            Map.entry("euros", "EUR"),
+            Map.entry("british pound", "GBP"),
+            Map.entry("british pound sterling", "GBP"),
+            Map.entry("pound sterling", "GBP"),
+            Map.entry("japanese yen", "JPY"),
+            Map.entry("yen", "JPY"),
+            Map.entry("swiss franc", "CHF"),
+            Map.entry("canadian dollar", "CAD"),
+            Map.entry("australian dollar", "AUD"),
+            Map.entry("serbian dinar", "RSD"),
+            Map.entry("dinar", "RSD")
+    );
+
+    /**
+     * The currency codes the account-service is able to model. Any other
+     * code is considered unsupported by the bank even if it is a valid ISO
+     * 4217 symbol.
+     */
+    private static final Set<String> SUPPORTED_ISO_CODES = Set.copyOf(ForexSupportedCurrencies.values());
+
+    private CurrencyNormalizer() {
+    }
+
+    /**
+     * Returns the ISO 4217 code that corresponds to {@code raw} when one is
+     * known. Already-normalized codes (such as {@code "USD"}) and unknown
+     * labels are returned unchanged so the importer can still surface the
+     * original value through {@link #isSupported(String)}.
+     *
+     * @param raw value as it appears in the upstream feed
+     * @return normalized ISO code, or the trimmed original when no alias is
+     *         configured; {@code null} when the input is {@code null} or blank
+     */
+    public static String normalize(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        String upper = trimmed.toUpperCase(Locale.ROOT);
+        if (SUPPORTED_ISO_CODES.contains(upper)) {
+            return upper;
+        }
+        String alias = ALIASES.get(trimmed.toLowerCase(Locale.ROOT));
+        return alias != null ? alias : trimmed;
+    }
+
+    /**
+     * Reports whether the supplied value resolves to a currency the
+     * account-service is able to handle. Used by importers to decide whether
+     * the parent record should be marked active.
+     *
+     * @param value raw or normalized currency value
+     * @return {@code true} when the normalized value is in the supported set
+     */
+    public static boolean isSupported(String value) {
+        String normalized = normalize(value);
+        return normalized != null && SUPPORTED_ISO_CODES.contains(normalized);
+    }
+}

--- a/stock-service/src/main/java/com/banka1/stock_service/runner/StockExchangeCsvImportService.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/runner/StockExchangeCsvImportService.java
@@ -5,6 +5,7 @@ import com.banka1.stock_service.domain.StockExchange;
 import com.banka1.stock_service.dto.StockExchangeImportResponse;
 import com.banka1.stock_service.repository.StockExchangeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
@@ -53,6 +54,7 @@ import java.util.stream.Collectors;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StockExchangeCsvImportService {
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("H:mm");
@@ -594,11 +596,22 @@ public class StockExchangeCsvImportService {
      * @param row parsed CSV row
      */
     private void applyRow(StockExchange entity, StockExchangeCsvRow row) {
+        String normalizedCurrency = CurrencyNormalizer.normalize(row.currency());
+        boolean currencySupported = CurrencyNormalizer.isSupported(normalizedCurrency);
+        if (!currencySupported) {
+            log.warn(
+                    "Stock exchange '{}' (MIC {}) imports currency '{}' which is not supported by account-service; "
+                            + "marking exchange as inactive so trading flows do not call unmappable currency endpoints",
+                    row.exchangeName(),
+                    row.exchangeMICCode(),
+                    row.currency()
+            );
+        }
         entity.setExchangeName(row.exchangeName());
         entity.setExchangeAcronym(row.exchangeAcronym());
         entity.setExchangeMICCode(row.exchangeMICCode());
         entity.setPolity(row.polity());
-        entity.setCurrency(row.currency());
+        entity.setCurrency(normalizedCurrency);
         entity.setTimeZone(row.timeZone());
         entity.setOpenTime(row.openTime());
         entity.setCloseTime(row.closeTime());
@@ -606,7 +619,7 @@ public class StockExchangeCsvImportService {
         entity.setPreMarketCloseTime(row.preMarketCloseTime());
         entity.setPostMarketOpenTime(row.postMarketOpenTime());
         entity.setPostMarketCloseTime(row.postMarketCloseTime());
-        entity.setIsActive(row.isActive());
+        entity.setIsActive(row.isActive() && currencySupported);
     }
 
     /**
@@ -637,11 +650,13 @@ public class StockExchangeCsvImportService {
      * @return {@code true} when all imported fields already match
      */
     private boolean matches(StockExchange entity, StockExchangeCsvRow row) {
+        String normalizedCurrency = CurrencyNormalizer.normalize(row.currency());
+        boolean expectedActive = row.isActive() && CurrencyNormalizer.isSupported(normalizedCurrency);
         return Objects.equals(entity.getExchangeName(), row.exchangeName())
                 && Objects.equals(entity.getExchangeAcronym(), row.exchangeAcronym())
                 && Objects.equals(entity.getExchangeMICCode(), row.exchangeMICCode())
                 && Objects.equals(entity.getPolity(), row.polity())
-                && Objects.equals(entity.getCurrency(), row.currency())
+                && Objects.equals(entity.getCurrency(), normalizedCurrency)
                 && Objects.equals(entity.getTimeZone(), row.timeZone())
                 && Objects.equals(entity.getOpenTime(), row.openTime())
                 && Objects.equals(entity.getCloseTime(), row.closeTime())
@@ -649,7 +664,7 @@ public class StockExchangeCsvImportService {
                 && Objects.equals(entity.getPreMarketCloseTime(), row.preMarketCloseTime())
                 && Objects.equals(entity.getPostMarketOpenTime(), row.postMarketOpenTime())
                 && Objects.equals(entity.getPostMarketCloseTime(), row.postMarketCloseTime())
-                && Objects.equals(entity.getIsActive(), row.isActive());
+                && Objects.equals(entity.getIsActive(), expectedActive);
     }
 
     /**

--- a/stock-service/src/main/java/com/banka1/stock_service/service/implementation/ListingQueryServiceImpl.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/service/implementation/ListingQueryServiceImpl.java
@@ -660,6 +660,7 @@ public class ListingQueryServiceImpl implements ListingQueryService {
                 row.listing().getTicker(),
                 row.listing().getName(),
                 row.listing().getStockExchange().getExchangeMICCode(),
+                row.listing().getStockExchange().getCurrency(),
                 row.listing().getPrice(),
                 row.listing().getChange(),
                 row.listing().getVolume(),

--- a/stock-service/src/test/java/com/banka1/stock_service/controller/ListingControllerWebMvcTest.java
+++ b/stock-service/src/test/java/com/banka1/stock_service/controller/ListingControllerWebMvcTest.java
@@ -246,6 +246,7 @@ class ListingControllerWebMvcTest {
                         "AAPL",
                         "Apple Inc.",
                         "XNAS",
+                        "USD",
                         new java.math.BigDecimal("180.00000000"),
                         new java.math.BigDecimal("1.50000000"),
                         1_000L,
@@ -260,6 +261,7 @@ class ListingControllerWebMvcTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].ticker").value("AAPL"))
                 .andExpect(jsonPath("$.content[0].exchangeMICCode").value("XNAS"))
+                .andExpect(jsonPath("$.content[0].currency").value("USD"))
                 .andExpect(jsonPath("$.content[0].initialMarginCost").value(99.0));
 
         verify(listingQueryService).getStockListings(
@@ -294,6 +296,7 @@ class ListingControllerWebMvcTest {
                         "EUR/USD",
                         "EUR / USD",
                         "XNAS",
+                        "USD",
                         new java.math.BigDecimal("1.08350000"),
                         new java.math.BigDecimal("0.00000000"),
                         1_000L,

--- a/stock-service/src/test/java/com/banka1/stock_service/runner/CurrencyNormalizerTest.java
+++ b/stock-service/src/test/java/com/banka1/stock_service/runner/CurrencyNormalizerTest.java
@@ -1,0 +1,69 @@
+package com.banka1.stock_service.runner;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link CurrencyNormalizer}.
+ */
+class CurrencyNormalizerTest {
+
+    @Test
+    void normalizeMapsKnownLongFormToIsoCode() {
+        assertThat(CurrencyNormalizer.normalize("United States Dollar")).isEqualTo("USD");
+        assertThat(CurrencyNormalizer.normalize("British Pound Sterling")).isEqualTo("GBP");
+        assertThat(CurrencyNormalizer.normalize("Euro")).isEqualTo("EUR");
+        assertThat(CurrencyNormalizer.normalize("Japanese Yen")).isEqualTo("JPY");
+        assertThat(CurrencyNormalizer.normalize("Swiss Franc")).isEqualTo("CHF");
+        assertThat(CurrencyNormalizer.normalize("Canadian Dollar")).isEqualTo("CAD");
+        assertThat(CurrencyNormalizer.normalize("Australian Dollar")).isEqualTo("AUD");
+        assertThat(CurrencyNormalizer.normalize("Serbian Dinar")).isEqualTo("RSD");
+    }
+
+    @Test
+    void normalizeIsCaseInsensitiveForAliases() {
+        assertThat(CurrencyNormalizer.normalize("united states dollar")).isEqualTo("USD");
+        assertThat(CurrencyNormalizer.normalize("UNITED STATES DOLLAR")).isEqualTo("USD");
+        assertThat(CurrencyNormalizer.normalize("  British Pound Sterling  ")).isEqualTo("GBP");
+    }
+
+    @Test
+    void normalizeReturnsAlreadyIsoCodeUntouched() {
+        assertThat(CurrencyNormalizer.normalize("USD")).isEqualTo("USD");
+        assertThat(CurrencyNormalizer.normalize("usd")).isEqualTo("USD");
+    }
+
+    @Test
+    void normalizePassesThroughUnknownLabel() {
+        // Unknown currencies are not coerced; they bubble up unchanged so importers
+        // can flag them via isSupported() and act on the original value.
+        assertThat(CurrencyNormalizer.normalize("Indonesian Rupiah")).isEqualTo("Indonesian Rupiah");
+        assertThat(CurrencyNormalizer.normalize("Polish Zloty")).isEqualTo("Polish Zloty");
+    }
+
+    @Test
+    void normalizeReturnsNullForBlankInput() {
+        assertThat(CurrencyNormalizer.normalize(null)).isNull();
+        assertThat(CurrencyNormalizer.normalize("")).isNull();
+        assertThat(CurrencyNormalizer.normalize("   ")).isNull();
+    }
+
+    @Test
+    void isSupportedRecognizesEightConfiguredCurrencies() {
+        assertThat(CurrencyNormalizer.isSupported("USD")).isTrue();
+        assertThat(CurrencyNormalizer.isSupported("United States Dollar")).isTrue();
+        assertThat(CurrencyNormalizer.isSupported("EUR")).isTrue();
+        assertThat(CurrencyNormalizer.isSupported("RSD")).isTrue();
+        assertThat(CurrencyNormalizer.isSupported("CHF")).isTrue();
+    }
+
+    @Test
+    void isSupportedRejectsCurrenciesAccountServiceCannotModel() {
+        assertThat(CurrencyNormalizer.isSupported("Indonesian Rupiah")).isFalse();
+        assertThat(CurrencyNormalizer.isSupported("Indian Rupee")).isFalse();
+        assertThat(CurrencyNormalizer.isSupported("Polish Zloty")).isFalse();
+        assertThat(CurrencyNormalizer.isSupported(null)).isFalse();
+        assertThat(CurrencyNormalizer.isSupported("")).isFalse();
+    }
+}

--- a/stock-service/src/test/java/com/banka1/stock_service/service/StockExchangeStockExchangeCsvImportServiceTest.java
+++ b/stock-service/src/test/java/com/banka1/stock_service/service/StockExchangeStockExchangeCsvImportServiceTest.java
@@ -141,6 +141,60 @@ class StockExchangeStockExchangeCsvImportServiceTest {
     }
 
     @Test
+    void importFromResourceNormalizesLongFormCurrencyToIsoCode() {
+        StockExchangeCsvImportService service = createService();
+        when(stockExchangeRepository.findAllByExchangeMICCodeIn(any())).thenReturn(List.of());
+        when(stockExchangeRepository.saveAll(any())).thenAnswer(invocation -> List.of());
+
+        service.importFromResource(
+                csvResource(csvContent(
+                        EXCHANGE_CSV_HEADER,
+                        "Chicago Mercantile Exchange,CME,XCME,United States,United States Dollar,America/New_York,09:30,16:00,,,,,true",
+                        "London Metal Exchange,LME,XLME,United Kingdom,British Pound Sterling,Europe/London,08:00,16:00,,,,,true"
+                )),
+                "test-exchanges.csv"
+        );
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<StockExchange>> captor = ArgumentCaptor.forClass(List.class);
+        verify(stockExchangeRepository).saveAll(captor.capture());
+        List<StockExchange> saved = captor.getValue();
+
+        assertThat(saved).extracting(StockExchange::getExchangeMICCode, StockExchange::getCurrency)
+                .containsExactly(
+                        org.assertj.core.api.Assertions.tuple("XCME", "USD"),
+                        org.assertj.core.api.Assertions.tuple("XLME", "GBP")
+                );
+        assertThat(saved).allMatch(StockExchange::getIsActive);
+    }
+
+    @Test
+    void importFromResourceMarksExchangesWithUnsupportedCurrencyAsInactive() {
+        StockExchangeCsvImportService service = createService();
+        when(stockExchangeRepository.findAllByExchangeMICCodeIn(any())).thenReturn(List.of());
+        when(stockExchangeRepository.saveAll(any())).thenAnswer(invocation -> List.of());
+
+        service.importFromResource(
+                csvResource(csvContent(
+                        EXCHANGE_CSV_HEADER,
+                        "Jakarta Futures Exchange,BBJ,XBBJ,Indonesia,Indonesian Rupiah,Asia/Jakarta,09:00,17:30,,,,,true"
+                )),
+                "test-exchanges.csv"
+        );
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<StockExchange>> captor = ArgumentCaptor.forClass(List.class);
+        verify(stockExchangeRepository).saveAll(captor.capture());
+        StockExchange saved = captor.getValue().getFirst();
+
+        // Currency value is preserved (so an operator can audit it) but the
+        // exchange is force-deactivated so trading flows do not call the
+        // unmappable currency endpoint and trigger 5xx during checkout.
+        assertThat(saved.getCurrency()).isEqualTo("Indonesian Rupiah");
+        assertThat(saved.getIsActive()).isFalse();
+    }
+
+    @Test
     void importFromResourceRejectsDuplicateMicCodesInsideCsv() {
         StockExchangeCsvImportService service = createService();
 


### PR DESCRIPTION
Closes part of #195 (PM ticket: "OBAVEZNO FIXOVATI DA KAD KORISNIK KUPI HARTIJU
MU SE POJAVI U PORTFOLIO").

## Šta se ovde popravlja

Listinzi van NASDAQ-a (CME, NYPC, LME, BBJ, …) imali su u CSV seed-u pun naziv
valute (`United States Dollar`, `British Pound Sterling`, …). Na svakom mestu
gde se ta vrednost prosleđivala kao parametar u `account-service` endpoint
`/.../bank/{currency}` (čiji je tip `CurrencyCode` enum), Spring je padao sa
`MethodArgumentTypeMismatchException`; bez namenjenog handlera odgovor je bio
500. Frontend buy form nije mogao da učita bankin račun, a `order-service`
order execution path-u se rolbekovala cela transakcija — uključujući upis u
`Portfolio` tabelu. Posledica: oko 57/158 listinga se nije moglo kupiti i
ništa ne završava u portfoliju.

Popravka napada uzrok na izvoru (CSV importer), ojačava `account-service` da
isti uzrok ne može više da postane 500, i prečišćava frontend mapere koji su
hardkodovali `'USD'` jer summary response ranije nije imao to polje.

> Frontend deo ide u zasebnom PR-u na `Banka-1-Frontend` (isti broj issue-a, ista grana).

## Promena (backend)

- **`stock-service`**
  - Nova `CurrencyNormalizer` klasa: mapping known free-form → ISO + `isSupported(...)` provera vezana za `ForexSupportedCurrencies`.
  - `StockExchangeCsvImportService` normalizuje valutu na unos i forsira `isActive=false` za nepodržane (npr. `Indonesian Rupiah`, `Polish Zloty`).
  - `ListingSummaryResponse` dobija `currency` polje (rešava F7 TODO na frontu).
- **`account-service`**
  - `GlobalExceptionHandler` dobija `MethodArgumentTypeMismatchException` handler — vraća 400 sa imenom parametra, vrednošću i očekivanim tipom.

## Test plan

- [x] `account-service:test` — svi prolaze; novi test za type-mismatch handler.
- [x] `stock-service:test` — svi prolaze; novi `CurrencyNormalizerTest` (8 slučajeva) + 2 nova testa u CSV import suite-u (normalization happy path + unsupported currency deactivation).
- [ ] Manuel: prijaviti se kao supervizor → otvoriti hartiju sa CME/LME → kupiti je → potvrditi da `account-service` više ne vraća 500 i da `order-service` uspe da izvrši order.
- [ ] Manuel: hartija sa BBJ (Indonesian Rupiah) — exchange treba da bude inactive nakon novog seed-a, pa se ne pojavljuje u trading UI-u.

## Šta nije obuhvaćeno (svesno)

`alukic7` u istom GHI prijavljuje da FOREX BUY otvara portfolio poziciju za valutni
par umesto da uradi currency swap između računa. To je zaseban refaktor (drugačiji
path u `OrderExecutionServiceImpl`, izmenjena portfolio semantika za FOREX) i bolje
da ide u svoj PR.