### PR TITLE
fix(#199): SELL forma + trade leg ne ide na bankin racun + E2E test fixture

### DIFF
--- a/account-service/src/main/java/com/banka1/account_service/advice/GlobalExceptionHandler.java
+++ b/account-service/src/main/java/com/banka1/account_service/advice/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.FieldError;
@@ -147,6 +148,22 @@ public class GlobalExceptionHandler {
                 "ERR_FORBIDDEN",
                 "Pristup odbijen",
                 "Nemate dozvolu za ovu akciju."
+        );
+        return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
+    }
+
+    /**
+     * Spring Security 6.x baca {@link AuthorizationDeniedException} pri @PreAuthorize/role
+     * neuspehu i to NIJE podklasa starije {@link AccessDeniedException}, pa generic Exception
+     * fallback ranije pretvara u 500. Ovde se mapira na 403, sto frontend pravilno
+     * prikazuje kao auth problem umesto serverske greske.
+     */
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ErrorResponseDto> handleAuthorizationDenied(AuthorizationDeniedException ex) {
+        ErrorResponseDto error = new ErrorResponseDto(
+                "ERR_FORBIDDEN",
+                "Pristup odbijen",
+                "Nedovoljne privilegije za ovu akciju."
         );
         return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
     }

--- a/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
+++ b/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
@@ -2,6 +2,7 @@ package com.banka1.account_service.controller;
 
 import com.banka1.account_service.domain.enums.CurrencyCode;
 import com.banka1.account_service.dto.request.BankPaymentDto;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 import com.banka1.account_service.dto.response.InfoResponseDto;
 import com.banka1.account_service.dto.response.InternalAccountDetailsDto;
@@ -110,6 +111,36 @@ public class AccountController {
     @PostMapping("/transfer")
     public ResponseEntity<UpdatedBalanceResponseDto> transfer(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid PaymentDto paymentDto) {
         return new ResponseEntity<>(accountService.transfer(paymentDto),HttpStatus.OK);
+    }
+
+    /**
+     * Jednostrana operacija skidanja sredstava sa zadatog racuna (BUY settlement).
+     * <p>
+     * Koristi se kada iznos berzanske kupovine treba samo skinuti sa korisnikovog
+     * racuna, bez kontra-strane (izricita PM direktiva u GHI #199 da
+     * <i>banci ne ide novac</i> za trade leg). Provizija se i dalje prebacuje
+     * klasicnim {@code /transaction} ili {@code /transfer} putem.
+     *
+     * @param dto podaci o operaciji (broj racuna, iznos, ID klijenta, opis)
+     * @return {@link UpdatedBalanceResponseDto} sa azuriranim stanjem racuna
+     */
+    @PostMapping("/exchange/buy")
+    public ResponseEntity<UpdatedBalanceResponseDto> exchangeBuy(@AuthenticationPrincipal Jwt jwt,
+                                                                  @RequestBody @Valid OneSidedTransactionDto dto) {
+        return new ResponseEntity<>(accountService.exchangeBuy(dto), HttpStatus.OK);
+    }
+
+    /**
+     * Jednostrana operacija dodavanja sredstava na zadati racun (SELL settlement).
+     * Simetricna operacija sa {@link #exchangeBuy(Jwt, OneSidedTransactionDto)}.
+     *
+     * @param dto podaci o operaciji (broj racuna, iznos, ID klijenta, opis)
+     * @return {@link UpdatedBalanceResponseDto} sa azuriranim stanjem racuna
+     */
+    @PostMapping("/exchange/sell")
+    public ResponseEntity<UpdatedBalanceResponseDto> exchangeSell(@AuthenticationPrincipal Jwt jwt,
+                                                                   @RequestBody @Valid OneSidedTransactionDto dto) {
+        return new ResponseEntity<>(accountService.exchangeSell(dto), HttpStatus.OK);
     }
 
     /**

--- a/account-service/src/main/java/com/banka1/account_service/dto/request/OneSidedTransactionDto.java
+++ b/account-service/src/main/java/com/banka1/account_service/dto/request/OneSidedTransactionDto.java
@@ -1,0 +1,55 @@
+package com.banka1.account_service.dto.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+/**
+ * DTO za jednostranu (one-sided) operaciju nad jednim racunom.
+ * <p>
+ * Koristi se kada sredstva treba samo skinuti ili dodati na racun bez parnjaka
+ * (kontra-strane). Tipican slucaj je settlement berzanske kupovine/prodaje gde
+ * po direktivi PM-a (GHI #199) <strong>iznos trgovine ne sme da prolazi kroz
+ * bankin racun</strong>: pri BUY-u se sredstva samo skinu sa korisnikovog
+ * racuna, pri SELL-u se samo upiseu. Provizija (commission) se i dalje prebacuje
+ * na bankin racun klasicnim {@code transaction}/{@code transfer} putem.
+ * <p>
+ * Validacija:
+ * <ul>
+ *   <li>{@code accountNumber} mora biti 19-cifren (kao i svuda u sistemu)</li>
+ *   <li>{@code amount} mora biti pozitivan</li>
+ *   <li>{@code clientId} obavezan zarad audit log-a</li>
+ * </ul>
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class OneSidedTransactionDto {
+    /** Broj racuna nad kojim se izvodi operacija. */
+    @NotBlank(message = "Unesi broj racuna")
+    @Pattern(regexp = "^\\d{19}$", message = "Broj racuna mora imati 19 cifara")
+    private String accountNumber;
+
+    /** Iznos koji se skida (debit) ili dodaje (credit). U valuti racuna. */
+    @NotNull(message = "Unesi iznos")
+    @DecimalMin(value = "0.0", inclusive = false, message = "Iznos mora biti veci od 0")
+    private BigDecimal amount;
+
+    /**
+     * ID klijenta-vlasnika racuna. Sluzi za audit log i verifikaciju da pozivajuca
+     * strana zaista obraduje operaciju za pravog vlasnika racuna.
+     */
+    @NotNull(message = "Unesi id klijenta")
+    private Long clientId;
+
+    /** Slobodan tekstualni opis operacije za audit. */
+    private String description;
+}

--- a/account-service/src/main/java/com/banka1/account_service/dto/response/AccountResponseDto.java
+++ b/account-service/src/main/java/com/banka1/account_service/dto/response/AccountResponseDto.java
@@ -23,6 +23,16 @@ import java.math.BigDecimal;
 @Getter
 @Setter
 public class AccountResponseDto {
+    /**
+     * Primarni kljuc racuna u bazi. Frontend i drugi servisi koriste ovu vrednost kao
+     * jedinstveni numericki identifikator (npr. order-service prosledjuje ga kao
+     * {@code accountId} u BUY/SELL request body-ju). Bez ovog polja, frontend je
+     * morao da hash-uje {@code brojRacuna} u 32-bit integer da bi imao "id", sto je
+     * proizvodilo vrednosti koje ne mapiraju ni na PK ni na broj racuna i rusilo
+     * naredne {@code /internal/accounts/id/...} pozive (vidi GHI #199).
+     */
+    private Long id;
+
     /** Naziv koji je korisnik dao za svoj račun. */
     private String nazivRacuna;
 
@@ -52,6 +62,7 @@ public class AccountResponseDto {
      * @param account entitet iz baze
      */
     public AccountResponseDto(Account account) {
+        this.id = account.getId();
         this.nazivRacuna = account.getNazivRacuna();
         this.brojRacuna = account.getBrojRacuna();
         this.raspolozivoStanje = account.getRaspolozivoStanje();

--- a/account-service/src/main/java/com/banka1/account_service/service/AccountService.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/AccountService.java
@@ -1,6 +1,7 @@
 package com.banka1.account_service.service;
 
 import com.banka1.account_service.dto.request.BankPaymentDto;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 
 import com.banka1.account_service.domain.enums.CurrencyCode;
@@ -83,4 +84,28 @@ public interface AccountService {
      * @return DTO sa detaljima drzavnog racuna
      */
     InternalAccountDetailsDto getStateAccountDetails(CurrencyCode currencyCode);
+
+    /**
+     * Jednostrana debit operacija (BUY settlement). Skida zadati iznos sa racuna
+     * bez kontra-strane. Po direktivi PM-a u GHI #199, iznos berzanske kupovine
+     * ne sme da bude kreditiran banci, pa se trade leg izvrsava ovim putem;
+     * provizija (commission) i dalje ide na bankin racun klasicnom transakcijom.
+     *
+     * @param dto podaci o operaciji (broj racuna, iznos, ID klijenta, opis)
+     * @return azurirano stanje racuna posle skidanja
+     * @throws IllegalArgumentException ako racun ne postoji ili klijent nije vlasnik
+     * @throws com.banka1.account_service.exception.BusinessException ako nema sredstava
+     */
+    UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto dto);
+
+    /**
+     * Jednostrana credit operacija (SELL settlement). Dodaje zadati iznos na racun
+     * bez kontra-strane. Simetricna operacija sa {@link #exchangeBuy(OneSidedTransactionDto)};
+     * pretpostavlja se da bankin racun ne sluzi kao izvor sredstava za isplatu prodaje.
+     *
+     * @param dto podaci o operaciji (broj racuna, iznos, ID klijenta, opis)
+     * @return azurirano stanje racuna posle dodavanja
+     * @throws IllegalArgumentException ako racun ne postoji ili klijent nije vlasnik
+     */
+    UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto dto);
 }

--- a/account-service/src/main/java/com/banka1/account_service/service/TransactionalService.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/TransactionalService.java
@@ -36,5 +36,22 @@ public interface TransactionalService {
 
     void transfer(Account sender, Account recipient, BankPaymentDto paymentDto);
 
+    /**
+     * Atomicno skida zadati iznos sa racuna (jednostrani debit, bez kontra-strane).
+     * Validira saldo i dnevne/mesecne limite kao i klasicni debit.
+     *
+     * @param account racun nad kojim se izvodi operacija
+     * @param amount iznos za skidanje (mora biti > 0)
+     * @return azurirano stanje istog racuna posle operacije
+     */
+    UpdatedBalanceResponseDto withdrawOneSided(Account account, BigDecimal amount);
 
+    /**
+     * Atomicno dodaje zadati iznos na racun (jednostrani credit, bez kontra-strane).
+     *
+     * @param account racun nad kojim se izvodi operacija
+     * @param amount iznos za dodavanje (mora biti > 0)
+     * @return azurirano stanje istog racuna posle operacije
+     */
+    UpdatedBalanceResponseDto depositOneSided(Account account, BigDecimal amount);
 }

--- a/account-service/src/main/java/com/banka1/account_service/service/implementation/AccountServiceImplementation.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/implementation/AccountServiceImplementation.java
@@ -4,6 +4,7 @@ import com.banka1.account_service.domain.Account;
 import com.banka1.account_service.domain.enums.CurrencyCode;
 import com.banka1.account_service.domain.enums.Status;
 import com.banka1.account_service.dto.request.BankPaymentDto;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 import com.banka1.account_service.dto.response.InfoResponseDto;
 import com.banka1.account_service.dto.response.InternalAccountDetailsDto;
@@ -188,6 +189,38 @@ public class AccountServiceImplementation implements AccountService {
         if (account == null)
             throw new NoSuchElementException("Ne postoji drzavni racun za valutu:" + currencyCode);
         return InternalAccountDetailsDto.from(account);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto dto) {
+        Account account = validate(dto.getAccountNumber());
+        if (dto.getClientId() == null)
+            throw new IllegalArgumentException("Unesi id clienta");
+        if (!account.getVlasnik().equals(dto.getClientId()))
+            throw new IllegalArgumentException("Nisi vlasnik racuna");
+        for (int i = 0; true; i++) {
+            try {
+                return transactionalService.withdrawOneSided(account, dto.getAmount());
+            } catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+                if (i >= 2) throw e;
+            }
+        }
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto dto) {
+        Account account = validate(dto.getAccountNumber());
+        if (dto.getClientId() == null)
+            throw new IllegalArgumentException("Unesi id clienta");
+        if (!account.getVlasnik().equals(dto.getClientId()))
+            throw new IllegalArgumentException("Nisi vlasnik racuna");
+        for (int i = 0; true; i++) {
+            try {
+                return transactionalService.depositOneSided(account, dto.getAmount());
+            } catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+                if (i >= 2) throw e;
+            }
+        }
     }
 
     @Override

--- a/account-service/src/main/java/com/banka1/account_service/service/implementation/TransactionalServiceImplementation.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/implementation/TransactionalServiceImplementation.java
@@ -110,5 +110,19 @@ public class TransactionalServiceImplementation implements TransactionalService 
         //return new UpdatedBalanceResponseDto(null,null);
     }
 
+    @Transactional
+    @Override
+    public UpdatedBalanceResponseDto withdrawOneSided(Account account, BigDecimal amount) {
+        debit(account, amount);
+        return new UpdatedBalanceResponseDto(account.getStanje(), account.getStanje());
+    }
+
+    @Transactional
+    @Override
+    public UpdatedBalanceResponseDto depositOneSided(Account account, BigDecimal amount) {
+        credit(account, amount);
+        return new UpdatedBalanceResponseDto(account.getStanje(), account.getStanje());
+    }
+
 
 }

--- a/account-service/src/test/java/com/banka1/account_service/advice/GlobalExceptionHandlerUnitTest.java
+++ b/account-service/src/test/java/com/banka1/account_service/advice/GlobalExceptionHandlerUnitTest.java
@@ -14,6 +14,8 @@ import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.AuthorizationDecision;
 
 import java.lang.reflect.Method;
 import java.util.NoSuchElementException;
@@ -43,6 +45,21 @@ class GlobalExceptionHandlerUnitTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getErrorCode()).isEqualTo("ERR_VALIDATION");
+    }
+
+    @Test
+    void handleAuthorizationDeniedMapsToForbidden() {
+        // Spring Security 6.x throws AuthorizationDeniedException at PreAuthorize failure.
+        // It is NOT a subclass of legacy AccessDeniedException, so without an explicit handler
+        // it falls through to the generic 500 path and the frontend sees "Serverska greska"
+        // for what is actually an auth problem (GHI #199 follow-up).
+        AuthorizationDeniedException ex = new AuthorizationDeniedException(
+                "denied", new AuthorizationDecision(false));
+
+        ResponseEntity<ErrorResponseDto> response = handler.handleAuthorizationDenied(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(response.getBody().getErrorCode()).isEqualTo("ERR_FORBIDDEN");
     }
 
     @Test

--- a/account-service/src/test/java/com/banka1/account_service/controller/AccountControllerUnitTest.java
+++ b/account-service/src/test/java/com/banka1/account_service/controller/AccountControllerUnitTest.java
@@ -1,6 +1,7 @@
 package com.banka1.account_service.controller;
 
 import com.banka1.account_service.domain.enums.CurrencyCode;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 import com.banka1.account_service.dto.response.InfoResponseDto;
 import com.banka1.account_service.dto.response.InternalAccountDetailsDto;
@@ -117,6 +118,36 @@ class AccountControllerUnitTest {
                 .hasMessageContaining("RSD");
 
         verify(accountService, never()).getStateAccountDetails(any());
+    }
+
+    @Test
+    void exchangeBuyDelegatesToServiceAndReturnsOk() {
+        AccountController controller = new AccountController(accountService);
+        OneSidedTransactionDto dto = new OneSidedTransactionDto(
+                "1110001400000000221", new BigDecimal("202.00"), 1L, "Order execution");
+        UpdatedBalanceResponseDto expected = new UpdatedBalanceResponseDto(new BigDecimal("9798"), new BigDecimal("9798"));
+        when(accountService.exchangeBuy(dto)).thenReturn(expected);
+
+        ResponseEntity<UpdatedBalanceResponseDto> response = controller.exchangeBuy(null, dto);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expected);
+        verify(accountService).exchangeBuy(dto);
+    }
+
+    @Test
+    void exchangeSellDelegatesToServiceAndReturnsOk() {
+        AccountController controller = new AccountController(accountService);
+        OneSidedTransactionDto dto = new OneSidedTransactionDto(
+                "1110001400000000221", new BigDecimal("198.00"), 1L, "Order execution");
+        UpdatedBalanceResponseDto expected = new UpdatedBalanceResponseDto(new BigDecimal("10198"), new BigDecimal("10198"));
+        when(accountService.exchangeSell(dto)).thenReturn(expected);
+
+        ResponseEntity<UpdatedBalanceResponseDto> response = controller.exchangeSell(null, dto);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expected);
+        verify(accountService).exchangeSell(dto);
     }
 
     private PaymentDto paymentDto() {

--- a/client-service/src/main/resources/db/changelog/008-client-trading-test-fixtures.sql
+++ b/client-service/src/main/resources/db/changelog/008-client-trading-test-fixtures.sql
@@ -1,0 +1,20 @@
+-- liquibase formatted sql
+
+-- changeset client-service:11
+-- comment: Promote a few seed clients to CLIENT_TRADING (with MARGIN_TRADE permission) so that
+-- end-to-end exchange testing for GHI #199 has obvious BUY-capable clients beyond Mateja Subin.
+-- Without this, the only seeded trading-capable client is id=9 (subin.mateja@gmail.com), which is
+-- not obvious to a tester following the project README and leads to confusing 403s on POST
+-- /orders/buy when logging in as the more "default" Marko/Ana clients. The change is seed-only;
+-- production deploys can reuse the migration, but the data is fixture-style.
+
+UPDATE clients SET role = 'CLIENT_TRADING' WHERE email IN (
+    'marko.markovic@banka.com',
+    'ana.anic@banka.com'
+);
+
+INSERT INTO client_permissions (client_id, permission)
+SELECT c.id, 'MARGIN_TRADE'
+FROM clients c
+WHERE c.email IN ('marko.markovic@banka.com', 'ana.anic@banka.com')
+ON CONFLICT DO NOTHING;

--- a/client-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/client-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -12,5 +12,6 @@
     <include file="db/changelog/005-activation.sql"/>
     <include file="db/changelog/006-add-test-client.sql"/>
     <include file="db/changelog/007-subin-trading-permissions.sql"/>
+    <include file="db/changelog/008-client-trading-test-fixtures.sql"/>
 
 </databaseChangeLog>

--- a/exchange-service/src/main/resources/db/changelog/002-seed-fallback-rates.sql
+++ b/exchange-service/src/main/resources/db/changelog/002-seed-fallback-rates.sql
@@ -1,0 +1,22 @@
+-- liquibase formatted sql
+
+-- changeset exchange-service:2
+-- comment: Bootstrap a daily snapshot of approximate FX rates so the service can serve
+-- /exchange/rates and currency-conversion calls when the upstream provider (TwelveData)
+-- key is missing or rate-limited. The scheduled refresh + manual /rates/fetch endpoint
+-- still overwrite these values once a real upstream is reachable. Without this seed the
+-- service cold-starts to an empty table, /rates returns 404, and order-service cross-
+-- currency BUY/SELL paths blow up with no rate available -- which then made the GHI #199
+-- end-to-end manual test impossible (issue surfaced while validating the trade-leg fix).
+-- Rates are anchored to 2026-05-04 (project current date) and use mid-market values that
+-- are realistic enough for fixture trading; replace with live data via /rates/fetch.
+
+INSERT INTO exchange_rate (currency_code, buying_rate, selling_rate, rate_date) VALUES
+    ('EUR', 117.00000000, 117.50000000, '2026-05-04'),
+    ('CHF', 119.00000000, 119.50000000, '2026-05-04'),
+    ('USD', 108.00000000, 108.50000000, '2026-05-04'),
+    ('GBP', 137.00000000, 137.50000000, '2026-05-04'),
+    ('JPY',   0.69000000,   0.70000000, '2026-05-04'),
+    ('CAD',  79.00000000,  79.50000000, '2026-05-04'),
+    ('AUD',  72.00000000,  72.50000000, '2026-05-04')
+ON CONFLICT (currency_code, rate_date) DO NOTHING;

--- a/exchange-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/exchange-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -6,5 +6,6 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.25.xsd">
 
     <include file="db/changelog/001-initial-schema.sql"/>
+    <include file="db/changelog/002-seed-fallback-rates.sql"/>
 
 </databaseChangeLog>

--- a/order-service/src/main/java/com/banka1/order/client/AccountClient.java
+++ b/order-service/src/main/java/com/banka1/order/client/AccountClient.java
@@ -2,6 +2,7 @@ package com.banka1.order.client;
 
 import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.AccountTransactionRequest;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 
@@ -72,4 +73,25 @@ public interface AccountClient {
      * @return updated balances after the transfer
      */
     UpdatedBalanceResponseDto transaction(PaymentDto payment);
+
+    /**
+     * One-sided exchange BUY settlement: debit the trader's account by the listed
+     * amount without crediting any bank account. Per issue #199 the trade leg of an
+     * exchange purchase must not flow into the bank's books; this method enforces
+     * that contract on the order-service side.
+     *
+     * @param request account number, amount in account currency, owner id, and audit description
+     * @return updated balance after the debit
+     */
+    UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request);
+
+    /**
+     * One-sided exchange SELL settlement: credit the trader's account by the listed
+     * amount without debiting any bank account. Symmetric counterpart to
+     * {@link #exchangeBuy(OneSidedTransactionDto)}.
+     *
+     * @param request account number, amount in account currency, owner id, and audit description
+     * @return updated balance after the credit
+     */
+    UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request);
 }

--- a/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
+++ b/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
@@ -3,6 +3,7 @@ package com.banka1.order.client.impl;
 import com.banka1.order.client.AccountClient;
 import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.AccountTransactionRequest;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -89,6 +90,24 @@ public class AccountClientImpl implements AccountClient {
     @Override
     public UpdatedBalanceResponseDto transaction(PaymentDto payment) {
         return postTransaction(payment).body(UpdatedBalanceResponseDto.class);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request) {
+        return accountRestClient.post()
+                .uri("/internal/accounts/exchange/buy")
+                .body(request)
+                .retrieve()
+                .body(UpdatedBalanceResponseDto.class);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request) {
+        return accountRestClient.post()
+                .uri("/internal/accounts/exchange/sell")
+                .body(request)
+                .retrieve()
+                .body(UpdatedBalanceResponseDto.class);
     }
 
     private RestClient.ResponseSpec postTransaction(Object payload) {

--- a/order-service/src/main/java/com/banka1/order/config/LocalStubClientsConfig.java
+++ b/order-service/src/main/java/com/banka1/order/config/LocalStubClientsConfig.java
@@ -16,6 +16,7 @@ import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.ExchangeStatusDto;
 import com.banka1.order.dto.StockExchangeDto;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 import com.banka1.order.entity.enums.ListingType;
@@ -62,6 +63,16 @@ class LocalStubClientsConfig {
 
             @Override
             public UpdatedBalanceResponseDto transaction(PaymentDto payment) {
+                return null;
+            }
+
+            @Override
+            public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request) {
+                return null;
+            }
+
+            @Override
+            public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request) {
                 return null;
             }
 

--- a/order-service/src/main/java/com/banka1/order/dto/PortfolioResponse.java
+++ b/order-service/src/main/java/com/banka1/order/dto/PortfolioResponse.java
@@ -29,6 +29,23 @@ import java.time.LocalDateTime;
 @Data
 public class PortfolioResponse {
 
+    /**
+     * Database primary key of this portfolio entry. Required by the frontend so it
+     * can address actions that operate on the holding itself (set-public-quantity,
+     * exercise-option, etc.). Was missing from earlier responses and the front had
+     * to disable the corresponding controls; see GHI #199.
+     */
+    private Long id;
+
+    /**
+     * Identifier of the underlying listing (security) held by this portfolio entry.
+     * Needed by the frontend to navigate from "Moj Portfolio" into the SELL flow
+     * (Create Order with direction=SELL pre-filled). Without it the Sell button
+     * cannot link back to the listing and silently does nothing -- the bug PM
+     * raised in GHI #199.
+     */
+    private Long listingId;
+
     /** Type of security held: STOCK, FUTURES, FOREX, or OPTION. */
     private ListingType listingType;
 

--- a/order-service/src/main/java/com/banka1/order/dto/client/OneSidedTransactionDto.java
+++ b/order-service/src/main/java/com/banka1/order/dto/client/OneSidedTransactionDto.java
@@ -1,0 +1,30 @@
+package com.banka1.order.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * Request body for the new account-service one-sided endpoints
+ * ({@code POST /internal/accounts/exchange/buy} and {@code .../exchange/sell}).
+ *
+ * <p>Per the issue #199 directive, exchange settlement legs must not credit
+ * (or debit) the bank's own account; only the trader's account moves. This DTO
+ * carries just enough information for that adjustment. Field names mirror the
+ * server-side {@code com.banka1.account_service.dto.request.OneSidedTransactionDto}.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OneSidedTransactionDto {
+    /** 19-digit account number whose balance will be adjusted. */
+    private String accountNumber;
+    /** Positive amount in the account's own currency. */
+    private BigDecimal amount;
+    /** Owner of the account, used for audit logging on the account-service side. */
+    private Long clientId;
+    /** Free-form description of the operation for audit. */
+    private String description;
+}

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
@@ -133,6 +133,15 @@ public class OrderCreationServiceImpl implements OrderCreationService {
 
         StockListingDto listing = stockClient.getListing(request.getListingId());
         validateTradingAccess(user, listing);
+        // FOREX is a currency swap, not a position-taking trade -- there is no Portfolio entry to
+        // sell from (see updatePortfolio early-return in OrderExecutionServiceImpl). Reject here
+        // with a clear error rather than letting the caller hit a confusing "Portfolio position
+        // not found" later in confirmOrder.
+        ListingType listingType = listing.getListingType() == null ? ListingType.STOCK : listing.getListingType();
+        if (listingType == ListingType.FOREX) {
+            throw new BadRequestException("Forex pari se ne mogu prodavati kao hartije od vrednosti; FX trgovina je "
+                    + "konverzija valuta, ne pozicija u portfoliju.");
+        }
         ensurePortfolioOwnership(user.userId(), request.getListingId(), request.getQuantity());
         ExchangeWindow exchangeWindow = resolveExchangeWindow(listing);
         OrderType orderType = determineOrderType(request.getLimitValue(), request.getStopValue());

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
@@ -8,6 +8,7 @@ import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.BankAccountDto;
 import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
@@ -310,6 +311,16 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
     }
 
     private void updatePortfolio(Order order, StockListingDto listing, int quantity, BigDecimal executionPricePerUnit) {
+        // GHI #199 follow-up (alukic7 komentar): FOREX trade is a currency swap between two cash
+        // accounts, not a position-taking trade. Storing it as a Portfolio holding is wrong --
+        // there is no "amount of EUR/USD pair" you own; you just exchanged one currency for
+        // another. Settlement (the actual cash movement) is handled in transferFunds via
+        // currency-conversion-aware credit/debit on the trader's accounts.
+        ListingType listingType = listing.getListingType() == null ? ListingType.STOCK : listing.getListingType();
+        if (listingType == ListingType.FOREX) {
+            return;
+        }
+
         Portfolio portfolio = portfolioRepository.findByUserIdAndListingIdForUpdate(order.getUserId(), order.getListingId()).orElse(null);
 
         if (order.getDirection() == OrderDirection.BUY) {
@@ -347,19 +358,64 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
         }
     }
 
+    /**
+     * Settles the trade leg of an order against the trader's account only -- the bank's own
+     * account is NEVER credited or debited for the trade amount itself. Per the PM directive
+     * recorded in GHI #199 ("ne daje banci pare, samo se skidaju sa racuna"), exchange BUY
+     * deducts the trader's account by the trade amount and exchange SELL credits it; there is
+     * no offsetting bank-side leg. Commissions/fees are handled by a separate path
+     * ({@code transferFee} in OrderCreationServiceImpl) and continue to flow into the bank's
+     * commission account as required by Celina 3.
+     *
+     * <p>Actuary orders (where the funding account already IS the bank's own account) remain a
+     * no-op: any movement against the bank's account on a BUY would directly contradict the
+     * directive, and on a SELL would create money out of thin air on the bank balance.
+     */
     private void transferFunds(Order order, String currency, BigDecimal amount) {
         BankAccountDto bankAccount = employeeClient.getBankAccount(currency);
         boolean actuaryOrder = bankAccount.getAccountId() != null && bankAccount.getAccountId().equals(order.getAccountId());
-
-        if (order.getDirection() == OrderDirection.BUY) {
-            if (actuaryOrder) {
-                return;
-            }
-            transferForClient(order.getAccountId(), bankAccount.getAccountId(), amount, currency, "Order execution");
+        if (actuaryOrder) {
             return;
         }
 
-        transferWithoutConversionFee(bankAccount.getAccountId(), order.getAccountId(), amount, currency, "Order execution");
+        AccountDetailsDto traderAccount = accountClient.getAccountDetails(order.getAccountId());
+        BigDecimal localAmount = convertTradeAmountToAccountCurrency(traderAccount, currency, amount, order.getDirection());
+
+        OneSidedTransactionDto request = new OneSidedTransactionDto(
+                traderAccount.getAccountNumber(),
+                localAmount,
+                traderAccount.getOwnerId(),
+                "Order execution"
+        );
+
+        if (order.getDirection() == OrderDirection.BUY) {
+            accountClient.exchangeBuy(request);
+        } else {
+            accountClient.exchangeSell(request);
+        }
+    }
+
+    /**
+     * Converts the trade amount expressed in the listing's currency into the trader's account
+     * currency when they differ. Currency conversion follows the same rules as the previous
+     * {@code transferForClient}/{@code transferWithoutConversionFee} pair, so behaviour for
+     * cross-currency BUY/SELL stays consistent: clients pay (or receive) in their own
+     * account's currency, never on the bank's books.
+     */
+    private BigDecimal convertTradeAmountToAccountCurrency(AccountDetailsDto traderAccount,
+                                                           String tradeCurrency,
+                                                           BigDecimal tradeAmount,
+                                                           OrderDirection direction) {
+        String accountCurrency = traderAccount.getCurrency();
+        if (accountCurrency == null || accountCurrency.equalsIgnoreCase(tradeCurrency)) {
+            return tradeAmount;
+        }
+        ExchangeRateDto conversion = direction == OrderDirection.BUY
+                ? exchangeClient.calculate(tradeCurrency, accountCurrency, tradeAmount)
+                : exchangeClient.calculateWithoutCommission(tradeCurrency, accountCurrency, tradeAmount);
+        return conversion == null || conversion.getConvertedAmount() == null
+                ? tradeAmount
+                : conversion.getConvertedAmount();
     }
 
     private void finalizeActuaryExposure(Order order, String currency, BigDecimal amount) {
@@ -440,52 +496,6 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
         }
         ExchangeRateDto conversion = exchangeClient.calculateWithoutCommission(fromCurrency, toCurrency, amount);
         return conversion.getConvertedAmount() == null ? amount : conversion.getConvertedAmount();
-    }
-
-    private void transferWithoutConversionFee(Long fromAccountId, Long toAccountId, BigDecimal amount, String currency, String description) {
-        if (fromAccountId != null && fromAccountId.equals(toAccountId)) {
-            throw new IllegalStateException("Transfer source and destination must differ");
-        }
-        AccountDetailsDto fromAccount = accountClient.getAccountDetails(fromAccountId);
-        AccountDetailsDto toAccount = accountClient.getAccountDetails(toAccountId);
-        PaymentDto payment = new PaymentDto(
-                fromAccount.getAccountNumber(),
-                toAccount.getAccountNumber(),
-                amount,
-                amount,
-                BigDecimal.ZERO,
-                orderOwnerId(fromAccount)
-        );
-        // Route by ownership: account-service /transaction rejects same-owner pairs and /transfer
-        // rejects different-owner pairs. Settlement legs that move funds between two bank-owned
-        // accounts (e.g. bank's funding account to bank's commission account) must therefore go
-        // through /transfer, while client-to-bank settlements continue to use /transaction.
-        Long fromOwner = fromAccount.getOwnerId();
-        Long toOwner = toAccount.getOwnerId();
-        if (fromOwner != null && fromOwner.equals(toOwner)) {
-            accountClient.transfer(payment);
-            return;
-        }
-        accountClient.transaction(payment);
-    }
-
-    private void transferForClient(Long fromAccountId, Long toAccountId, BigDecimal amount, String currency, String description) {
-        AccountDetailsDto fromAccount = accountClient.getAccountDetails(fromAccountId);
-        if (fromAccount.getCurrency() == null || fromAccount.getCurrency().equalsIgnoreCase(currency)) {
-            transferWithoutConversionFee(fromAccountId, toAccountId, amount, currency, description);
-            return;
-        }
-
-        // Account currency differs from listing currency: convert the trade amount to the account's currency,
-        // then pay the bank account that matches the client's currency directly.
-        ExchangeRateDto conversion = exchangeClient.calculate(currency, fromAccount.getCurrency(), amount);
-        BigDecimal convertedAmount = conversion.getConvertedAmount() == null ? amount : conversion.getConvertedAmount();
-        BankAccountDto fromCurrencyBank = employeeClient.getBankAccount(fromAccount.getCurrency());
-        transferWithoutConversionFee(fromAccountId, fromCurrencyBank.getAccountId(), convertedAmount, fromAccount.getCurrency(), description);
-    }
-
-    private Long orderOwnerId(AccountDetailsDto account) {
-        return account.getOwnerId() == null ? 0L : account.getOwnerId();
     }
 
     private int defaultInteger(Integer value) {

--- a/order-service/src/main/java/com/banka1/order/service/impl/PortfolioServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/PortfolioServiceImpl.java
@@ -235,6 +235,12 @@ public class PortfolioServiceImpl implements PortfolioService {
 
         PortfolioResponse response = new PortfolioResponse();
 
+        // GHI #199: expose the portfolio PK and the underlying listingId so the
+        // frontend can wire actions that operate on the holding (Sell flow,
+        // public-quantity update, option exercise) and stop falling back to the
+        // disabled-button state described in PortfolioController hasPortfolioActionId.
+        response.setId(portfolio.getId());
+        response.setListingId(portfolio.getListingId());
         response.setListingType(portfolio.getListingType());
         response.setQuantity(portfolio.getQuantity());
         response.setPublicQuantity(portfolio.getPublicQuantity());

--- a/order-service/src/test/java/com/banka1/order/service/PortfolioServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/PortfolioServiceTest.java
@@ -127,6 +127,12 @@ class PortfolioServiceTest {
         assertThat(result.getHoldings().get(0).getAveragePurchasePrice()).isEqualByComparingTo("100");
         assertThat(result.getHoldings().get(0).getProfit()).isEqualByComparingTo("500");
         assertThat(result.getHoldings().get(0).getPublicQuantity()).isEqualTo(2);
+        // GHI #199: portfolio id and listingId must surface on the response so the front
+        // can wire actions (Sell button navigation, public-quantity update, exercise).
+        assertThat(result.getHoldings().get(0).getId()).isEqualTo(1L);
+        assertThat(result.getHoldings().get(0).getListingId()).isEqualTo(100L);
+        assertThat(result.getHoldings().get(1).getId()).isEqualTo(2L);
+        assertThat(result.getHoldings().get(1).getListingId()).isEqualTo(200L);
         assertThat(result.getHoldings().get(1).getAveragePurchasePrice()).isEqualByComparingTo("12");
         assertThat(result.getHoldings().get(1).getExercisable()).isTrue();
         assertThat(result.getTotalProfit()).isEqualByComparingTo("876");

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java
@@ -540,6 +540,27 @@ class OrderCreationServiceTest {
     }
 
     @Test
+    void createSellOrder_rejectsForexBecauseFxIsCurrencyConversionNotAPosition() {
+        // GHI #199 follow-up: FX pair is a currency swap so there is no Portfolio entry to sell;
+        // SELL flow must reject up-front rather than fall through to "Portfolio position not
+        // found". Test as actuary because clients are already blocked earlier in
+        // validateTradingAccess (per Celina 3, klijenti trguju samo stocks + futures).
+        StockListingDto forexListing = new StockListingDto();
+        forexListing.setId(42L);
+        forexListing.setListingType(ListingType.FOREX);
+        forexListing.setCurrency("USD");
+        forexListing.setContractSize(1000);
+        forexListing.setPrice(new BigDecimal("1.0850"));
+        forexListing.setBid(new BigDecimal("1.0840"));
+        forexListing.setAsk(new BigDecimal("1.0860"));
+        when(stockClient.getListing(42L)).thenReturn(forexListing);
+
+        assertThatThrownBy(() -> service.createSellOrder(actuaryUser, sellRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Forex");
+    }
+
+    @Test
     void confirmMarginSell_rejectsWhenUserLacksMarginPermission() {
         Portfolio portfolio = new Portfolio();
         portfolio.setUserId(1L);

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
@@ -8,6 +8,7 @@ import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.BankAccountDto;
 import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
@@ -203,10 +204,14 @@ class OrderExecutionServiceTest {
         assertThat(transactionCaptor.getValue().getPricePerUnit()).isEqualByComparingTo("101.00");
         assertThat(transactionCaptor.getValue().getTotalPrice()).isEqualByComparingTo("202.00");
 
-        ArgumentCaptor<PaymentDto> transferCaptor = ArgumentCaptor.forClass(PaymentDto.class);
-        verify(accountClient).transaction(transferCaptor.capture());
-        assertThat(transferCaptor.getValue().getFromAccountNumber()).isEqualTo("1110001400000000221");
-        assertThat(transferCaptor.getValue().getToAccountNumber()).isEqualTo("1110001000000000023");
+        // GHI #199: trade leg goes through one-sided exchangeBuy (no bank counterparty);
+        // the legacy /transaction call must NOT happen for the trade amount.
+        ArgumentCaptor<OneSidedTransactionDto> exchangeCaptor = ArgumentCaptor.forClass(OneSidedTransactionDto.class);
+        verify(accountClient).exchangeBuy(exchangeCaptor.capture());
+        assertThat(exchangeCaptor.getValue().getAccountNumber()).isEqualTo("1110001400000000221");
+        assertThat(exchangeCaptor.getValue().getAmount()).isEqualByComparingTo("202.00");
+        assertThat(exchangeCaptor.getValue().getClientId()).isEqualTo(1L);
+        verify(accountClient, never()).transaction(any(PaymentDto.class));
         assertThat(order.getStatus()).isEqualTo(OrderStatus.DONE);
         assertThat(order.getIsDone()).isTrue();
     }
@@ -265,7 +270,8 @@ class OrderExecutionServiceTest {
 
         assertThat(staleOrder.getRemainingPortions()).isEqualTo(5);
         assertThat(lockedOrder.getRemainingPortions()).isZero();
-        verify(accountClient).transaction(any(PaymentDto.class));
+        verify(accountClient).exchangeBuy(any(OneSidedTransactionDto.class));
+        verify(accountClient, never()).transaction(any(PaymentDto.class));
         verify(transactionRepository).save(any(Transaction.class));
     }
 
@@ -376,10 +382,26 @@ class OrderExecutionServiceTest {
         service.executeOrderPortion(order);
 
         verify(portfolioRepository, atLeastOnce()).save(portfolio);
-        ArgumentCaptor<PaymentDto> captor = ArgumentCaptor.forClass(PaymentDto.class);
-        verify(accountClient).transaction(captor.capture());
-        assertThat(captor.getValue().getFromAccountNumber()).isEqualTo("1110001000000000023");
-        assertThat(captor.getValue().getToAccountNumber()).isEqualTo("1110001400000000221");
+        // GHI #199: SELL credits the trader's account via one-sided exchangeSell;
+        // the bank account is never debited for the proceeds.
+        ArgumentCaptor<OneSidedTransactionDto> captor = ArgumentCaptor.forClass(OneSidedTransactionDto.class);
+        verify(accountClient).exchangeSell(captor.capture());
+        assertThat(captor.getValue().getAccountNumber()).isEqualTo("1110001400000000221");
+        assertThat(captor.getValue().getClientId()).isEqualTo(1L);
+        verify(accountClient, never()).transaction(any(PaymentDto.class));
+    }
+
+    @Test
+    void forexBuyExecution_doesNotCreatePortfolioEntry() {
+        // GHI #199 follow-up (alukic7): FOREX trade is a currency swap, not a position; the
+        // updatePortfolio path must early-return so we do not store a "holding" of the pair.
+        // The trade leg (one-sided debit) still happens against the trader's account.
+        listing.setListingType(ListingType.FOREX);
+
+        service.executeOrderPortion(order);
+
+        verify(portfolioRepository, never()).save(any(Portfolio.class));
+        verify(accountClient).exchangeBuy(any(OneSidedTransactionDto.class));
     }
 
     @Test
@@ -399,6 +421,10 @@ class OrderExecutionServiceTest {
 
         service.executeOrderPortion(order);
 
+        // For actuary BUY the funding account already IS the bank's own account, so the
+        // trade leg is a no-op: no exchangeBuy/Sell and no legacy transaction either.
+        verify(accountClient, never()).exchangeBuy(any(OneSidedTransactionDto.class));
+        verify(accountClient, never()).exchangeSell(any(OneSidedTransactionDto.class));
         verify(accountClient, never()).transaction(any(PaymentDto.class));
     }
 

--- a/stock-service/src/main/java/com/banka1/stock_service/runner/StockTickerSeedService.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/runner/StockTickerSeedService.java
@@ -37,24 +37,31 @@ import java.util.List;
 public class StockTickerSeedService {
 
     private static final String SOURCE = "built-in starter stock tickers";
-    private static final BigDecimal ZERO_PRICE = new BigDecimal("0.00000000");
     private static final BigDecimal ZERO_DIVIDEND_YIELD = new BigDecimal("0.0000");
     private static final long ZERO_OUTSTANDING_SHARES = 0L;
-    private static final long ZERO_VOLUME = 0L;
+    private static final long DEFAULT_VOLUME = 50_000_000L;
+    /**
+     * Approximate mid-market spreads applied to {@code price} so newly seeded listings have
+     * usable bid/ask values without depending on the upstream market-data refresh succeeding.
+     * Without this, freshly seeded listings sit at price=ask=bid=0 until Alpha Vantage refresh
+     * runs successfully, which is unreliable in a sandboxed dev environment.
+     */
+    private static final BigDecimal ASK_SPREAD = new BigDecimal("0.05000000");
+    private static final BigDecimal BID_SPREAD = new BigDecimal("0.05000000");
     private static final List<SeededStockRow> DEFAULT_STOCKS = List.of(
             // Nasdaq (XNAS)
-            new SeededStockRow("AAPL", "Apple Inc.", "XNAS"),
-            new SeededStockRow("MSFT", "Microsoft Corporation", "XNAS"),
-            new SeededStockRow("GOOGL", "Alphabet Inc. Class A", "XNAS"),
-            new SeededStockRow("AMZN", "Amazon.com, Inc.", "XNAS"),
-            new SeededStockRow("TSLA", "Tesla, Inc.", "XNAS"),
-            // New York Portfolio Clearing (NYPC) — exchange acronym and MIC start with "NY"
-            new SeededStockRow("IBM", "International Business Machines Corp.", "NYPC"),
-            new SeededStockRow("GS", "Goldman Sachs Group Inc.", "NYPC"),
-            new SeededStockRow("JPM", "JPMorgan Chase & Co.", "NYPC"),
+            new SeededStockRow("AAPL", "Apple Inc.", "XNAS", new BigDecimal("180.00000000")),
+            new SeededStockRow("MSFT", "Microsoft Corporation", "XNAS", new BigDecimal("420.00000000")),
+            new SeededStockRow("GOOGL", "Alphabet Inc. Class A", "XNAS", new BigDecimal("165.00000000")),
+            new SeededStockRow("AMZN", "Amazon.com, Inc.", "XNAS", new BigDecimal("185.00000000")),
+            new SeededStockRow("TSLA", "Tesla, Inc.", "XNAS", new BigDecimal("260.00000000")),
+            // New York Portfolio Clearing (NYPC)
+            new SeededStockRow("IBM", "International Business Machines Corp.", "NYPC", new BigDecimal("210.00000000")),
+            new SeededStockRow("GS", "Goldman Sachs Group Inc.", "NYPC", new BigDecimal("450.00000000")),
+            new SeededStockRow("JPM", "JPMorgan Chase & Co.", "NYPC", new BigDecimal("210.00000000")),
             // Chicago Mercantile Exchange (XCME)
-            new SeededStockRow("WMT", "Walmart Inc.", "XCME"),
-            new SeededStockRow("BAC", "Bank of America Corp.", "XCME")
+            new SeededStockRow("WMT", "Walmart Inc.", "XCME", new BigDecimal("70.00000000")),
+            new SeededStockRow("BAC", "Bank of America Corp.", "XCME", new BigDecimal("40.00000000"))
     );
 
     private final StockRepository stockRepository;
@@ -99,7 +106,7 @@ public class StockTickerSeedService {
             Listing listing = listingRepository.findByListingTypeAndSecurityId(ListingType.STOCK, stock.getId())
                     .orElse(null);
             if (listing == null) {
-                listingRepository.save(createListing(stock, exchange));
+                listingRepository.save(createListing(row, stock, exchange));
                 rowCreated = true;
             }
 
@@ -135,13 +142,17 @@ public class StockTickerSeedService {
     }
 
     /**
-     * Creates a placeholder listing row linked to an already persisted stock.
+     * Creates a placeholder listing row linked to an already persisted stock with sane fallback
+     * mid-market price/ask/bid/volume so manual exchange testing works even without a successful
+     * upstream Alpha Vantage refresh. Once {@code refresh-market-data} runs successfully, these
+     * placeholder values are overwritten by real quotes.
      *
+     * @param row seed row carrying the per-ticker fallback price
      * @param stock persisted stock entity
      * @param stockExchange exchange used for the starter listing
      * @return new listing entity
      */
-    private Listing createListing(Stock stock, StockExchange stockExchange) {
+    private Listing createListing(SeededStockRow row, Stock stock, StockExchange stockExchange) {
         Listing listing = new Listing();
         listing.setSecurityId(stock.getId());
         listing.setListingType(ListingType.STOCK);
@@ -149,11 +160,12 @@ public class StockTickerSeedService {
         listing.setTicker(stock.getTicker());
         listing.setName(stock.getName());
         listing.setLastRefresh(LocalDateTime.now());
-        listing.setPrice(ZERO_PRICE);
-        listing.setAsk(ZERO_PRICE);
-        listing.setBid(ZERO_PRICE);
-        listing.setChange(ZERO_PRICE);
-        listing.setVolume(ZERO_VOLUME);
+        BigDecimal price = row.price();
+        listing.setPrice(price);
+        listing.setAsk(price.add(ASK_SPREAD));
+        listing.setBid(price.subtract(BID_SPREAD));
+        listing.setChange(BigDecimal.ZERO);
+        listing.setVolume(DEFAULT_VOLUME);
         return listing;
     }
 
@@ -162,11 +174,14 @@ public class StockTickerSeedService {
      *
      * @param ticker unique stock ticker
      * @param name display name
+     * @param exchangeMicCode MIC code of the exchange the listing belongs to
+     * @param price mid-market starter price; ask/bid are derived with a small spread
      */
     private record SeededStockRow(
             String ticker,
             String name,
-            String exchangeMicCode
+            String exchangeMicCode,
+            BigDecimal price
     ) {
     }
 }

--- a/stock-service/src/main/java/com/banka1/stock_service/web/StockServiceResponseStatusExceptionHandler.java
+++ b/stock-service/src/main/java/com/banka1/stock_service/web/StockServiceResponseStatusExceptionHandler.java
@@ -6,6 +6,8 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
@@ -14,6 +16,13 @@ import java.time.OffsetDateTime;
 
 /**
  * Preserves explicit HTTP statuses and messages raised inside stock-service.
+ *
+ * <p>Also captures Spring Security authorization failures so a missing role
+ * (e.g. on {@code /admin/stocks/refresh-all}) returns a clean HTTP 403 instead
+ * of falling through to the generic 500 path. Without this mapping the
+ * frontend would only see "Serverska greska" and could not distinguish a
+ * legitimate auth problem from an actual bug -- which is what GHI #199
+ * surfaced when refresh-all was invoked with an AGENT/BASIC token.
  */
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -40,6 +49,21 @@ public class StockServiceResponseStatusExceptionHandler {
                 request.getRequestURI()
         );
         return ResponseEntity.status(statusCode).body(response);
+    }
+
+    @ExceptionHandler({AuthorizationDeniedException.class, AccessDeniedException.class})
+    public ResponseEntity<StockServiceErrorResponse> handleAuthorizationDenied(
+            RuntimeException exception,
+            HttpServletRequest request
+    ) {
+        StockServiceErrorResponse response = new StockServiceErrorResponse(
+                OffsetDateTime.now(),
+                HttpStatus.FORBIDDEN.value(),
+                HttpStatus.FORBIDDEN.getReasonPhrase(),
+                "Nedovoljne privilegije za ovu akciju.",
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
     }
 }
 

--- a/stock-service/src/test/java/com/banka1/stock_service/service/StockTickerSeedServiceTest.java
+++ b/stock-service/src/test/java/com/banka1/stock_service/service/StockTickerSeedServiceTest.java
@@ -75,11 +75,14 @@ class StockTickerSeedServiceTest {
         assertThat(appleListing.getTicker()).isEqualTo("AAPL");
         assertThat(appleListing.getName()).isEqualTo("Apple Inc.");
         assertThat(appleListing.getLastRefresh()).isCloseTo(LocalDateTime.now(), within(5, ChronoUnit.SECONDS));
-        assertThat(appleListing.getPrice()).isEqualByComparingTo("0.00000000");
-        assertThat(appleListing.getAsk()).isEqualByComparingTo("0.00000000");
-        assertThat(appleListing.getBid()).isEqualByComparingTo("0.00000000");
-        assertThat(appleListing.getChange()).isEqualByComparingTo("0.00000000");
-        assertThat(appleListing.getVolume()).isZero();
+        // GHI #199 follow-up: starter listings se sada seeduju sa fallback mid-market cenama
+        // (Apple ~$180) tako da manuel testiranje radi cak i kada Alpha Vantage refresh nije
+        // uspeo. Realni quote overrride-uje ove vrednosti pri prvom uspesnom refresh-u.
+        assertThat(appleListing.getPrice()).isEqualByComparingTo("180.00000000");
+        assertThat(appleListing.getAsk()).isEqualByComparingTo("180.05000000");
+        assertThat(appleListing.getBid()).isEqualByComparingTo("179.95000000");
+        assertThat(appleListing.getChange()).isEqualByComparingTo("0");
+        assertThat(appleListing.getVolume()).isEqualTo(50_000_000L);
     }
 
     @Test

--- a/stock-service/src/test/java/com/banka1/stock_service/service/implementation/ListingQueryServiceImplTest.java
+++ b/stock-service/src/test/java/com/banka1/stock_service/service/implementation/ListingQueryServiceImplTest.java
@@ -362,10 +362,12 @@ class ListingQueryServiceImplTest {
 
         assertThat(response.listingId()).isEqualTo(seededListing.getId());
         assertThat(response.ticker()).isEqualTo("AAPL");
-        assertThat(response.price()).isEqualByComparingTo("0.00000000");
-        assertThat(response.change()).isEqualByComparingTo("0.00000000");
-        assertThat(response.changePercent()).isNull();
-        assertThat(response.dollarVolume()).isEqualByComparingTo("0E-8");
+        // GHI #199 follow-up: starter listings sada nose fallback mid-market cene
+        // (vidi StockTickerSeedService); change ostaje 0 dok ne stigne prvi refresh,
+        // pa je changePercent definisan i jednak 0 (price=180, change=0, previous=180).
+        assertThat(response.price()).isEqualByComparingTo("180.00000000");
+        assertThat(response.change()).isEqualByComparingTo("0");
+        assertThat(response.changePercent()).isEqualByComparingTo("0.0000");
         assertThat(response.priceHistory()).isEmpty();
     }
 

--- a/stock-service/src/test/java/com/banka1/stock_service/web/StockServiceResponseStatusExceptionHandlerTest.java
+++ b/stock-service/src/test/java/com/banka1/stock_service/web/StockServiceResponseStatusExceptionHandlerTest.java
@@ -1,0 +1,45 @@
+package com.banka1.stock_service.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.AuthorizationDecision;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StockServiceResponseStatusExceptionHandlerTest {
+
+    private final StockServiceResponseStatusExceptionHandler handler = new StockServiceResponseStatusExceptionHandler();
+
+    @Test
+    void authorizationDeniedExceptionIsMappedTo403() {
+        // GHI #199 follow-up: Spring Security 6.x baca AuthorizationDeniedException pri PreAuthorize
+        // neuspehu; bez ovog handlera generic Exception fallback bi vratio 500 i frontend bi pokazao
+        // "Serverska greska" umesto cistog 403 kao na refresh-all kada je pozivalac AGENT/BASIC.
+        HttpServletRequest request = new MockHttpServletRequest("POST", "/admin/stocks/refresh-all");
+
+        ResponseEntity<?> response = handler.handleAuthorizationDenied(
+                new AuthorizationDeniedException("denied", new AuthorizationDecision(false)),
+                request
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void accessDeniedExceptionIsAlsoMappedTo403() {
+        // Stara klasa iz spring-security-access; obe rute treba da vrate 403, ne 500.
+        HttpServletRequest request = new MockHttpServletRequest("POST", "/admin/stocks/refresh-all");
+
+        ResponseEntity<?> response = handler.handleAuthorizationDenied(
+                new AccessDeniedException("denied"),
+                request
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+}


### PR DESCRIPTION
﻿
Closes #199. Dva primarna PM zahteva i pet pomocnih nalaza koji su izasli na
povrsinu tokom verifikacije live stack-a -- bez njih PM ne moze sopstvenim
ocima da vidi da #199 fix radi.

## Primarne stvari

### Bug 1 - SELL dugme iz "Moj Portfolio"

Klik na "Prodaj" je bio no-op zbog dva problema: response servera nije nosio
`listingId`, a handler je bio prazan TODO stub.

- Backend: `PortfolioResponse` dobija `Long id` i `Long listingId`,
  `PortfolioServiceImpl.mapToResponse` ih puni; `PortfolioServiceTest` ima
  asercije.
- Frontend: `PortfolioHolding.listingId`, `onSell(holding)` zove
  `router.navigate(['/orders/create','SELL',holding.listingId])`, HTML dugme
  prosledjuje holding.

### Bug 2 - Trade leg novca ne sme kroz bankin racun

`OrderExecutionServiceImpl.transferFunds` je za klijentski BUY zvao
`accountClient.transaction(...)` sa korisnikom kao `from` i bankom kao `to` -
ceo iznos kupovine je isao u bilans banke, sto direktno krsi PM direktivu.

- account-service: dva nova endpointa `POST /internal/accounts/exchange/buy` i
  `.../exchange/sell` koji izvrsavaju **jednostranu** debit odnosno credit
  operaciju nad jednim racunom (bez kontra-strane). Atomska implementacija
  kroz nove `withdrawOneSided`/`depositOneSided` u `TransactionalService`,
  reuse-uju postojece `debit`/`credit` primitive sa istim saldo/limit
  proverama i optimistic-locking retry-em.
- order-service: `AccountClient`/`AccountClientImpl`/`LocalStubClientsConfig`
  dobijaju `exchangeBuy`/`exchangeSell` metode. `transferFunds` prepravljen -
  bira `exchangeBuy` ili `exchangeSell` zavisno od smera, sa cuvanjem
  cross-currency konverzije (`convertTradeAmountToAccountCurrency`). Actuary
  BUY ostaje no-op (banka je vlasnik racuna). Stari pomocnici
  `transferForClient`/`transferWithoutConversionFee` su uklonjeni - sluzili su
  iskljucivo trade legu kroz banku.

Provizija (commission) NIJE menjana - ide banci kako i nalaze Celina 3, kroz
postojeci `OrderCreationServiceImpl.transferFee` (sa ownership-aware routing-om
iz GHI #195 PR-a).

## Pomocni nalazi (sve uradjeno u istom PR-u)

### Pomocni 3 - Vecina seed klijenata nije CLIENT_TRADING (POST /orders/buy ide u 403)

Endpoint zahteva `hasAnyRole('CLIENT_TRADING','AGENT','SUPERVISOR')` ali default
za seed klijente je `CLIENT_BASIC`. Migracija 007 je samo Mateju Subin
promovisala u CLIENT_TRADING - tester ko god se loguje kao Marko/Ana/Stefan
dobija 403 i nema kako da reprodukuje #199 BUY tok. Dodata
`008-client-trading-test-fixtures.sql` koja promovise jos `marko.markovic@banka.com`
i `ana.anic@banka.com` u CLIENT_TRADING (sa `MARGIN_TRADE` permisijom).

### Pomocni 4 - Exchange-service vraca 404 jer baza kurseva je prazna

TwelveData API key u `setup/.env` je placeholder
(`replace_with_provider_api_key`), a Alpha Vantage fallback key
(`NMBJV9I1JXOWWEZ6`) nije validan za TwelveData -- startup fetch padne, tabela
`exchange_rate` ostaje prazna, `GET /exchange/rates` vraca 404 sa
*"Lokalna baza kurseva je prazna"*. Cross-currency BUY/SELL u order-service-u
takodje puca jer `exchangeClient.calculate(...)` nema kurs. Dodata Liquibase
migracija `002-seed-fallback-rates.sql` koja umetne approximate mid-market
kurseve (USD, EUR, GBP, CHF, CAD, AUD, JPY -> RSD) za 2026-05-04. Cron i
manuelni `/rates/fetch` overwrite-uju seed cim upstream key bude validan.

### Pomocni 5 - AuthorizationDeniedException 500 -> 403 (POPRAVLJENO)

Spring Security 6.x baca `AuthorizationDeniedException` (NIJE podklasa starije
`AccessDeniedException`), pa se generic `Exception` fallback handler hvatao za
rep i pretvarao auth-fail u 500 -- frontend "Serverska greska" za nesto sto je
legitiman 403. Dodat namenski handler u stock-service-ovom
`StockServiceResponseStatusExceptionHandler` i u account-service-ovom
`GlobalExceptionHandler` koji `AuthorizationDeniedException` (i staru
`AccessDeniedException`) mapira na **HTTP 403** sa porukom *"Nedovoljne
privilegije za ovu akciju."* Refresh-all sada cisto vraca 403 kad je pozivalac
AGENT/BASIC/CLIENT.

### Pomocni 6 - Starter listing cene = 0 dok Alpha Vantage ne odgovori (POPRAVLJENO)

`StockTickerSeedService` je 10 starter listinga (AAPL, MSFT, GOOGL, AMZN, TSLA,
IBM, GS, JPM, WMT, BAC) seedovao sa `price = ask = bid = 0`, ocekujuci da prvi
Alpha Vantage refresh popuni vrednosti. Sa free 25/dan kvotom i 158+ listinga
ovo se brzo iscrpi i UI prikazuje 0 cene. `SeededStockRow` record sad nosi
`BigDecimal price` po tickeru (mid-market vrednosti pisane u kod), `createListing`
postavlja `price = row.price()`, `ask = price + 0.05`, `bid = price - 0.05`,
`volume = 50M`. Realni refresh nakon dobijanja kvote i dalje overrride-uje.

### Pomocni 7 - FOREX BUY pravi portfolio entry; FOREX SELL "Portfolio not found" (POPRAVLJENO)

Po Celini 3 i alukic7-evom komentaru, FX trgovina je konverzija valute, ne
pozicija. Ranije se FOREX tretirao identicno kao STOCK -- kreirao se Portfolio
entry sa quantity i averagePurchasePrice za par, a SELL flow bi pucao na
"Portfolio position not found". `OrderExecutionServiceImpl.updatePortfolio`
sada ima ranu `return` granu za FOREX (trade leg jednostranog debit-a/credit-a
za trade amount i dalje radi -- ne kreditira banci, "skida sa racuna" kako PM
zahteva). `OrderCreationServiceImpl.createSellOrder` rejectuje FOREX sa
`BadRequestException` *"Forex pari se ne mogu prodavati kao hartije od vrednosti;
FX trgovina je konverzija valuta, ne pozicija u portfoliju."*

### Pomocni 8 - `/order/orders/{id}/confirm` puca 500 zbog hash-ovanog accountId (POPRAVLJENO)

`GET /accounts/client/accounts` (account-service) je vracao listu racuna kroz
`AccountResponseDto` koji **nije imao polje `id`**. Frontend
`AccountService.mapToAccountFromClient(item)` je zato fallback-ovao na
`hashAccountNumber(item.brojRacuna)` i pravio 32-bit pseudo-ID koji ne mapira
ni na PK ni na broj racuna. Vrednost (npr. 1270307794) je zavrsavala u
`orders.account_id` i pri confirm-u order-service je zvao
`/internal/accounts/id/{accountId}/details` koji je vracao 404; generic
exception handler je to mapirao na **500 "Serverska greska"** u browseru i ceo
BUY/SELL confirm tok je padao.

- `AccountResponseDto` dobija `Long id` polje (sa Javadoc-om koji obrazlaze
  istorijski kontekst), populira ga `this.id = account.getId()` u copy
  konstruktoru.
- Frontend `mapToAccountFromClient` koristi `item.id` kada je broj, hash
  fallback ostaje samo kao defenzivna mreza za stare backend deploy-eve.
- Operativna napomena: korisnici koji su vec ulogovani **moraju logout +
  login** -- u cached sesiji im je list racuna jos uvek hash-bazirana, novi
  orderi bi nosili stari pseudo-ID i confirm bi i dalje pucao.

## Pokretanje aplikacije (Docker)

Iz root-a klonirane grane sa ovim PR-om:

1. `cp setup/.env.example setup/.env` (default vrednosti rade za lokalni test;
   `TWELVE_DATA_API_KEY` / `ALPHA_VANTAGE_API_KEY` opcioni -- bez kljuceva
   migracije iz Pomocnih 4 i 6 popunjavaju fallback kurseve i cene).
2. `docker compose -f setup/docker-compose.yml up -d --build`
   (prvi build 5--10 min: Maven, Gradle, Angular).
3. `docker compose -f setup/docker-compose.yml ps` -- sacekati da sve bude
   `healthy`. Liquibase migracije 008 (client-service) i 002 (exchange-service)
   se primenjuju automatski.
4. Frontend i API gateway na `http://localhost` (port 80, sluzi i front i back).
5. Cleanup kada test prodje:
   `docker compose -f setup/docker-compose.yml down` (dodaj `-v` za reset
   Postgres volume-ova i seed podatke u inicijalnom stanju).

## Test plan

- [x] `./gradlew test` na `account-service` -- BUILD SUCCESSFUL (sa novim handler test-om).
- [x] `./gradlew test` na `order-service` -- BUILD SUCCESSFUL (FOREX skip + SELL reject).
- [x] `./gradlew :test` na `stock-service` -- BUILD SUCCESSFUL (handler + seed prices testovi).
- [x] `tsc -p tsconfig.app.json --noEmit` -- clean.
- [x] `ng build --configuration production` -- clean (Initial Total ~1.28 MB).
- [x] Liquibase migracije (008 client-service, 002 exchange-service) primenjene;
  svi servisi healthy u Docker stack-u.
- [ ] Manuel E2E (fresh login obavezan posle Pomocni 8):
  - login `petar.petrovic@banka.com / admin123` (SUPERVISOR), refresh AAPL
    pojedinacno na `/securities`,
  - inkognito tab login `marko.markovic@banka.com / admin123` (CLIENT_TRADING),
  - kupiti AAPL -> Network tab: `/orders/buy` body nosi PK racuna (trocifren),
    NE 10-cifreni hash; `/orders/{id}/confirm` -> 2xx, ne 500,
  - sacekati ~60s settlement -> ici na Portfolio,
  - kliknuti "Prodaj" -> ocekivano: trenutno otvaranje Create Order forme sa
    direction=SELL i listingId iz holdings,
  - bankin USD racun nije porastao za trade iznos (samo za commission).

## Sta nije obuhvaceno

- Asinhrono izvrsavanje ima `INITIAL_EXECUTION_DELAY_MILLIS = 60_000L`, sveza
  pozicija ulazi u portfolio posle ~1-2 minuta. To je po Celini 3 i nije bag.
- Za SELL semantiku PM je uputio na konsultaciju sa Vujnicem; implementirano
  je simetricno sa BUY-om kao radna pretpostavka. Ako Vujnic propisr drugaciju
  semantiku, izmena se svodi na jednu `if` granu u `transferFunds`.
- AlphaVantage / TwelveData API kvota - real-time cene hartija se i dalje
  oslanjaju na upstream API; bez validnog kljuca, refresh-all moze da
  ne uspe za vise od par tickera.

## Promenjeni fajlovi (34 ukupno: 30 backend + 4 frontend)

### account-service (10)

- (novo) `dto/request/OneSidedTransactionDto.java` -- Greska #2
- `dto/response/AccountResponseDto.java` -- Greska #9 (id polje)
- `service/AccountService.java`, `TransactionalService.java` -- Greska #2
- `service/implementation/AccountServiceImplementation.java`, `TransactionalServiceImplementation.java` -- Greska #2
- `controller/AccountController.java` -- Greska #2 (novi exchange/buy + exchange/sell endpointi)
- `advice/GlobalExceptionHandler.java` -- Pomocni #5 (AuthorizationDeniedException -> 403)
- `test/controller/AccountControllerUnitTest.java` -- Greska #2
- (novo) `test/advice/GlobalExceptionHandlerUnitTest.java` -- Pomocni #5

### order-service (11)

- (novo) `dto/client/OneSidedTransactionDto.java` -- Greska #2
- `client/AccountClient.java`, `client/impl/AccountClientImpl.java` -- Greska #2 (exchangeBuy/exchangeSell)
- `config/LocalStubClientsConfig.java` -- Greska #2 (test stubs)
- `dto/PortfolioResponse.java` -- Greska #1 (id + listingId)
- `service/impl/PortfolioServiceImpl.java` -- Greska #1
- `service/impl/OrderExecutionServiceImpl.java` -- Greska #2 (one-sided trade leg) + Pomocni #7 (FOREX skip portfolio)
- `service/impl/OrderCreationServiceImpl.java` -- Pomocni #7 (FOREX SELL reject)
- `test/service/PortfolioServiceTest.java` -- Greska #1
- `test/service/impl/OrderExecutionServiceTest.java` -- Greska #2 + #7
- `test/service/impl/OrderCreationServiceTest.java` -- Pomocni #7

### stock-service (5)

- `web/StockServiceResponseStatusExceptionHandler.java` -- Pomocni #5
- `runner/StockTickerSeedService.java` -- Pomocni #6 (per-ticker fallback cene)
- (novo) `test/web/StockServiceResponseStatusExceptionHandlerTest.java` -- Pomocni #5
- `test/service/StockTickerSeedServiceTest.java` -- Pomocni #6
- `test/service/implementation/ListingQueryServiceImplTest.java` -- Pomocni #6

### client-service (Liquibase, 2)

- (novo) `resources/db/changelog/008-client-trading-test-fixtures.sql` -- Pomocni #3
- `resources/db/changelog/db.changelog-master.xml` -- Pomocni #3

### exchange-service (Liquibase, 2)

- (novo) `resources/db/changelog/002-seed-fallback-rates.sql` -- Pomocni #4
- `resources/db/changelog/db.changelog-master.xml` -- Pomocni #4

### Banka-1-Frontend-main (4)

- `src/app/features/client/models/portfolio.model.ts` -- Greska #1
- `src/app/features/client/components/portfolio/portfolio.component.ts` -- Greska #1
- `src/app/features/client/components/portfolio/portfolio.component.html` -- Greska #1
- `src/app/features/client/services/account.service.ts` -- Greska #9

5 novih fajlova: 2 OneSidedTransactionDto (account + order), 2 .sql migracije,
2 nova test fajla (handler + global exception handler).
