### PR TITLE
Popravljen buy i sell u order service

### DIFF
--- a/order-service/src/main/java/com/banka1/order/client/AccountClient.java
+++ b/order-service/src/main/java/com/banka1/order/client/AccountClient.java
@@ -2,6 +2,8 @@ package com.banka1.order.client;
 
 import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.AccountTransactionRequest;
+import com.banka1.order.dto.client.CreditDebitAccountDto;
+import com.banka1.order.dto.client.CreditDebitBankDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 
@@ -56,6 +58,14 @@ public interface AccountClient {
      * @param request the transaction request
      */
     void transfer(AccountTransactionRequest request);
+
+    void debit(CreditDebitAccountDto request);
+
+    void credit(CreditDebitAccountDto request);
+
+    void debitBank(CreditDebitBankDto request);
+
+    void creditBank(CreditDebitBankDto request);
 
     /**
      * Performs a same-owner cross-currency transfer using explicit debit and credit amounts.

--- a/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
+++ b/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
@@ -3,6 +3,8 @@ package com.banka1.order.client.impl;
 import com.banka1.order.client.AccountClient;
 import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.AccountTransactionRequest;
+import com.banka1.order.dto.client.CreditDebitAccountDto;
+import com.banka1.order.dto.client.CreditDebitBankDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -75,6 +77,42 @@ public class AccountClientImpl implements AccountClient {
     @Override
     public void transfer(AccountTransactionRequest request) {
         postTransaction(request).toBodilessEntity();
+    }
+
+    @Override
+    public void debit(CreditDebitAccountDto request) {
+        accountRestClient.post()
+                .uri("/internal/accounts/debit")
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    @Override
+    public void credit(CreditDebitAccountDto request) {
+        accountRestClient.post()
+                .uri("/internal/accounts/credit")
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    @Override
+    public void debitBank(CreditDebitBankDto request) {
+        accountRestClient.post()
+                .uri("/internal/accounts/debitBank")
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    @Override
+    public void creditBank(CreditDebitBankDto request) {
+        accountRestClient.post()
+                .uri("/internal/accounts/creditBank")
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
     }
 
     @Override

--- a/order-service/src/main/java/com/banka1/order/config/LocalStubClientsConfig.java
+++ b/order-service/src/main/java/com/banka1/order/config/LocalStubClientsConfig.java
@@ -16,6 +16,8 @@ import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.ExchangeStatusDto;
 import com.banka1.order.dto.StockExchangeDto;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.CreditDebitAccountDto;
+import com.banka1.order.dto.client.CreditDebitBankDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 import com.banka1.order.entity.enums.ListingType;
@@ -53,6 +55,22 @@ class LocalStubClientsConfig {
 
             @Override
             public void transfer(AccountTransactionRequest request) {
+            }
+
+            @Override
+            public void debit(CreditDebitAccountDto request) {
+            }
+
+            @Override
+            public void credit(CreditDebitAccountDto request) {
+            }
+
+            @Override
+            public void debitBank(CreditDebitBankDto request) {
+            }
+
+            @Override
+            public void creditBank(CreditDebitBankDto request) {
             }
 
             @Override

--- a/order-service/src/main/java/com/banka1/order/dto/PortfolioResponse.java
+++ b/order-service/src/main/java/com/banka1/order/dto/PortfolioResponse.java
@@ -29,6 +29,9 @@ import java.time.LocalDateTime;
 @Data
 public class PortfolioResponse {
 
+    /** Stock-service listing identifier used by portfolio SELL navigation and order creation. */
+    private Long listingId;
+
     /** Type of security held: STOCK, FUTURES, FOREX, or OPTION. */
     private ListingType listingType;
 

--- a/order-service/src/main/java/com/banka1/order/dto/client/CreditDebitAccountDto.java
+++ b/order-service/src/main/java/com/banka1/order/dto/client/CreditDebitAccountDto.java
@@ -1,0 +1,14 @@
+package com.banka1.order.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class CreditDebitAccountDto {
+    private String accountNumber;
+    private BigDecimal amount;
+    private Long clientId;
+}

--- a/order-service/src/main/java/com/banka1/order/dto/client/CreditDebitBankDto.java
+++ b/order-service/src/main/java/com/banka1/order/dto/client/CreditDebitBankDto.java
@@ -1,0 +1,13 @@
+package com.banka1.order.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class CreditDebitBankDto {
+    private String currencyCode;
+    private BigDecimal amount;
+}

--- a/order-service/src/main/java/com/banka1/order/exception/FinancialTransferException.java
+++ b/order-service/src/main/java/com/banka1/order/exception/FinancialTransferException.java
@@ -1,0 +1,12 @@
+package com.banka1.order.exception;
+
+/**
+ * Signals that order execution reached a stage with external financial side effects
+ * and automatic retry must stop until the situation is investigated.
+ */
+public class FinancialTransferException extends RuntimeException {
+
+    public FinancialTransferException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
@@ -16,6 +16,8 @@ import com.banka1.order.dto.OrderNotificationPayload;
 import com.banka1.order.dto.OrderOverviewResponse;
 import com.banka1.order.dto.OrderResponse;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.CreditDebitAccountDto;
+import com.banka1.order.dto.client.CreditDebitBankDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
@@ -133,6 +135,9 @@ public class OrderCreationServiceImpl implements OrderCreationService {
 
         StockListingDto listing = stockClient.getListing(request.getListingId());
         validateTradingAccess(user, listing);
+        if (user.isClient()) {
+            validateClientAccount(user.userId(), request.getAccountId());
+        }
         ensurePortfolioOwnership(user.userId(), request.getListingId(), request.getQuantity());
         ExchangeWindow exchangeWindow = resolveExchangeWindow(listing);
         OrderType orderType = determineOrderType(request.getLimitValue(), request.getStopValue());
@@ -617,14 +622,36 @@ public class OrderCreationServiceImpl implements OrderCreationService {
     }
 
     private void transferFee(AuthenticatedUser user, Long fundingAccountId, BigDecimal fee, String currency) {
-        transferFee(fundingAccountId, fee, currency, user.isClient());
+        if (user.isClient()) {
+            transferClientFee(user.userId(), fundingAccountId, fee, currency);
+            return;
+        }
+        transferFeeLegacy(fundingAccountId, fee, currency, false);
     }
 
     private void transferFee(Long userId, Long fundingAccountId, BigDecimal fee, String currency) {
-        transferFee(fundingAccountId, fee, currency, !isEmployeeUser(userId));
+        if (!isEmployeeUser(userId)) {
+            transferClientFee(userId, fundingAccountId, fee, currency);
+            return;
+        }
+        transferFeeLegacy(fundingAccountId, fee, currency, false);
     }
 
-    private void transferFee(Long fundingAccountId, BigDecimal fee, String currency, boolean applyConversionFee) {
+    private void transferClientFee(Long clientId, Long fundingAccountId, BigDecimal fee, String currency) {
+        BankAccountDto bankAccount = employeeClient.getBankAccount(currency);
+        if (fundingAccountId != null && fundingAccountId.equals(bankAccount.getAccountId())) {
+            return;
+        }
+        AccountDetailsDto fundingAccount = accountClient.getAccountDetails(fundingAccountId);
+        accountClient.debit(new CreditDebitAccountDto(
+                fundingAccount.getAccountNumber(),
+                fee,
+                clientId
+        ));
+        accountClient.creditBank(new CreditDebitBankDto(currency, fee));
+    }
+
+    private void transferFeeLegacy(Long fundingAccountId, BigDecimal fee, String currency, boolean applyConversionFee) {
         BankAccountDto bankAccount = employeeClient.getBankAccount(currency);
         if (fundingAccountId != null && fundingAccountId.equals(bankAccount.getAccountId())) {
             return;

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
@@ -354,6 +354,7 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
 
         if (order.getDirection() == OrderDirection.BUY) {
             if (actuaryOrder) {
+                accountClient.debitBank(new CreditDebitBankDto(currency, amount));
                 return;
             }
             AccountDetailsDto clientAccount = accountClient.getAccountDetails(order.getAccountId());

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
@@ -8,7 +8,8 @@ import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.BankAccountDto;
 import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.StockListingDto;
-import com.banka1.order.dto.client.PaymentDto;
+import com.banka1.order.dto.client.CreditDebitAccountDto;
+import com.banka1.order.dto.client.CreditDebitBankDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
 import com.banka1.order.entity.Portfolio;
@@ -355,11 +356,23 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
             if (actuaryOrder) {
                 return;
             }
-            transferForClient(order.getAccountId(), bankAccount.getAccountId(), amount, currency, "Order execution");
+            AccountDetailsDto clientAccount = accountClient.getAccountDetails(order.getAccountId());
+            accountClient.debit(new CreditDebitAccountDto(
+                    clientAccount.getAccountNumber(),
+                    amount,
+                    order.getUserId()
+            ));
+            accountClient.creditBank(new CreditDebitBankDto(currency, amount));
             return;
         }
 
-        transferWithoutConversionFee(bankAccount.getAccountId(), order.getAccountId(), amount, currency, "Order execution");
+        accountClient.debitBank(new CreditDebitBankDto(currency, amount));
+        AccountDetailsDto clientAccount = accountClient.getAccountDetails(order.getAccountId());
+        accountClient.credit(new CreditDebitAccountDto(
+                clientAccount.getAccountNumber(),
+                amount,
+                order.getUserId()
+        ));
     }
 
     private void finalizeActuaryExposure(Order order, String currency, BigDecimal amount) {
@@ -440,52 +453,6 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
         }
         ExchangeRateDto conversion = exchangeClient.calculateWithoutCommission(fromCurrency, toCurrency, amount);
         return conversion.getConvertedAmount() == null ? amount : conversion.getConvertedAmount();
-    }
-
-    private void transferWithoutConversionFee(Long fromAccountId, Long toAccountId, BigDecimal amount, String currency, String description) {
-        if (fromAccountId != null && fromAccountId.equals(toAccountId)) {
-            throw new IllegalStateException("Transfer source and destination must differ");
-        }
-        AccountDetailsDto fromAccount = accountClient.getAccountDetails(fromAccountId);
-        AccountDetailsDto toAccount = accountClient.getAccountDetails(toAccountId);
-        PaymentDto payment = new PaymentDto(
-                fromAccount.getAccountNumber(),
-                toAccount.getAccountNumber(),
-                amount,
-                amount,
-                BigDecimal.ZERO,
-                orderOwnerId(fromAccount)
-        );
-        // Route by ownership: account-service /transaction rejects same-owner pairs and /transfer
-        // rejects different-owner pairs. Settlement legs that move funds between two bank-owned
-        // accounts (e.g. bank's funding account to bank's commission account) must therefore go
-        // through /transfer, while client-to-bank settlements continue to use /transaction.
-        Long fromOwner = fromAccount.getOwnerId();
-        Long toOwner = toAccount.getOwnerId();
-        if (fromOwner != null && fromOwner.equals(toOwner)) {
-            accountClient.transfer(payment);
-            return;
-        }
-        accountClient.transaction(payment);
-    }
-
-    private void transferForClient(Long fromAccountId, Long toAccountId, BigDecimal amount, String currency, String description) {
-        AccountDetailsDto fromAccount = accountClient.getAccountDetails(fromAccountId);
-        if (fromAccount.getCurrency() == null || fromAccount.getCurrency().equalsIgnoreCase(currency)) {
-            transferWithoutConversionFee(fromAccountId, toAccountId, amount, currency, description);
-            return;
-        }
-
-        // Account currency differs from listing currency: convert the trade amount to the account's currency,
-        // then pay the bank account that matches the client's currency directly.
-        ExchangeRateDto conversion = exchangeClient.calculate(currency, fromAccount.getCurrency(), amount);
-        BigDecimal convertedAmount = conversion.getConvertedAmount() == null ? amount : conversion.getConvertedAmount();
-        BankAccountDto fromCurrencyBank = employeeClient.getBankAccount(fromAccount.getCurrency());
-        transferWithoutConversionFee(fromAccountId, fromCurrencyBank.getAccountId(), convertedAmount, fromAccount.getCurrency(), description);
-    }
-
-    private Long orderOwnerId(AccountDetailsDto account) {
-        return account.getOwnerId() == null ? 0L : account.getOwnerId();
     }
 
     private int defaultInteger(Integer value) {

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
@@ -18,6 +18,7 @@ import com.banka1.order.entity.enums.ListingType;
 import com.banka1.order.entity.enums.OrderDirection;
 import com.banka1.order.entity.enums.OrderStatus;
 import com.banka1.order.entity.enums.OrderType;
+import com.banka1.order.exception.FinancialTransferException;
 import com.banka1.order.repository.ActuaryInfoRepository;
 import com.banka1.order.repository.OrderRepository;
 import com.banka1.order.repository.PortfolioRepository;
@@ -116,6 +117,9 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
 
         try {
             selfProvider.getObject().executeOrderPortion(order);
+        } catch (FinancialTransferException e) {
+            log.error("Order {} execution reached a non-retryable financial transfer state; automatic retries are stopped", orderId, e);
+            return;
         } catch (Exception e) {
             log.error("Order {} execution attempt failed, retrying in {}ms", orderId, RETRY_DELAY_ON_ERROR_MILLIS, e);
             scheduleExecution(orderId, RETRY_DELAY_ON_ERROR_MILLIS);
@@ -177,15 +181,30 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
 
         createTransaction(managedOrder, quantityToExecute, executionPricePerUnit, grossChunkAmount, commission);
         updatePortfolio(managedOrder, listing, quantityToExecute, executionPricePerUnit);
-        transferFunds(managedOrder, listing.getCurrency(), grossChunkAmount);
-        finalizeActuaryExposure(managedOrder, listing.getCurrency(), grossChunkAmount);
+        boolean fundsTransferred = false;
+        try {
+            transferFunds(managedOrder, listing.getCurrency(), grossChunkAmount);
+            fundsTransferred = true;
+            finalizeActuaryExposure(managedOrder, listing.getCurrency(), grossChunkAmount);
 
-        managedOrder.setRemainingPortions(managedOrder.getRemainingPortions() - quantityToExecute);
-        if (managedOrder.getRemainingPortions() == 0) {
-            managedOrder.setIsDone(true);
-            managedOrder.setStatus(OrderStatus.DONE);
+            managedOrder.setRemainingPortions(managedOrder.getRemainingPortions() - quantityToExecute);
+            if (managedOrder.getRemainingPortions() == 0) {
+                managedOrder.setIsDone(true);
+                managedOrder.setStatus(OrderStatus.DONE);
+            }
+            orderRepository.save(managedOrder);
+        } catch (FinancialTransferException e) {
+            throw e;
+        } catch (Exception e) {
+            if (fundsTransferred) {
+                compensateCompletedTransfer(managedOrder, listing.getCurrency(), grossChunkAmount);
+                throw new FinancialTransferException(
+                        "Order " + managedOrder.getId() + " failed after funds were transferred; automatic retry blocked",
+                        e
+                );
+            }
+            throw e;
         }
-        orderRepository.save(managedOrder);
     }
 
     private boolean activateIfEligible(Order order, StockListingDto listing) {
@@ -363,17 +382,80 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
                     amount,
                     order.getUserId()
             ));
-            accountClient.creditBank(new CreditDebitBankDto(currency, amount));
+            try {
+                accountClient.creditBank(new CreditDebitBankDto(currency, amount));
+            } catch (Exception e) {
+                compensateClientAccountCredit(clientAccount.getAccountNumber(), amount, order.getUserId());
+                throw new FinancialTransferException(
+                        "Client BUY transfer could not be completed after debiting the client account",
+                        e
+                );
+            }
             return;
         }
 
         accountClient.debitBank(new CreditDebitBankDto(currency, amount));
+        try {
+            AccountDetailsDto clientAccount = accountClient.getAccountDetails(order.getAccountId());
+            accountClient.credit(new CreditDebitAccountDto(
+                    clientAccount.getAccountNumber(),
+                    amount,
+                    order.getUserId()
+            ));
+        } catch (Exception e) {
+            compensateBankCredit(currency, amount);
+            throw new FinancialTransferException(
+                    "SELL payout could not be completed after debiting the bank account",
+                    e
+            );
+        }
+    }
+
+    private void compensateCompletedTransfer(Order order, String currency, BigDecimal amount) {
+        try {
+            if (order.getDirection() == OrderDirection.BUY) {
+                compensateBuyTransfer(order, currency, amount);
+                return;
+            }
+            compensateSellTransfer(order, currency, amount);
+        } catch (Exception compensationError) {
+            log.error("Compensation failed for order {}", order.getId(), compensationError);
+        }
+    }
+
+    private void compensateBuyTransfer(Order order, String currency, BigDecimal amount) {
+        BankAccountDto bankAccount = employeeClient.getBankAccount(currency);
+        boolean bankFundedBuy = bankAccount.getAccountId() != null && bankAccount.getAccountId().equals(order.getAccountId());
+        if (bankFundedBuy) {
+            compensateBankCredit(currency, amount);
+            return;
+        }
+
         AccountDetailsDto clientAccount = accountClient.getAccountDetails(order.getAccountId());
-        accountClient.credit(new CreditDebitAccountDto(
-                clientAccount.getAccountNumber(),
-                amount,
-                order.getUserId()
-        ));
+        compensateBankDebit(currency, amount);
+        compensateClientAccountCredit(clientAccount.getAccountNumber(), amount, order.getUserId());
+    }
+
+    private void compensateSellTransfer(Order order, String currency, BigDecimal amount) {
+        AccountDetailsDto clientAccount = accountClient.getAccountDetails(order.getAccountId());
+        compensateClientAccountDebit(clientAccount.getAccountNumber(), amount, order.getUserId());
+        compensateBankCredit(currency, amount);
+    }
+
+    private void compensateClientAccountCredit(String accountNumber, BigDecimal amount, Long clientId) {
+        accountClient.credit(new CreditDebitAccountDto(accountNumber, amount, clientId));
+    }
+
+    private void compensateClientAccountDebit(String accountNumber, BigDecimal amount, Long clientId) {
+        accountClient.debit(new CreditDebitAccountDto(accountNumber, amount, clientId));
+    }
+
+    private void compensateBankCredit(String currency, BigDecimal amount) {
+        accountClient.creditBank(new CreditDebitBankDto(currency, amount));
+    }
+
+    private void compensateBankDebit(String currency, BigDecimal amount) {
+        accountClient.debitBank(new CreditDebitBankDto(currency, amount));
     }
 
     private void finalizeActuaryExposure(Order order, String currency, BigDecimal amount) {

--- a/order-service/src/main/java/com/banka1/order/service/impl/PortfolioServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/PortfolioServiceImpl.java
@@ -235,6 +235,7 @@ public class PortfolioServiceImpl implements PortfolioService {
 
         PortfolioResponse response = new PortfolioResponse();
 
+        response.setListingId(portfolio.getListingId());
         response.setListingType(portfolio.getListingType());
         response.setQuantity(portfolio.getQuantity());
         response.setPublicQuantity(portfolio.getPublicQuantity());

--- a/order-service/src/test/java/com/banka1/order/controller/PortfolioControllerTest.java
+++ b/order-service/src/test/java/com/banka1/order/controller/PortfolioControllerTest.java
@@ -1,6 +1,7 @@
 package com.banka1.order.controller;
 
 import com.banka1.order.dto.AuthenticatedUser;
+import com.banka1.order.dto.PortfolioResponse;
 import com.banka1.order.dto.PortfolioSummaryResponse;
 import com.banka1.order.dto.SetPublicQuantityRequestDto;
 import com.banka1.order.service.PortfolioService;
@@ -40,6 +41,9 @@ class PortfolioControllerTest {
     @Test
     void getPortfolio_usesAuthenticatedPrincipalInsteadOfRequestUserId() {
         PortfolioSummaryResponse summary = new PortfolioSummaryResponse();
+        PortfolioResponse holding = new PortfolioResponse();
+        holding.setListingId(100L);
+        summary.setHoldings(List.of(holding));
         when(portfolioService.getPortfolio(org.mockito.ArgumentMatchers.any())).thenReturn(summary);
 
         Jwt jwt = Jwt.withTokenValue("token")
@@ -52,6 +56,9 @@ class PortfolioControllerTest {
         ResponseEntity<PortfolioSummaryResponse> response = controller.getPortfolio(jwt);
 
         assertThat(response.getBody()).isSameAs(summary);
+        assertThat(response.getBody().getHoldings()).singleElement()
+                .extracting(PortfolioResponse::getListingId)
+                .isEqualTo(100L);
         ArgumentCaptor<AuthenticatedUser> captor = ArgumentCaptor.forClass(AuthenticatedUser.class);
         verify(portfolioService).getPortfolio(captor.capture());
         assertThat(captor.getValue().userId()).isEqualTo(42L);

--- a/order-service/src/test/java/com/banka1/order/service/PortfolioServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/PortfolioServiceTest.java
@@ -123,10 +123,12 @@ class PortfolioServiceTest {
         PortfolioSummaryResponse result = portfolioService.getPortfolio(clientUser);
 
         assertThat(result.getHoldings()).hasSize(2);
+        assertThat(result.getHoldings().get(0).getListingId()).isEqualTo(100L);
         assertThat(result.getHoldings().get(0).getTicker()).isEqualTo("AAPL");
         assertThat(result.getHoldings().get(0).getAveragePurchasePrice()).isEqualByComparingTo("100");
         assertThat(result.getHoldings().get(0).getProfit()).isEqualByComparingTo("500");
         assertThat(result.getHoldings().get(0).getPublicQuantity()).isEqualTo(2);
+        assertThat(result.getHoldings().get(1).getListingId()).isEqualTo(200L);
         assertThat(result.getHoldings().get(1).getAveragePurchasePrice()).isEqualByComparingTo("12");
         assertThat(result.getHoldings().get(1).getExercisable()).isTrue();
         assertThat(result.getTotalProfit()).isEqualByComparingTo("876");

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java
@@ -17,6 +17,8 @@ import com.banka1.order.dto.OrderNotificationPayload;
 import com.banka1.order.dto.OrderOverviewResponse;
 import com.banka1.order.dto.OrderResponse;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.CreditDebitAccountDto;
+import com.banka1.order.dto.client.CreditDebitBankDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
@@ -183,6 +185,10 @@ class OrderCreationServiceTest {
         lenient().when(accountClient.getAccountDetails(5L)).thenReturn(accountDetails);
         lenient().when(accountClient.getAccountDetails(999L)).thenReturn(accountDetails);
         lenient().doNothing().when(accountClient).transfer(any(AccountTransactionRequest.class));
+        lenient().doNothing().when(accountClient).debit(any(CreditDebitAccountDto.class));
+        lenient().doNothing().when(accountClient).credit(any(CreditDebitAccountDto.class));
+        lenient().doNothing().when(accountClient).debitBank(any(CreditDebitBankDto.class));
+        lenient().doNothing().when(accountClient).creditBank(any(CreditDebitBankDto.class));
         lenient().when(accountClient.transaction(any(PaymentDto.class))).thenReturn(null);
         lenient().when(employeeClient.getBankAccount("USD")).thenReturn(bankAccount);
         lenient().when(employeeClient.getEmployee(2L)).thenReturn(employee);
@@ -229,6 +235,13 @@ class OrderCreationServiceTest {
 
         assertThat(response.getStatus()).isEqualTo(OrderStatus.APPROVED);
         assertThat(response.getApprovedBy()).isEqualTo(OrderCreationServiceImpl.NO_APPROVAL_REQUIRED);
+        ArgumentCaptor<CreditDebitAccountDto> debitCaptor = ArgumentCaptor.forClass(CreditDebitAccountDto.class);
+        ArgumentCaptor<CreditDebitBankDto> creditBankCaptor = ArgumentCaptor.forClass(CreditDebitBankDto.class);
+        verify(accountClient).debit(debitCaptor.capture());
+        verify(accountClient).creditBank(creditBankCaptor.capture());
+        assertThat(debitCaptor.getValue().getAccountNumber()).isEqualTo("ACC-1");
+        assertThat(debitCaptor.getValue().getClientId()).isEqualTo(1L);
+        assertThat(creditBankCaptor.getValue().getCurrencyCode()).isEqualTo("USD");
         verify(accountClient, never()).transfer(any(AccountTransactionRequest.class));
         verify(orderExecutionService).executeOrderAsync(100L);
         // Approving the order must seed fresh quote data so the async executor can fill on
@@ -528,6 +541,8 @@ class OrderCreationServiceTest {
 
         assertThat(created.getStatus()).isEqualTo(OrderStatus.PENDING_CONFIRMATION);
         assertThat(confirmed.getStatus()).isEqualTo(OrderStatus.APPROVED);
+        verify(accountClient).debit(any(CreditDebitAccountDto.class));
+        verify(accountClient).creditBank(any(CreditDebitBankDto.class));
     }
 
     @Test
@@ -537,6 +552,15 @@ class OrderCreationServiceTest {
         assertThatThrownBy(() -> service.createSellOrder(clientUser, sellRequest))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Portfolio position not found");
+    }
+
+    @Test
+    void createSellOrder_rejectsForeignSettlementAccountForClient() {
+        accountDetails.setOwnerId(99L);
+
+        assertThatThrownBy(() -> service.createSellOrder(clientUser, sellRequest))
+                .isInstanceOf(ForbiddenOperationException.class)
+                .hasMessageContaining("Account does not belong to this user");
     }
 
     @Test

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
@@ -18,6 +18,7 @@ import com.banka1.order.entity.enums.ListingType;
 import com.banka1.order.entity.enums.OrderDirection;
 import com.banka1.order.entity.enums.OrderStatus;
 import com.banka1.order.entity.enums.OrderType;
+import com.banka1.order.exception.FinancialTransferException;
 import com.banka1.order.repository.ActuaryInfoRepository;
 import com.banka1.order.repository.OrderRepository;
 import com.banka1.order.repository.PortfolioRepository;
@@ -40,9 +41,11 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -191,6 +194,23 @@ class OrderExecutionServiceTest {
         verify(orderExecutionTaskScheduler, org.mockito.Mockito.times(2)).schedule(any(Runnable.class), instantCaptor.capture());
         Instant secondScheduleTime = instantCaptor.getAllValues().getLast();
         assertThat(secondScheduleTime).isAfter(firstScheduleTime);
+    }
+
+    @Test
+    void executeOrderAsync_stopsRetryingAfterFinancialTransferException() {
+        org.mockito.ArgumentCaptor<Runnable> runnableCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+        when(orderRepository.findById(10L)).thenReturn(Optional.of(order));
+        when(selfProvider.getObject()).thenReturn(self);
+        doThrow(new FinancialTransferException("stop", new RuntimeException("boom")))
+                .when(self).executeOrderPortion(order);
+
+        service.executeOrderAsync(10L);
+        verify(orderExecutionTaskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+        runnableCaptor.getValue().run();
+
+        verify(self).executeOrderPortion(order);
+        verify(orderExecutionTaskScheduler, org.mockito.Mockito.times(1)).schedule(any(Runnable.class), any(Instant.class));
     }
 
     @Test
@@ -389,6 +409,10 @@ class OrderExecutionServiceTest {
         assertThat(debitBankCaptor.getValue().getCurrencyCode()).isEqualTo("USD");
         assertThat(creditCaptor.getValue().getAccountNumber()).isEqualTo("1110001400000000221");
         assertThat(creditCaptor.getValue().getClientId()).isEqualTo(1L);
+        assertThat(portfolio.getQuantity()).isEqualTo(2);
+        assertThat(order.getRemainingPortions()).isZero();
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.DONE);
+        assertThat(order.getIsDone()).isTrue();
     }
 
     @Test
@@ -414,6 +438,52 @@ class OrderExecutionServiceTest {
         assertThat(debitBankCaptor.getValue().getAmount()).isEqualByComparingTo("202.00");
         verify(accountClient, never()).debit(any(CreditDebitAccountDto.class));
         verify(accountClient, never()).creditBank(any(CreditDebitBankDto.class));
+    }
+
+    @Test
+    void sellExecution_compensatesBankDebitWhenClientCreditFails() {
+        order.setDirection(OrderDirection.SELL);
+        doThrow(new RuntimeException("credit failed"))
+                .when(accountClient).credit(any(CreditDebitAccountDto.class));
+
+        assertThatThrownBy(() -> service.executeOrderPortion(order))
+                .isInstanceOf(FinancialTransferException.class);
+
+        verify(accountClient).debitBank(any(CreditDebitBankDto.class));
+        verify(accountClient).credit(any(CreditDebitAccountDto.class));
+        verify(accountClient).creditBank(any(CreditDebitBankDto.class));
+    }
+
+    @Test
+    void sellExecution_compensatesAndBlocksRetryWhenPostTransferStateFails() {
+        order.setDirection(OrderDirection.SELL);
+        org.mockito.ArgumentCaptor<Runnable> runnableCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+        when(orderRepository.findById(10L)).thenReturn(Optional.of(order));
+        when(selfProvider.getObject()).thenReturn(self);
+        doThrow(new FinancialTransferException("state failed", new RuntimeException("boom")))
+                .when(self).executeOrderPortion(order);
+
+        service.executeOrderAsync(10L);
+        verify(orderExecutionTaskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+        runnableCaptor.getValue().run();
+
+        verify(self).executeOrderPortion(order);
+        verify(orderExecutionTaskScheduler, org.mockito.Mockito.times(1)).schedule(any(Runnable.class), any(Instant.class));
+    }
+
+    @Test
+    void sellExecution_compensatesCompletedTransferWhenOrderSaveFails() {
+        order.setDirection(OrderDirection.SELL);
+        when(orderRepository.save(any(Order.class))).thenThrow(new RuntimeException("save failed"));
+
+        assertThatThrownBy(() -> service.executeOrderPortion(order))
+                .isInstanceOf(FinancialTransferException.class);
+
+        verify(accountClient).debitBank(any(CreditDebitBankDto.class));
+        verify(accountClient, atLeastOnce()).credit(any(CreditDebitAccountDto.class));
+        verify(accountClient).debit(any(CreditDebitAccountDto.class));
+        verify(accountClient).creditBank(any(CreditDebitBankDto.class));
     }
 
     @Test

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
@@ -408,6 +408,10 @@ class OrderExecutionServiceTest {
 
         service.executeOrderPortion(order);
 
+        ArgumentCaptor<CreditDebitBankDto> debitBankCaptor = ArgumentCaptor.forClass(CreditDebitBankDto.class);
+        verify(accountClient).debitBank(debitBankCaptor.capture());
+        assertThat(debitBankCaptor.getValue().getCurrencyCode()).isEqualTo("USD");
+        assertThat(debitBankCaptor.getValue().getAmount()).isEqualByComparingTo("202.00");
         verify(accountClient, never()).debit(any(CreditDebitAccountDto.class));
         verify(accountClient, never()).creditBank(any(CreditDebitBankDto.class));
     }

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
@@ -8,7 +8,8 @@ import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.BankAccountDto;
 import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.StockListingDto;
-import com.banka1.order.dto.client.PaymentDto;
+import com.banka1.order.dto.client.CreditDebitAccountDto;
+import com.banka1.order.dto.client.CreditDebitBankDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
 import com.banka1.order.entity.Portfolio;
@@ -203,10 +204,13 @@ class OrderExecutionServiceTest {
         assertThat(transactionCaptor.getValue().getPricePerUnit()).isEqualByComparingTo("101.00");
         assertThat(transactionCaptor.getValue().getTotalPrice()).isEqualByComparingTo("202.00");
 
-        ArgumentCaptor<PaymentDto> transferCaptor = ArgumentCaptor.forClass(PaymentDto.class);
-        verify(accountClient).transaction(transferCaptor.capture());
-        assertThat(transferCaptor.getValue().getFromAccountNumber()).isEqualTo("1110001400000000221");
-        assertThat(transferCaptor.getValue().getToAccountNumber()).isEqualTo("1110001000000000023");
+        ArgumentCaptor<CreditDebitAccountDto> debitCaptor = ArgumentCaptor.forClass(CreditDebitAccountDto.class);
+        ArgumentCaptor<CreditDebitBankDto> creditBankCaptor = ArgumentCaptor.forClass(CreditDebitBankDto.class);
+        verify(accountClient).debit(debitCaptor.capture());
+        verify(accountClient).creditBank(creditBankCaptor.capture());
+        assertThat(debitCaptor.getValue().getAccountNumber()).isEqualTo("1110001400000000221");
+        assertThat(debitCaptor.getValue().getClientId()).isEqualTo(1L);
+        assertThat(creditBankCaptor.getValue().getCurrencyCode()).isEqualTo("USD");
         assertThat(order.getStatus()).isEqualTo(OrderStatus.DONE);
         assertThat(order.getIsDone()).isTrue();
     }
@@ -230,7 +234,8 @@ class OrderExecutionServiceTest {
         service.executeOrderPortion(staleOrder);
 
         verify(transactionRepository, never()).save(any(Transaction.class));
-        verify(accountClient, never()).transaction(any(PaymentDto.class));
+        verify(accountClient, never()).debit(any(CreditDebitAccountDto.class));
+        verify(accountClient, never()).creditBank(any(CreditDebitBankDto.class));
         verify(portfolioRepository, never()).save(any(Portfolio.class));
         verify(orderRepository, never()).save(cancelledOrder);
     }
@@ -265,7 +270,8 @@ class OrderExecutionServiceTest {
 
         assertThat(staleOrder.getRemainingPortions()).isEqualTo(5);
         assertThat(lockedOrder.getRemainingPortions()).isZero();
-        verify(accountClient).transaction(any(PaymentDto.class));
+        verify(accountClient).debit(any(CreditDebitAccountDto.class));
+        verify(accountClient).creditBank(any(CreditDebitBankDto.class));
         verify(transactionRepository).save(any(Transaction.class));
     }
 
@@ -376,10 +382,13 @@ class OrderExecutionServiceTest {
         service.executeOrderPortion(order);
 
         verify(portfolioRepository, atLeastOnce()).save(portfolio);
-        ArgumentCaptor<PaymentDto> captor = ArgumentCaptor.forClass(PaymentDto.class);
-        verify(accountClient).transaction(captor.capture());
-        assertThat(captor.getValue().getFromAccountNumber()).isEqualTo("1110001000000000023");
-        assertThat(captor.getValue().getToAccountNumber()).isEqualTo("1110001400000000221");
+        ArgumentCaptor<CreditDebitBankDto> debitBankCaptor = ArgumentCaptor.forClass(CreditDebitBankDto.class);
+        ArgumentCaptor<CreditDebitAccountDto> creditCaptor = ArgumentCaptor.forClass(CreditDebitAccountDto.class);
+        verify(accountClient).debitBank(debitBankCaptor.capture());
+        verify(accountClient).credit(creditCaptor.capture());
+        assertThat(debitBankCaptor.getValue().getCurrencyCode()).isEqualTo("USD");
+        assertThat(creditCaptor.getValue().getAccountNumber()).isEqualTo("1110001400000000221");
+        assertThat(creditCaptor.getValue().getClientId()).isEqualTo(1L);
     }
 
     @Test
@@ -399,7 +408,8 @@ class OrderExecutionServiceTest {
 
         service.executeOrderPortion(order);
 
-        verify(accountClient, never()).transaction(any(PaymentDto.class));
+        verify(accountClient, never()).debit(any(CreditDebitAccountDto.class));
+        verify(accountClient, never()).creditBank(any(CreditDebitBankDto.class));
     }
 
     @Test
@@ -409,7 +419,8 @@ class OrderExecutionServiceTest {
         service.executeOrderPortion(order);
 
         verify(transactionRepository, never()).save(any(Transaction.class));
-        verify(accountClient, never()).transaction(any(PaymentDto.class));
+        verify(accountClient, never()).debit(any(CreditDebitAccountDto.class));
+        verify(accountClient, never()).creditBank(any(CreditDebitBankDto.class));
         verify(portfolioRepository, never()).save(any(Portfolio.class));
     }
 
@@ -421,7 +432,8 @@ class OrderExecutionServiceTest {
         service.executeOrderPortion(order);
 
         verify(transactionRepository, never()).save(any(Transaction.class));
-        verify(accountClient, never()).transaction(any(PaymentDto.class));
+        verify(accountClient, never()).debit(any(CreditDebitAccountDto.class));
+        verify(accountClient, never()).creditBank(any(CreditDebitBankDto.class));
         verify(portfolioRepository, never()).save(any(Portfolio.class));
     }
 
@@ -432,7 +444,8 @@ class OrderExecutionServiceTest {
         service.executeOrderPortion(order);
 
         verify(transactionRepository, never()).save(any(Transaction.class));
-        verify(accountClient, never()).transaction(any(PaymentDto.class));
+        verify(accountClient, never()).debit(any(CreditDebitAccountDto.class));
+        verify(accountClient, never()).creditBank(any(CreditDebitBankDto.class));
         verify(portfolioRepository, never()).save(any(Portfolio.class));
     }
 


### PR DESCRIPTION
Ispravljen je BUY/SELL transfer flow u order-service-u bez menjanja account-service-a. Client account operacije sada koriste JWT-derived clientId kroz debit/credit metode, dok bank account operacije koriste debitBank/creditBank bez fake clientId-ja.

