### PR TITLE
feat(#213): Infrastruktura za saga-orchestrator-service

### DIFF
--- a/api-gateway/default.conf.template
+++ b/api-gateway/default.conf.template
@@ -47,6 +47,10 @@ upstream notification_service {
     server notification-service:${NOTIFICATION_SERVICE_PORT};
 }
 
+upstream saga_orchestrator_service {
+    server saga-orchestrator-service:${SAGA_SERVICE_PORT};
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -221,6 +225,20 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Prefix /notifications;
+    }
+
+    # Saga Orchestrator (admin/internal API - Issue #213)
+    location = /saga {
+        return 301 /saga/;
+    }
+
+    location /saga/ {
+        proxy_pass http://saga_orchestrator_service/saga/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Prefix /saga;
     }
 
     # Health check

--- a/saga-orchestrator-service/Dockerfile
+++ b/saga-orchestrator-service/Dockerfile
@@ -1,0 +1,25 @@
+# ===== Build Stage =====
+FROM gradle:8.14.3-jdk21-alpine AS builder
+
+WORKDIR /app
+
+COPY saga-orchestrator-service ./saga-orchestrator-service
+COPY company-observability-starter ./company-observability-starter
+
+WORKDIR /app/saga-orchestrator-service
+
+RUN gradle build --no-daemon -x test -x checkstyleMain -x checkstyleTest
+
+# ===== Runtime Stage =====
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk add --no-cache curl
+
+WORKDIR /app
+
+COPY --from=builder /app/saga-orchestrator-service/build/libs/*.jar app.jar
+
+ARG SERVER_PORT=8095
+EXPOSE ${SERVER_PORT}
+
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/saga-orchestrator-service/README.md
+++ b/saga-orchestrator-service/README.md
@@ -1,0 +1,86 @@
+# saga-orchestrator-service
+
+SAGA pattern orchestrator za distribuirane transakcije u Banka-1 stack-u. Centralizuje OTC kupoprodaju i fondovsku kupovinu/likvidaciju hartija — koraci koji ostaju u različitim servisima posle banking-konsolidacije (#210/#211).
+
+GH issues iz koje ovaj servis raste: **#213** (infrastruktura), **#214** (SagaInstance + state machine), **#215** (RabbitMQ topologija).
+
+## Šta orkestrira
+
+Po **DoD #213** i konsolidaciji iz `banking-service`:
+
+| SAGA tip | Koraci (ukratko) |
+|---|---|
+| `OTC_EXERCISE` | rezervacija sredstava (banking) → transfer hartija (order) → naplata (banking) |
+| `FUND_LIQUIDATION_FOR_REDEMPTION` | likvidacija pozicija fonda (order) → transfer sredstava klijentu (banking) |
+
+OTC SAGA je posle konsolidacije svedena sa 5 servisa na 2 (`banking` i `order`); SAGA i dalje postoji jer transfer hartija i naplata sredstava ostaju u različitim servisima.
+
+## Tehnologije
+
+- Spring Boot 4.0.x + Java 21
+- PostgreSQL (`saga_db` schema, Flyway migracije)
+- RabbitMQ (Topic exchange `saga.exchange`, queues `saga.cmd.{banking,order,otc,fund}` + `saga.events` + `saga.dlq`)
+- OpenAPI (`/v3/api-docs`, Swagger UI na `/swagger-ui/index.html`, statični `docs/openapi.yml`)
+- Spring Actuator za infra health (`/actuator/health/liveness`)
+
+## Endpointi
+
+- `GET /saga/health` — domain liveness (api-gateway probe; ne treba auth)
+- `GET /saga/instances` — admin listing (Issue #214 implementacija)
+- `GET /saga/instances/{id}` — detalj jedne instance
+- `GET /actuator/health` — Spring Actuator (DB + Rabbit)
+- `GET /v3/api-docs` — OpenAPI JSON
+- `GET /swagger-ui/index.html` — Swagger UI
+
+Sve admin/internal rute idu kroz api-gateway `/saga/*` lokaciju.
+
+## Lokalno pokretanje
+
+Iz root-a `Banka-1-Backend-main`:
+
+```bash
+docker compose -f setup/docker-compose.yml up -d --build saga-orchestrator-service
+```
+
+Servis sluša na portu **8095** (env `SAGA_SERVER_PORT`).
+
+Standalone (bez ostatka stack-a, samo za servis dev):
+
+```bash
+cd saga-orchestrator-service
+docker compose up -d
+```
+
+Pretpostavka: postgres + rabbitmq kontejneri iz root stack-a su već pokrenuti i `banka-network` postoji.
+
+## Health check
+
+```bash
+curl http://localhost/saga/health
+# {"status":"UP","service":"saga-orchestrator-service"}
+
+curl http://localhost:8095/actuator/health/liveness
+# {"status":"UP"}
+```
+
+## Konfiguracija
+
+Sve env varijable imaju default vrednosti — vidi [src/main/resources/application.properties](src/main/resources/application.properties).
+
+Ključne:
+
+| Var | Default | Opis |
+|---|---|---|
+| `SAGA_SERVER_PORT` | `8095` | HTTP port |
+| `POSTGRES_DB` | `saga_db` | DB ime |
+| `SAGA_EXCHANGE` | `saga.exchange` | Topic exchange |
+| `SAGA_DLQ` | `saga.dlq` | Dead-letter queue |
+| `SAGA_RETRY_MAX_ATTEMPTS` | `5` | Retry pokušaja po koraku |
+
+## Roadmap
+
+- **#213** (ovaj PR): infrastruktura + health + OpenAPI + skelet
+- **#214**: `SagaInstance` entitet, `SagaStep` interface, `SagaOrchestrator` state machine
+- **#215**: `RabbitConfig` sa exchange-om, queue-ovima, DLQ
+- **#220**: prva real SAGA — OTC "Iskoristi opciju" flow
+- **#231**: druga SAGA — strategija likvidacije hartija pri velikim isplatama iz fonda

--- a/saga-orchestrator-service/build.gradle
+++ b/saga-orchestrator-service/build.gradle
@@ -1,0 +1,75 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '4.0.3'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
+    id 'checkstyle'
+}
+
+group = 'com.banka1.saga_orchestrator'
+version = '0.0.1-SNAPSHOT'
+description = 'SAGA Orchestrator service for distributed transactions (OTC + investment fund flows)'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    testcontainersVersion = '1.20.6'
+}
+
+configurations {
+    mockitoAgent
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
+    implementation project(':company-observability-starter')
+    runtimeOnly 'org.postgresql:postgresql'
+    implementation 'me.paulschwarz:springboot3-dotenv:5.0.1'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.amqp:spring-rabbit-test'
+    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
+    testImplementation "org.testcontainers:rabbitmq:${testcontainersVersion}"
+    testImplementation "org.testcontainers:postgresql:${testcontainersVersion}"
+    testRuntimeOnly 'com.h2database:h2'
+    mockitoAgent('org.mockito:mockito-core') {
+        transitive = false
+    }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+    jvmArgs "-javaagent:${configurations.mockitoAgent.singleFile.absolutePath}"
+    finalizedBy jacocoTestReport
+}
+
+checkstyle {
+    configFile = rootProject.file('checkstyle.xml')
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}

--- a/saga-orchestrator-service/docker-compose.yml
+++ b/saga-orchestrator-service/docker-compose.yml
@@ -1,0 +1,40 @@
+# Standalone compose for local development of the saga-orchestrator-service.
+# Production stack registers this service via the root setup/docker-compose.yml.
+services:
+  saga-orchestrator-service:
+    build:
+      context: ..
+      dockerfile: saga-orchestrator-service/Dockerfile
+      args:
+        SERVER_PORT: ${SAGA_SERVER_PORT:-8095}
+    container_name: saga-orchestrator-service
+    restart: unless-stopped
+    env_file:
+      - ../setup/.env
+    environment:
+      SAGA_SERVICE_HOST: 0.0.0.0
+      SAGA_SERVICE_PORT: ${SAGA_SERVER_PORT:-8095}
+      SERVER_PORT: ${SAGA_SERVER_PORT:-8095}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: ${SAGA_POSTGRES_DB:-saga_db}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:-guest}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-guest}
+    ports:
+      - "${SAGA_SERVER_PORT:-8095}:${SAGA_SERVER_PORT:-8095}"
+    networks:
+      - banka-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${SAGA_SERVER_PORT:-8095}/actuator/health/liveness || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+networks:
+  banka-network:
+    external: true

--- a/saga-orchestrator-service/docs/openapi.yml
+++ b/saga-orchestrator-service/docs/openapi.yml
@@ -1,0 +1,152 @@
+openapi: 3.0.3
+info:
+  title: Saga Orchestrator API
+  version: 0.0.1
+  description: |
+    Distributed transaction orchestration (SAGA pattern) for OTC trade exercise
+    and investment fund redemption flows. Admin/internal API only - external
+    traffic must come through api-gateway under /saga.
+servers:
+  - url: /
+    description: Same-origin via api-gateway
+  - url: http://localhost:8095
+    description: Direct (developer)
+
+paths:
+  /saga/health:
+    get:
+      tags: [Health]
+      summary: Liveness check
+      description: |
+        Domain-level liveness probe used by api-gateway. For infrastructure
+        health (DB, RabbitMQ) use Spring Actuator at /actuator/health.
+      responses:
+        '200':
+          description: Service is UP
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /saga/instances:
+    get:
+      tags: [Saga]
+      summary: List saga instances (admin)
+      description: |
+        Returns paged list of SagaInstance entries for monitoring/debugging.
+        Implementation lands in Issue #214 (state machine + entity).
+      parameters:
+        - in: query
+          name: state
+          schema:
+            $ref: '#/components/schemas/SagaState'
+        - in: query
+          name: sagaType
+          schema:
+            $ref: '#/components/schemas/SagaType'
+      responses:
+        '200':
+          description: Paged list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SagaInstance'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /saga/instances/{id}:
+    get:
+      tags: [Saga]
+      summary: Detalj jedne SAGA instance
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: SAGA instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SagaInstance'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  responses:
+    Unauthorized:
+      description: Missing or invalid auth
+    Forbidden:
+      description: Insufficient privileges (admin only)
+    NotFound:
+      description: SAGA instance does not exist
+
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, service]
+      properties:
+        status:
+          type: string
+          example: UP
+        service:
+          type: string
+          example: saga-orchestrator-service
+
+    SagaType:
+      type: string
+      enum:
+        - OTC_EXERCISE
+        - FUND_LIQUIDATION_FOR_REDEMPTION
+
+    SagaState:
+      type: string
+      enum:
+        - STARTED
+        - IN_PROGRESS
+        - COMPENSATING
+        - COMPLETED
+        - FAILED
+
+    SagaInstance:
+      type: object
+      required: [id, sagaType, currentStep, state, createdAt, updatedAt, retryCount]
+      properties:
+        id:
+          type: string
+          format: uuid
+        sagaType:
+          $ref: '#/components/schemas/SagaType'
+        currentStep:
+          type: integer
+          format: int32
+          minimum: 0
+        state:
+          $ref: '#/components/schemas/SagaState'
+        payload:
+          type: object
+          additionalProperties: true
+          description: Original input payload (JSONB)
+        compensationLog:
+          type: array
+          description: List of completed steps to be compensated in reverse order
+          items:
+            type: object
+            additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        retryCount:
+          type: integer
+          format: int32
+          minimum: 0

--- a/saga-orchestrator-service/settings.gradle
+++ b/saga-orchestrator-service/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'saga-orchestrator-service'
+
+include ':company-observability-starter'
+project(':company-observability-starter').projectDir = file('../company-observability-starter')

--- a/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/SagaOrchestratorApplication.java
+++ b/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/SagaOrchestratorApplication.java
@@ -1,0 +1,12 @@
+package com.banka1.saga_orchestrator;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SagaOrchestratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SagaOrchestratorApplication.class, args);
+    }
+}

--- a/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/config/OpenApiConfig.java
+++ b/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/config/OpenApiConfig.java
@@ -1,0 +1,30 @@
+package com.banka1.saga_orchestrator.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI sagaOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Saga Orchestrator API")
+                        .version("0.0.1")
+                        .description(
+                                "Distributed transaction orchestration (SAGA pattern) for OTC trade "
+                                        + "exercise and investment fund redemption flows. "
+                                        + "Admin/internal API only - external traffic must come through api-gateway."
+                        ))
+                .servers(List.of(
+                        new Server().url("/").description("Same-origin via api-gateway"),
+                        new Server().url("http://localhost:8095").description("Direct (developer)")
+                ));
+    }
+}

--- a/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/controller/HealthController.java
+++ b/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/controller/HealthController.java
@@ -1,0 +1,31 @@
+package com.banka1.saga_orchestrator.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * Domain-level health endpoint za saga-orchestrator-service. Spring Actuator
+ * pokriva infrastrukturni health (DB, Rabbit) na /actuator/health; ovaj endpoint
+ * je tu da bi /saga/health bio brzi liveness check za api-gateway nezavisno od
+ * Actuator-a (i zadovoljava DoD #213 "Health endpoint radi").
+ */
+@RestController
+@RequestMapping("/saga")
+@Tag(name = "Health", description = "Saga orchestrator liveness")
+public class HealthController {
+
+    @Operation(summary = "Liveness check za saga-orchestrator-service")
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, String>> health() {
+        return ResponseEntity.ok(Map.of(
+                "status", "UP",
+                "service", "saga-orchestrator-service"
+        ));
+    }
+}

--- a/saga-orchestrator-service/src/main/resources/application.properties
+++ b/saga-orchestrator-service/src/main/resources/application.properties
@@ -1,0 +1,46 @@
+spring.application.name=saga-orchestrator-service
+
+server.address=${SAGA_SERVICE_HOST:0.0.0.0}
+server.port=${SAGA_SERVICE_PORT:8095}
+
+# RabbitMQ - SAGA komunikacija
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${RABBITMQ_USERNAME:guest}
+spring.rabbitmq.password=${RABBITMQ_PASSWORD:guest}
+
+# SAGA topology (vidi RabbitConfig.java - Issue #215)
+saga.rabbit.exchange=${SAGA_EXCHANGE:saga.exchange}
+saga.rabbit.dlq=${SAGA_DLQ:saga.dlq}
+saga.rabbit.events-queue=${SAGA_EVENTS_QUEUE:saga.events}
+saga.rabbit.cmd-banking-queue=${SAGA_CMD_BANKING_QUEUE:saga.cmd.banking}
+saga.rabbit.cmd-order-queue=${SAGA_CMD_ORDER_QUEUE:saga.cmd.order}
+saga.rabbit.cmd-otc-queue=${SAGA_CMD_OTC_QUEUE:saga.cmd.otc}
+saga.rabbit.cmd-fund-queue=${SAGA_CMD_FUND_QUEUE:saga.cmd.fund}
+
+# Retry mehanizam (Issue #214)
+saga.retry.max-attempts=${SAGA_RETRY_MAX_ATTEMPTS:5}
+saga.retry.initial-backoff-millis=${SAGA_RETRY_INITIAL_BACKOFF:1000}
+saga.retry.multiplier=${SAGA_RETRY_MULTIPLIER:2.0}
+
+spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:saga_db}
+spring.datasource.username=${POSTGRES_USER:postgres}
+spring.datasource.password=${POSTGRES_PASSWORD:postgres}
+spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.open-in-view=false
+
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+
+spring.rabbitmq.listener.simple.default-requeue-rejected=false
+spring.rabbitmq.listener.simple.auto-startup=${RABBITMQ_LISTENER_ENABLED:true}
+spring.rabbitmq.listener.simple.prefetch=10
+
+management.endpoints.web.exposure.include=health
+management.endpoint.health.probes.enabled=true
+management.endpoint.health.show-details=never
+management.tracing.sampling.probability=1.0
+management.otlp.tracing.endpoint=${MANAGEMENT_OTLP_TRACING_ENDPOINT:http://localhost:4318/v1/traces}
+management.otlp.metrics.export.enabled=true
+management.otlp.metrics.export.url=${MANAGEMENT_OTLP_METRICS_EXPORT_URL:http://localhost:4318/v1/metrics}

--- a/saga-orchestrator-service/src/test/java/com/banka1/saga_orchestrator/controller/HealthControllerTest.java
+++ b/saga-orchestrator-service/src/test/java/com/banka1/saga_orchestrator/controller/HealthControllerTest.java
@@ -1,0 +1,28 @@
+package com.banka1.saga_orchestrator.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * DoD #213: ,,Health endpoint radi'' - smoke test.
+ */
+@WebMvcTest(HealthController.class)
+class HealthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void healthEndpointReturnsUp() throws Exception {
+        mockMvc.perform(get("/saga/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.service").value("saga-orchestrator-service"));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,4 @@ include 'order-service'
 
 
 include 'stock-service'
+include 'saga-orchestrator-service'

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -843,6 +843,8 @@ services:
       CREDIT_SERVER_PORT: ${CREDIT_SERVER_PORT:-8089}
       NOTIFICATION_SERVICE_PORT: ${NOTIFICATION_SERVER_PORT:-8006}
       ORDER_SERVER_PORT: ${ORDER_SERVER_PORT:-8088}
+      STOCK_SERVICE_PORT: ${STOCK_SERVICE_PORT:-8090}
+      SAGA_SERVICE_PORT: ${SAGA_SERVER_PORT:-8095}
     depends_on:
       employee-service:
         condition: service_healthy
@@ -864,6 +866,8 @@ services:
         condition: service_healthy
       order-service:
         condition: service_healthy
+      saga-orchestrator-service:
+        condition: service_healthy
     networks:
       - banka-network
     healthcheck:
@@ -872,6 +876,52 @@ services:
       timeout: 5s
       retries: 10
       start_period: 10s
+
+  # Saga Orchestrator Service (#213, #214, #215)
+  saga-orchestrator-service:
+    build:
+      context: ..
+      dockerfile: saga-orchestrator-service/Dockerfile
+      args:
+        SERVER_PORT: ${SAGA_SERVER_PORT:-8095}
+    container_name: saga-orchestrator-service
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      SAGA_SERVICE_HOST: 0.0.0.0
+      SAGA_SERVICE_PORT: ${SAGA_SERVER_PORT:-8095}
+      SERVER_PORT: ${SAGA_SERVER_PORT:-8095}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: ${SAGA_POSTGRES_DB:-saga_db}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:-guest}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-guest}
+      MANAGEMENT_OTLP_TRACING_ENDPOINT: http://otel-collector:4318/v1/traces
+      MANAGEMENT_OTLP_METRICS_EXPORT_URL: http://otel-collector:4318/v1/metrics
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_SERVICE_NAME: saga-orchestrator-service
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    expose:
+      - "${SAGA_SERVER_PORT:-8095}"
+    networks:
+      - banka-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${SAGA_SERVER_PORT:-8095}/actuator/health/liveness || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
 networks:
   banka-network:

--- a/setup/init-db.sh
+++ b/setup/init-db.sh
@@ -15,4 +15,5 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     CREATE DATABASE orderdb;
     CREATE DATABASE stock_db;
     CREATE DATABASE credit_db;
+    CREATE DATABASE saga_db;
 EOSQL


### PR DESCRIPTION
# feat(#213): Infrastruktura za saga-orchestrator-service

Closes #213.

Prvi od tri PR-a koji uvode SAGA orkestraciju u Banka-1 stack
(#213 infra → #214 state machine → #215 RabbitMQ topologija).

Branch: `feature/213-saga-orchestrator-infra` (na `main`).

## Šta uvodi

Nov mikroservis `saga-orchestrator-service` (Spring Boot 4.0.x, Java 21,
port **8095**) koji će orkestrirati distribuirane transakcije po SAGA
pattern-u — OTC kupoprodaja (#220) i fond likvidacija pri velikim
isplatama (#231). Posle banking-konsolidacije (#210/#211) OTC SAGA je
svedena sa 5 servisa na 2, ali SAGA i dalje postoji jer transfer hartija
(`order-service`) i naplata sredstava (`banking-service`) ostaju u
različitim servisima.

## Files (1 nov modul + 4 izmenjena infra fajla)

```
A  saga-orchestrator-service/Dockerfile                                      multistage, Gradle 8.14 + JRE 21
A  saga-orchestrator-service/build.gradle                                    Spring Boot 4.0.3, JPA, AMQP, springdoc
A  saga-orchestrator-service/settings.gradle                                 uključuje company-observability-starter
A  saga-orchestrator-service/docker-compose.yml                              standalone dev compose
A  saga-orchestrator-service/README.md                                       overview + endpointi + roadmap
A  saga-orchestrator-service/docs/openapi.yml                                OpenAPI 3.0.3 statički spec
A  .../SagaOrchestratorApplication.java                                      Spring Boot main
A  .../controller/HealthController.java                                      GET /saga/health (DoD: "Health endpoint radi")
A  .../config/OpenApiConfig.java                                             springdoc OpenAPI bean
A  .../resources/application.properties                                      DB + Rabbit + saga.* env varijable
A  .../test/.../HealthControllerTest.java                                    smoke test za /saga/health

M  settings.gradle                                                           include 'saga-orchestrator-service'
M  setup/docker-compose.yml                                                  novi service block + api-gateway depends_on
M  setup/init-db.sh                                                          CREATE DATABASE saga_db
M  api-gateway/default.conf.template                                         upstream + location /saga/
```

## DoD checklist (iz issue-a)

- [x] **Health endpoint radi** — `GET /saga/health` vraća `{"status":"UP","service":"saga-orchestrator-service"}`. Pokriveno smoke testom `HealthControllerTest`.
- [x] **OpenAPI validan** — `docs/openapi.yml` je OpenAPI 3.0.3, ide u repo plus runtime servira `/v3/api-docs` + Swagger UI kroz springdoc.
- [x] **Registrovan u root `settings.gradle`** — `include 'saga-orchestrator-service'`.
- [x] **Registrovan u `setup/docker-compose.yml`** — novi service block sa `depends_on: postgres + rabbitmq + otel-collector`, healthcheck preko Actuator-a.
- [x] **api-gateway `/saga` ruta** — upstream `saga_orchestrator_service` na portu `${SAGA_SERVICE_PORT}`, `location /saga/` proxy_pass sa `X-Forwarded-Prefix /saga`.
- [x] **`Dockerfile`** — multistage, Gradle 8.14.3-jdk21-alpine builder + eclipse-temurin:21-jre-alpine runtime.
- [x] **`docker-compose.yml`** — standalone (lokalni dev) + integrisan u root setup.
- [x] **`README.md`** — overview, endpointi, env varijable, roadmap (link na #214/#215/#220/#231).

## Šta NIJE u ovom PR-u

- `SagaInstance` entitet, `SagaStep` interface, `SagaOrchestrator` state machine — Issue #214 (sledeći PR).
- `RabbitConfig` sa exchange-om/queue-ovima/DLQ-om — Issue #215 (paralelan PR).
- Konkretne SAGA implementacije (OTC, fund) — Issue-i #220, #231.
- JWT/role enforcement za `/saga/*` admin rute — sledeći iteration kroz security-lib.

## Test plan

- [x] `./gradlew :saga-orchestrator-service:build` — kompajluje, jar generated.
- [x] `./gradlew :saga-orchestrator-service:test` — `HealthControllerTest` prolazi.
- [x] `docker compose -f setup/docker-compose.yml up -d --build saga-orchestrator-service` — kontejner se digne, healthcheck postaje `healthy`.
- [x] `curl http://localhost/saga/health` (kroz api-gateway) → 200 sa JSON-om.
- [x] `curl http://localhost:8095/actuator/health/liveness` (direktno) → 200.
- [x] `curl http://localhost/saga/v3/api-docs` → JSON OpenAPI dokument.
- [x] Postojeći servisi i dalje `healthy` (ne lomi stack).

## Konfiguracija

Sve env varijable imaju default vrednosti (vidi `application.properties`).
Najvažnije:

| Var | Default | Opis |
|---|---|---|
| `SAGA_SERVER_PORT` | 8095 | HTTP port |
| `SAGA_POSTGRES_DB` | `saga_db` | Ime baze |
| `SAGA_EXCHANGE` | `saga.exchange` | Topic exchange (priprema za #215) |
| `SAGA_DLQ` | `saga.dlq` | DLQ ime (priprema za #215) |
