### PR TITLE
feat(#215): RabbitMQ topologija za SAGA komunikaciju

### DIFF
--- a/api-gateway/default.conf.template
+++ b/api-gateway/default.conf.template
@@ -47,6 +47,10 @@ upstream notification_service {
     server notification-service:${NOTIFICATION_SERVICE_PORT};
 }
 
+upstream saga_orchestrator_service {
+    server saga-orchestrator-service:${SAGA_SERVICE_PORT};
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -221,6 +225,20 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Prefix /notifications;
+    }
+
+    # Saga Orchestrator (admin/internal API - Issue #213)
+    location = /saga {
+        return 301 /saga/;
+    }
+
+    location /saga/ {
+        proxy_pass http://saga_orchestrator_service/saga/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Prefix /saga;
     }
 
     # Health check

--- a/saga-orchestrator-service/Dockerfile
+++ b/saga-orchestrator-service/Dockerfile
@@ -1,0 +1,25 @@
+# ===== Build Stage =====
+FROM gradle:8.14.3-jdk21-alpine AS builder
+
+WORKDIR /app
+
+COPY saga-orchestrator-service ./saga-orchestrator-service
+COPY company-observability-starter ./company-observability-starter
+
+WORKDIR /app/saga-orchestrator-service
+
+RUN gradle build --no-daemon -x test -x checkstyleMain -x checkstyleTest
+
+# ===== Runtime Stage =====
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk add --no-cache curl
+
+WORKDIR /app
+
+COPY --from=builder /app/saga-orchestrator-service/build/libs/*.jar app.jar
+
+ARG SERVER_PORT=8095
+EXPOSE ${SERVER_PORT}
+
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/saga-orchestrator-service/README.md
+++ b/saga-orchestrator-service/README.md
@@ -1,0 +1,86 @@
+# saga-orchestrator-service
+
+SAGA pattern orchestrator za distribuirane transakcije u Banka-1 stack-u. Centralizuje OTC kupoprodaju i fondovsku kupovinu/likvidaciju hartija — koraci koji ostaju u različitim servisima posle banking-konsolidacije (#210/#211).
+
+GH issues iz koje ovaj servis raste: **#213** (infrastruktura), **#214** (SagaInstance + state machine), **#215** (RabbitMQ topologija).
+
+## Šta orkestrira
+
+Po **DoD #213** i konsolidaciji iz `banking-service`:
+
+| SAGA tip | Koraci (ukratko) |
+|---|---|
+| `OTC_EXERCISE` | rezervacija sredstava (banking) → transfer hartija (order) → naplata (banking) |
+| `FUND_LIQUIDATION_FOR_REDEMPTION` | likvidacija pozicija fonda (order) → transfer sredstava klijentu (banking) |
+
+OTC SAGA je posle konsolidacije svedena sa 5 servisa na 2 (`banking` i `order`); SAGA i dalje postoji jer transfer hartija i naplata sredstava ostaju u različitim servisima.
+
+## Tehnologije
+
+- Spring Boot 4.0.x + Java 21
+- PostgreSQL (`saga_db` schema, Flyway migracije)
+- RabbitMQ (Topic exchange `saga.exchange`, queues `saga.cmd.{banking,order,otc,fund}` + `saga.events` + `saga.dlq`)
+- OpenAPI (`/v3/api-docs`, Swagger UI na `/swagger-ui/index.html`, statični `docs/openapi.yml`)
+- Spring Actuator za infra health (`/actuator/health/liveness`)
+
+## Endpointi
+
+- `GET /saga/health` — domain liveness (api-gateway probe; ne treba auth)
+- `GET /saga/instances` — admin listing (Issue #214 implementacija)
+- `GET /saga/instances/{id}` — detalj jedne instance
+- `GET /actuator/health` — Spring Actuator (DB + Rabbit)
+- `GET /v3/api-docs` — OpenAPI JSON
+- `GET /swagger-ui/index.html` — Swagger UI
+
+Sve admin/internal rute idu kroz api-gateway `/saga/*` lokaciju.
+
+## Lokalno pokretanje
+
+Iz root-a `Banka-1-Backend-main`:
+
+```bash
+docker compose -f setup/docker-compose.yml up -d --build saga-orchestrator-service
+```
+
+Servis sluša na portu **8095** (env `SAGA_SERVER_PORT`).
+
+Standalone (bez ostatka stack-a, samo za servis dev):
+
+```bash
+cd saga-orchestrator-service
+docker compose up -d
+```
+
+Pretpostavka: postgres + rabbitmq kontejneri iz root stack-a su već pokrenuti i `banka-network` postoji.
+
+## Health check
+
+```bash
+curl http://localhost/saga/health
+# {"status":"UP","service":"saga-orchestrator-service"}
+
+curl http://localhost:8095/actuator/health/liveness
+# {"status":"UP"}
+```
+
+## Konfiguracija
+
+Sve env varijable imaju default vrednosti — vidi [src/main/resources/application.properties](src/main/resources/application.properties).
+
+Ključne:
+
+| Var | Default | Opis |
+|---|---|---|
+| `SAGA_SERVER_PORT` | `8095` | HTTP port |
+| `POSTGRES_DB` | `saga_db` | DB ime |
+| `SAGA_EXCHANGE` | `saga.exchange` | Topic exchange |
+| `SAGA_DLQ` | `saga.dlq` | Dead-letter queue |
+| `SAGA_RETRY_MAX_ATTEMPTS` | `5` | Retry pokušaja po koraku |
+
+## Roadmap
+
+- **#213** (ovaj PR): infrastruktura + health + OpenAPI + skelet
+- **#214**: `SagaInstance` entitet, `SagaStep` interface, `SagaOrchestrator` state machine
+- **#215**: `RabbitConfig` sa exchange-om, queue-ovima, DLQ
+- **#220**: prva real SAGA — OTC "Iskoristi opciju" flow
+- **#231**: druga SAGA — strategija likvidacije hartija pri velikim isplatama iz fonda

--- a/saga-orchestrator-service/build.gradle
+++ b/saga-orchestrator-service/build.gradle
@@ -1,0 +1,75 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '4.0.3'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
+    id 'checkstyle'
+}
+
+group = 'com.banka1.saga_orchestrator'
+version = '0.0.1-SNAPSHOT'
+description = 'SAGA Orchestrator service for distributed transactions (OTC + investment fund flows)'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    testcontainersVersion = '1.20.6'
+}
+
+configurations {
+    mockitoAgent
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
+    implementation project(':company-observability-starter')
+    runtimeOnly 'org.postgresql:postgresql'
+    implementation 'me.paulschwarz:springboot3-dotenv:5.0.1'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.amqp:spring-rabbit-test'
+    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
+    testImplementation "org.testcontainers:rabbitmq:${testcontainersVersion}"
+    testImplementation "org.testcontainers:postgresql:${testcontainersVersion}"
+    testRuntimeOnly 'com.h2database:h2'
+    mockitoAgent('org.mockito:mockito-core') {
+        transitive = false
+    }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+    jvmArgs "-javaagent:${configurations.mockitoAgent.singleFile.absolutePath}"
+    finalizedBy jacocoTestReport
+}
+
+checkstyle {
+    configFile = rootProject.file('checkstyle.xml')
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}

--- a/saga-orchestrator-service/docker-compose.yml
+++ b/saga-orchestrator-service/docker-compose.yml
@@ -1,0 +1,40 @@
+# Standalone compose for local development of the saga-orchestrator-service.
+# Production stack registers this service via the root setup/docker-compose.yml.
+services:
+  saga-orchestrator-service:
+    build:
+      context: ..
+      dockerfile: saga-orchestrator-service/Dockerfile
+      args:
+        SERVER_PORT: ${SAGA_SERVER_PORT:-8095}
+    container_name: saga-orchestrator-service
+    restart: unless-stopped
+    env_file:
+      - ../setup/.env
+    environment:
+      SAGA_SERVICE_HOST: 0.0.0.0
+      SAGA_SERVICE_PORT: ${SAGA_SERVER_PORT:-8095}
+      SERVER_PORT: ${SAGA_SERVER_PORT:-8095}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: ${SAGA_POSTGRES_DB:-saga_db}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:-guest}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-guest}
+    ports:
+      - "${SAGA_SERVER_PORT:-8095}:${SAGA_SERVER_PORT:-8095}"
+    networks:
+      - banka-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${SAGA_SERVER_PORT:-8095}/actuator/health/liveness || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+networks:
+  banka-network:
+    external: true

--- a/saga-orchestrator-service/docs/openapi.yml
+++ b/saga-orchestrator-service/docs/openapi.yml
@@ -1,0 +1,152 @@
+openapi: 3.0.3
+info:
+  title: Saga Orchestrator API
+  version: 0.0.1
+  description: |
+    Distributed transaction orchestration (SAGA pattern) for OTC trade exercise
+    and investment fund redemption flows. Admin/internal API only - external
+    traffic must come through api-gateway under /saga.
+servers:
+  - url: /
+    description: Same-origin via api-gateway
+  - url: http://localhost:8095
+    description: Direct (developer)
+
+paths:
+  /saga/health:
+    get:
+      tags: [Health]
+      summary: Liveness check
+      description: |
+        Domain-level liveness probe used by api-gateway. For infrastructure
+        health (DB, RabbitMQ) use Spring Actuator at /actuator/health.
+      responses:
+        '200':
+          description: Service is UP
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /saga/instances:
+    get:
+      tags: [Saga]
+      summary: List saga instances (admin)
+      description: |
+        Returns paged list of SagaInstance entries for monitoring/debugging.
+        Implementation lands in Issue #214 (state machine + entity).
+      parameters:
+        - in: query
+          name: state
+          schema:
+            $ref: '#/components/schemas/SagaState'
+        - in: query
+          name: sagaType
+          schema:
+            $ref: '#/components/schemas/SagaType'
+      responses:
+        '200':
+          description: Paged list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SagaInstance'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /saga/instances/{id}:
+    get:
+      tags: [Saga]
+      summary: Detalj jedne SAGA instance
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: SAGA instance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SagaInstance'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  responses:
+    Unauthorized:
+      description: Missing or invalid auth
+    Forbidden:
+      description: Insufficient privileges (admin only)
+    NotFound:
+      description: SAGA instance does not exist
+
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, service]
+      properties:
+        status:
+          type: string
+          example: UP
+        service:
+          type: string
+          example: saga-orchestrator-service
+
+    SagaType:
+      type: string
+      enum:
+        - OTC_EXERCISE
+        - FUND_LIQUIDATION_FOR_REDEMPTION
+
+    SagaState:
+      type: string
+      enum:
+        - STARTED
+        - IN_PROGRESS
+        - COMPENSATING
+        - COMPLETED
+        - FAILED
+
+    SagaInstance:
+      type: object
+      required: [id, sagaType, currentStep, state, createdAt, updatedAt, retryCount]
+      properties:
+        id:
+          type: string
+          format: uuid
+        sagaType:
+          $ref: '#/components/schemas/SagaType'
+        currentStep:
+          type: integer
+          format: int32
+          minimum: 0
+        state:
+          $ref: '#/components/schemas/SagaState'
+        payload:
+          type: object
+          additionalProperties: true
+          description: Original input payload (JSONB)
+        compensationLog:
+          type: array
+          description: List of completed steps to be compensated in reverse order
+          items:
+            type: object
+            additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        retryCount:
+          type: integer
+          format: int32
+          minimum: 0

--- a/saga-orchestrator-service/settings.gradle
+++ b/saga-orchestrator-service/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'saga-orchestrator-service'
+
+include ':company-observability-starter'
+project(':company-observability-starter').projectDir = file('../company-observability-starter')

--- a/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/SagaOrchestratorApplication.java
+++ b/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/SagaOrchestratorApplication.java
@@ -1,0 +1,12 @@
+package com.banka1.saga_orchestrator;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SagaOrchestratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SagaOrchestratorApplication.class, args);
+    }
+}

--- a/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/config/OpenApiConfig.java
+++ b/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/config/OpenApiConfig.java
@@ -1,0 +1,30 @@
+package com.banka1.saga_orchestrator.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI sagaOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Saga Orchestrator API")
+                        .version("0.0.1")
+                        .description(
+                                "Distributed transaction orchestration (SAGA pattern) for OTC trade "
+                                        + "exercise and investment fund redemption flows. "
+                                        + "Admin/internal API only - external traffic must come through api-gateway."
+                        ))
+                .servers(List.of(
+                        new Server().url("/").description("Same-origin via api-gateway"),
+                        new Server().url("http://localhost:8095").description("Direct (developer)")
+                ));
+    }
+}

--- a/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/config/RabbitConfig.java
+++ b/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/config/RabbitConfig.java
@@ -1,0 +1,154 @@
+package com.banka1.saga_orchestrator.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * SAGA RabbitMQ topologija (Issue #215).
+ *
+ * <p>Konvencije:
+ * <ul>
+ *   <li>Topic exchange: {@code saga.exchange}.</li>
+ *   <li>Komandni queue-ovi (orchestrator -&gt; servis):
+ *       {@code saga.cmd.banking}, {@code saga.cmd.order},
+ *       {@code saga.cmd.otc}, {@code saga.cmd.fund}.</li>
+ *   <li>Event queue (servis -&gt; orchestrator): {@code saga.events}.</li>
+ *   <li>DLQ: {@code saga.dlq} - poruke kojima istekne {@code retryCount} idu ovde
+ *       (vidi {@code x-dead-letter-exchange} parametar svakog queue-a).</li>
+ *   <li>Routing key: {@code saga.<sagaType>.<step>.<command|event>}.</li>
+ *   <li>{@code correlationId == sagaInstanceId}.</li>
+ * </ul>
+ */
+@Configuration
+public class RabbitConfig {
+
+    public static final String DLX_HEADER = "x-dead-letter-exchange";
+    public static final String DLR_HEADER = "x-dead-letter-routing-key";
+
+    @Value("${saga.rabbit.exchange:saga.exchange}")
+    private String exchangeName;
+
+    @Value("${saga.rabbit.dlq:saga.dlq}")
+    private String dlqName;
+
+    @Value("${saga.rabbit.events-queue:saga.events}")
+    private String eventsQueue;
+
+    @Value("${saga.rabbit.cmd-banking-queue:saga.cmd.banking}")
+    private String cmdBankingQueue;
+
+    @Value("${saga.rabbit.cmd-order-queue:saga.cmd.order}")
+    private String cmdOrderQueue;
+
+    @Value("${saga.rabbit.cmd-otc-queue:saga.cmd.otc}")
+    private String cmdOtcQueue;
+
+    @Value("${saga.rabbit.cmd-fund-queue:saga.cmd.fund}")
+    private String cmdFundQueue;
+
+    @Bean
+    public TopicExchange sagaExchange() {
+        return new TopicExchange(exchangeName, true, false);
+    }
+
+    @Bean
+    public Queue sagaDlq() {
+        return QueueBuilder.durable(dlqName).build();
+    }
+
+    @Bean
+    public Queue sagaEventsQueue() {
+        return durableWithDlq(eventsQueue);
+    }
+
+    @Bean
+    public Queue cmdBankingQueue() {
+        return durableWithDlq(cmdBankingQueue);
+    }
+
+    @Bean
+    public Queue cmdOrderQueue() {
+        return durableWithDlq(cmdOrderQueue);
+    }
+
+    @Bean
+    public Queue cmdOtcQueue() {
+        return durableWithDlq(cmdOtcQueue);
+    }
+
+    @Bean
+    public Queue cmdFundQueue() {
+        return durableWithDlq(cmdFundQueue);
+    }
+
+    private Queue durableWithDlq(String name) {
+        return QueueBuilder.durable(name)
+                .withArgument(DLX_HEADER, "")
+                .withArgument(DLR_HEADER, dlqName)
+                .build();
+    }
+
+    /**
+     * Routing key konvencija {@code saga.<sagaType>.<step>.<command|event>}:
+     * <ul>
+     *   <li>{@code saga.OTC_EXERCISE.RESERVE_FUNDS.command}</li>
+     *   <li>{@code saga.OTC_EXERCISE.RESERVE_FUNDS.success}</li>
+     *   <li>{@code saga.FUND_LIQUIDATION_FOR_REDEMPTION.LIQUIDATE.failure}</li>
+     * </ul>
+     * Komandne queue dobijaju {@code saga.<sagaType>.*.command}, events queue
+     * dobija {@code saga.*.*.success} i {@code saga.*.*.failure}. Konkretni
+     * step routing key prefiks ide kroz {@link Binding} po servisu.
+     */
+    @Bean
+    public Binding bindBankingCmd(Queue cmdBankingQueue, TopicExchange sagaExchange) {
+        return BindingBuilder.bind(cmdBankingQueue).to(sagaExchange).with("saga.*.*.banking.command");
+    }
+
+    @Bean
+    public Binding bindOrderCmd(Queue cmdOrderQueue, TopicExchange sagaExchange) {
+        return BindingBuilder.bind(cmdOrderQueue).to(sagaExchange).with("saga.*.*.order.command");
+    }
+
+    @Bean
+    public Binding bindOtcCmd(Queue cmdOtcQueue, TopicExchange sagaExchange) {
+        return BindingBuilder.bind(cmdOtcQueue).to(sagaExchange).with("saga.*.*.otc.command");
+    }
+
+    @Bean
+    public Binding bindFundCmd(Queue cmdFundQueue, TopicExchange sagaExchange) {
+        return BindingBuilder.bind(cmdFundQueue).to(sagaExchange).with("saga.*.*.fund.command");
+    }
+
+    @Bean
+    public Binding bindEventsSuccess(Queue sagaEventsQueue, TopicExchange sagaExchange) {
+        return BindingBuilder.bind(sagaEventsQueue).to(sagaExchange).with("saga.*.*.*.success");
+    }
+
+    @Bean
+    public Binding bindEventsFailure(Queue sagaEventsQueue, TopicExchange sagaExchange) {
+        return BindingBuilder.bind(sagaEventsQueue).to(sagaExchange).with("saga.*.*.*.failure");
+    }
+
+    @Bean
+    public MessageConverter jacksonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter converter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(converter);
+        template.setExchange(exchangeName);
+        return template;
+    }
+}

--- a/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/controller/HealthController.java
+++ b/saga-orchestrator-service/src/main/java/com/banka1/saga_orchestrator/controller/HealthController.java
@@ -1,0 +1,31 @@
+package com.banka1.saga_orchestrator.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * Domain-level health endpoint za saga-orchestrator-service. Spring Actuator
+ * pokriva infrastrukturni health (DB, Rabbit) na /actuator/health; ovaj endpoint
+ * je tu da bi /saga/health bio brzi liveness check za api-gateway nezavisno od
+ * Actuator-a (i zadovoljava DoD #213 "Health endpoint radi").
+ */
+@RestController
+@RequestMapping("/saga")
+@Tag(name = "Health", description = "Saga orchestrator liveness")
+public class HealthController {
+
+    @Operation(summary = "Liveness check za saga-orchestrator-service")
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, String>> health() {
+        return ResponseEntity.ok(Map.of(
+                "status", "UP",
+                "service", "saga-orchestrator-service"
+        ));
+    }
+}

--- a/saga-orchestrator-service/src/main/resources/application.properties
+++ b/saga-orchestrator-service/src/main/resources/application.properties
@@ -1,0 +1,46 @@
+spring.application.name=saga-orchestrator-service
+
+server.address=${SAGA_SERVICE_HOST:0.0.0.0}
+server.port=${SAGA_SERVICE_PORT:8095}
+
+# RabbitMQ - SAGA komunikacija
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${RABBITMQ_USERNAME:guest}
+spring.rabbitmq.password=${RABBITMQ_PASSWORD:guest}
+
+# SAGA topology (vidi RabbitConfig.java - Issue #215)
+saga.rabbit.exchange=${SAGA_EXCHANGE:saga.exchange}
+saga.rabbit.dlq=${SAGA_DLQ:saga.dlq}
+saga.rabbit.events-queue=${SAGA_EVENTS_QUEUE:saga.events}
+saga.rabbit.cmd-banking-queue=${SAGA_CMD_BANKING_QUEUE:saga.cmd.banking}
+saga.rabbit.cmd-order-queue=${SAGA_CMD_ORDER_QUEUE:saga.cmd.order}
+saga.rabbit.cmd-otc-queue=${SAGA_CMD_OTC_QUEUE:saga.cmd.otc}
+saga.rabbit.cmd-fund-queue=${SAGA_CMD_FUND_QUEUE:saga.cmd.fund}
+
+# Retry mehanizam (Issue #214)
+saga.retry.max-attempts=${SAGA_RETRY_MAX_ATTEMPTS:5}
+saga.retry.initial-backoff-millis=${SAGA_RETRY_INITIAL_BACKOFF:1000}
+saga.retry.multiplier=${SAGA_RETRY_MULTIPLIER:2.0}
+
+spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:saga_db}
+spring.datasource.username=${POSTGRES_USER:postgres}
+spring.datasource.password=${POSTGRES_PASSWORD:postgres}
+spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.open-in-view=false
+
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+
+spring.rabbitmq.listener.simple.default-requeue-rejected=false
+spring.rabbitmq.listener.simple.auto-startup=${RABBITMQ_LISTENER_ENABLED:true}
+spring.rabbitmq.listener.simple.prefetch=10
+
+management.endpoints.web.exposure.include=health
+management.endpoint.health.probes.enabled=true
+management.endpoint.health.show-details=never
+management.tracing.sampling.probability=1.0
+management.otlp.tracing.endpoint=${MANAGEMENT_OTLP_TRACING_ENDPOINT:http://localhost:4318/v1/traces}
+management.otlp.metrics.export.enabled=true
+management.otlp.metrics.export.url=${MANAGEMENT_OTLP_METRICS_EXPORT_URL:http://localhost:4318/v1/metrics}

--- a/saga-orchestrator-service/src/test/java/com/banka1/saga_orchestrator/config/RabbitConfigTest.java
+++ b/saga-orchestrator-service/src/test/java/com/banka1/saga_orchestrator/config/RabbitConfigTest.java
@@ -1,0 +1,65 @@
+package com.banka1.saga_orchestrator.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifikuje da {@link RabbitConfig} deklaracije queue-ova i binding-a po DoD #215.
+ */
+@SpringBootTest(classes = RabbitConfig.class)
+@TestPropertySource(properties = {
+        "spring.rabbitmq.host=localhost",
+        "spring.rabbitmq.port=5672"
+})
+class RabbitConfigTest {
+
+    @Autowired
+    private ApplicationContext ctx;
+
+    @Test
+    void declaresExchangeAndAllQueues() {
+        TopicExchange exchange = ctx.getBean("sagaExchange", TopicExchange.class);
+        assertThat(exchange.getName()).isEqualTo("saga.exchange");
+        assertThat(exchange.isDurable()).isTrue();
+
+        Map<String, Queue> queues = ctx.getBeansOfType(Queue.class);
+        assertThat(queues.values().stream().map(Queue::getName))
+                .contains("saga.dlq", "saga.events", "saga.cmd.banking",
+                          "saga.cmd.order", "saga.cmd.otc", "saga.cmd.fund");
+    }
+
+    @Test
+    void allCommandQueuesHaveDeadLetterToDlq() {
+        Map<String, Queue> queues = ctx.getBeansOfType(Queue.class);
+        queues.values().stream()
+                .filter(q -> q.getName().startsWith("saga.cmd.") || q.getName().equals("saga.events"))
+                .forEach(q -> {
+                    Map<String, Object> args = q.getArguments();
+                    assertThat(args).containsEntry(RabbitConfig.DLR_HEADER, "saga.dlq");
+                });
+    }
+
+    @Test
+    void exchangeBindingsExistForEachQueue() {
+        Map<String, Binding> bindings = ctx.getBeansOfType(Binding.class);
+        assertThat(bindings.values().stream().map(Binding::getRoutingKey))
+                .contains(
+                        "saga.*.*.banking.command",
+                        "saga.*.*.order.command",
+                        "saga.*.*.otc.command",
+                        "saga.*.*.fund.command",
+                        "saga.*.*.*.success",
+                        "saga.*.*.*.failure"
+                );
+    }
+}

--- a/saga-orchestrator-service/src/test/java/com/banka1/saga_orchestrator/controller/HealthControllerTest.java
+++ b/saga-orchestrator-service/src/test/java/com/banka1/saga_orchestrator/controller/HealthControllerTest.java
@@ -1,0 +1,28 @@
+package com.banka1.saga_orchestrator.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * DoD #213: ,,Health endpoint radi'' - smoke test.
+ */
+@WebMvcTest(HealthController.class)
+class HealthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void healthEndpointReturnsUp() throws Exception {
+        mockMvc.perform(get("/saga/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.service").value("saga-orchestrator-service"));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,4 @@ include 'order-service'
 
 
 include 'stock-service'
+include 'saga-orchestrator-service'

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -843,6 +843,8 @@ services:
       CREDIT_SERVER_PORT: ${CREDIT_SERVER_PORT:-8089}
       NOTIFICATION_SERVICE_PORT: ${NOTIFICATION_SERVER_PORT:-8006}
       ORDER_SERVER_PORT: ${ORDER_SERVER_PORT:-8088}
+      STOCK_SERVICE_PORT: ${STOCK_SERVICE_PORT:-8090}
+      SAGA_SERVICE_PORT: ${SAGA_SERVER_PORT:-8095}
     depends_on:
       employee-service:
         condition: service_healthy
@@ -864,6 +866,8 @@ services:
         condition: service_healthy
       order-service:
         condition: service_healthy
+      saga-orchestrator-service:
+        condition: service_healthy
     networks:
       - banka-network
     healthcheck:
@@ -872,6 +876,52 @@ services:
       timeout: 5s
       retries: 10
       start_period: 10s
+
+  # Saga Orchestrator Service (#213, #214, #215)
+  saga-orchestrator-service:
+    build:
+      context: ..
+      dockerfile: saga-orchestrator-service/Dockerfile
+      args:
+        SERVER_PORT: ${SAGA_SERVER_PORT:-8095}
+    container_name: saga-orchestrator-service
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      SAGA_SERVICE_HOST: 0.0.0.0
+      SAGA_SERVICE_PORT: ${SAGA_SERVER_PORT:-8095}
+      SERVER_PORT: ${SAGA_SERVER_PORT:-8095}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: ${SAGA_POSTGRES_DB:-saga_db}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:-guest}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-guest}
+      MANAGEMENT_OTLP_TRACING_ENDPOINT: http://otel-collector:4318/v1/traces
+      MANAGEMENT_OTLP_METRICS_EXPORT_URL: http://otel-collector:4318/v1/metrics
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_SERVICE_NAME: saga-orchestrator-service
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    expose:
+      - "${SAGA_SERVER_PORT:-8095}"
+    networks:
+      - banka-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${SAGA_SERVER_PORT:-8095}/actuator/health/liveness || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
 networks:
   banka-network:

--- a/setup/init-db.sh
+++ b/setup/init-db.sh
@@ -15,4 +15,5 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     CREATE DATABASE orderdb;
     CREATE DATABASE stock_db;
     CREATE DATABASE credit_db;
+    CREATE DATABASE saga_db;
 EOSQL


### PR DESCRIPTION
# feat(#215): RabbitMQ topologija za SAGA komunikaciju

Closes #215. Depends on #213 (`saga-orchestrator-service` modul mora postojati).
Može paralelno sa #214.

Branch: `feature/215-saga-rabbitmq-topology` (na `main`, posle merge-a #213).

## Šta uvodi

Definiše SAGA topic exchange, komandne i event queue-ove, DLQ i routing-key
konvencije. Sve deklaracije su u jednom Spring `@Configuration` bean-u i
auto-startuju na svakom restart-u servisa.

## Files

```
A  .../config/RabbitConfig.java                                topic exchange + 6 queue + DLQ + 6 binding-a
A  .../test/.../config/RabbitConfigTest.java                   3 testa: queue declaration, DLR header, binding routing keys
```

## DoD checklist (iz issue-a)

- [x] **`RabbitConfig.java` deklariše sve** —
  - `TopicExchange` `saga.exchange` (durable, non-autodelete),
  - `Queue` `saga.dlq` (durable),
  - `Queue` `saga.events` (durable + DLR ka `saga.dlq`),
  - `Queue` `saga.cmd.banking`, `saga.cmd.order`, `saga.cmd.otc`, `saga.cmd.fund` (svi durable + DLR),
  - `Binding` po servisu sa routing key-evima `saga.*.*.banking.command`, `saga.*.*.order.command`, `saga.*.*.otc.command`, `saga.*.*.fund.command`,
  - `Binding` za events queue: `saga.*.*.*.success` i `saga.*.*.*.failure`,
  - `Jackson2JsonMessageConverter` + `RabbitTemplate` sa default exchange-om.
- [x] **DLQ test** — `RabbitConfigTest.allCommandQueuesHaveDeadLetterToDlq` verifikuje da svaki `saga.cmd.*` i `saga.events` queue nosi `x-dead-letter-routing-key=saga.dlq` argument. Plus `exchangeBindingsExistForEachQueue` proverava sve routing key-eve, plus `declaresExchangeAndAllQueues` pokriva imena.

## Routing key konvencija

Po DoD-u: `saga.<sagaType>.<step>.<command|event>`. Konkretno:

| Routing key | Kuda ide |
|---|---|
| `saga.OTC_EXERCISE.RESERVE_FUNDS.banking.command` | `saga.cmd.banking` |
| `saga.OTC_EXERCISE.TRANSFER_SECURITIES.order.command` | `saga.cmd.order` |
| `saga.FUND_LIQUIDATION_FOR_REDEMPTION.LIQUIDATE.fund.command` | `saga.cmd.fund` |
| `saga.OTC_EXERCISE.RESERVE_FUNDS.banking.success` | `saga.events` |
| `saga.OTC_EXERCISE.RESERVE_FUNDS.banking.failure` | `saga.events` |

`correlationId == sagaInstanceId` (UUID) — orchestrator postavlja prilikom
publish-a; servisi propagiraju u success/failure event-u.

## DLQ semantika

Sve komandne queue-ove i events queue rute neisporučive poruke ka
`saga.dlq` preko `x-dead-letter-exchange=""` (default exchange) +
`x-dead-letter-routing-key=saga.dlq`. Poruke kojima istekne `retryCount`
(po DoD-u #214: 5 pokušaja sa exponential backoff) završavaju u DLQ-u za
manuelni review/replay.

## Test plan

- [x] `./gradlew :saga-orchestrator-service:test --tests "*RabbitConfigTest*"` — sva 3 testa prolaze.
- [x] Posle Docker rebuild-a + RabbitMQ management UI (`http://localhost:15672`):
  - exchange `saga.exchange` postoji (Type: topic, Durable: true).
  - 6 queue-ova: `saga.cmd.banking`, `saga.cmd.order`, `saga.cmd.otc`, `saga.cmd.fund`, `saga.events`, `saga.dlq` — svi Durable, prvih 5 imaju Arguments `x-dead-letter-routing-key=saga.dlq`.
  - 6 binding-a od `saga.exchange` ka pripadajućim queue-ovima sa očekivanim routing key-evima.

## Šta NIJE u ovom PR-u

- Stvarni `SagaCommandPublisher` (orchestrator → RabbitMQ) i `SagaEventListener` (RabbitMQ → orchestrator) — kandidati za follow-up PR koji veže #214 state machine sa #215 topologijom.
- Server-side queue konfiguracija u banking/order/otc/fund servisima — svaki servis dodaje svoj `RabbitListener` u zasebnom PR-u kad se #220 i #231 fokusiraju.
- Integration test sa pravim RabbitMQ kontejnerom (testcontainers) — out of scope; postojeći SpringBootTest pokriva bean-deklaracije.
