### PR TITLE
fix(#199): SELL button + trade leg off bank + accountId PK (not hash)

### DIFF
--- a/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
+++ b/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
@@ -4,6 +4,7 @@ import com.banka1.account_service.domain.enums.CurrencyCode;
 import com.banka1.account_service.dto.request.BankPaymentDto;
 import com.banka1.account_service.dto.request.CreditDebitAccountDto;
 import com.banka1.account_service.dto.request.CreditDebitBankDto;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 import com.banka1.account_service.dto.response.InfoResponseDto;
 import com.banka1.account_service.dto.response.InternalAccountDetailsDto;
@@ -56,6 +57,26 @@ public class AccountController {
     @PostMapping("/transaction")
     public ResponseEntity<UpdatedBalanceResponseDto> transaction(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid PaymentDto paymentDto) {
         return new ResponseEntity<>(accountService.transaction(paymentDto),HttpStatus.OK);
+    }
+
+    /**
+     * GHI #199: jednostrani debit za trade-leg klijentskog BUY-a.
+     * Bankin racun se NE dira (po PM direktivi); samo se sredstva skidaju sa
+     * korisnikovog racuna.
+     */
+    @PostMapping("/exchange/buy")
+    public ResponseEntity<UpdatedBalanceResponseDto> exchangeBuy(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid OneSidedTransactionDto request) {
+        return new ResponseEntity<>(accountService.exchangeBuy(request), HttpStatus.OK);
+    }
+
+    /**
+     * GHI #199: jednostrani credit za trade-leg klijentskog SELL-a.
+     * Bankin racun se NE dira na drugoj strani; korisnikov racun se direktno
+     * popunjava trade proceeds-om.
+     */
+    @PostMapping("/exchange/sell")
+    public ResponseEntity<UpdatedBalanceResponseDto> exchangeSell(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid OneSidedTransactionDto request) {
+        return new ResponseEntity<>(accountService.exchangeSell(request), HttpStatus.OK);
     }
 
 

--- a/account-service/src/main/java/com/banka1/account_service/dto/request/OneSidedTransactionDto.java
+++ b/account-service/src/main/java/com/banka1/account_service/dto/request/OneSidedTransactionDto.java
@@ -1,0 +1,43 @@
+package com.banka1.account_service.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * Request payload za jednostranu trade-leg operaciju (debit/credit) nad jednim
+ * racunom (GHI #199, primarni bug 2).
+ *
+ * <p>Po PM direktivi <em>,,NE DAJE BANCI PARE, samo se skidaju sa racuna''</em>:
+ * trade leg klijentskog BUY/SELL ne sme da prolazi kroz bankin racun. Ranije je
+ * orchestrator zvao {@code accountClient.transaction(...)} sa korisnikom kao
+ * {@code from} i bankom kao {@code to}, sto je celokupan iznos kupovine
+ * kreditiralo banci. Novi endpointi {@code /internal/accounts/exchange/buy} i
+ * {@code .../exchange/sell} izvrsavaju jednostrani debit odnosno credit nad
+ * korisnikovim racunom; bankin racun se ne dira (osim provizije, koja i dalje
+ * ide kroz {@code OrderCreationServiceImpl.transferFee}).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OneSidedTransactionDto {
+
+    /** Broj racuna (18 cifara) ili PK racuna; servis prihvata oba. */
+    private String accountNumber;
+
+    /** ID racuna (PK iz baze). Alternativa za {@code accountNumber}. */
+    private Long accountId;
+
+    /** Iznos za debit/credit. Mora biti pozitivan. */
+    private BigDecimal amount;
+
+    /** Klijent koji inicira (audit/log). */
+    private Long clientId;
+
+    /** Opis transakcije za audit. */
+    private String description;
+}

--- a/account-service/src/main/java/com/banka1/account_service/service/AccountService.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/AccountService.java
@@ -44,6 +44,26 @@ public interface AccountService {
     void transactionFromBank(BankPaymentDto paymentDto);
 
     /**
+     * Jednostrana debit operacija za trade-leg klijentskog BUY-a (GHI #199).
+     * Bankin racun se NE dira - po PM direktivi
+     * <em>,,NE DAJE BANCI PARE, samo se skidaju sa racuna''</em>.
+     *
+     * @param request payload sa account identifikatorom + iznosom
+     * @return azurirano stanje racuna nakon debita
+     */
+    UpdatedBalanceResponseDto exchangeBuy(com.banka1.account_service.dto.request.OneSidedTransactionDto request);
+
+    /**
+     * Jednostrana credit operacija za trade-leg klijentskog SELL-a (GHI #199).
+     * Smer je obrnut od {@link #exchangeBuy}: korisniku se dodaju trade proceeds,
+     * dok bankin racun ostaje netaknut.
+     *
+     * @param request payload sa account identifikatorom + iznosom
+     * @return azurirano stanje racuna nakon credita
+     */
+    UpdatedBalanceResponseDto exchangeSell(com.banka1.account_service.dto.request.OneSidedTransactionDto request);
+
+    /**
      * Izvrsava transfer izmedju dva racuna istog vlasnika.
      * Razlikuje se od {@link #transaction} po tome sto proverava da oba racuna
      * pripadaju istom vlasniku.

--- a/account-service/src/main/java/com/banka1/account_service/service/TransactionalService.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/TransactionalService.java
@@ -43,4 +43,28 @@ public interface TransactionalService {
     void debitTransactional(Account account, BigDecimal amount);
 
 
+    /**
+     * Jednostrana debit operacija nad racunom za potrebe trade-leg-a (GHI #199).
+     * Po PM direktivi <em>,,NE DAJE BANCI PARE, samo se skidaju sa racuna''</em>,
+     * trade leg klijentskog BUY-a ne sme prolaziti kroz bankin racun. Ova metoda
+     * smanjuje raspolozivo stanje racuna za zadati iznos uz iste saldo/limit
+     * provere koje izvodi {@link #debitTransactional(Account, BigDecimal)}.
+     *
+     * @param account racun sa kojeg se skidaju sredstva
+     * @param amount  pozitivan iznos koji se debituje
+     */
+    void withdrawOneSided(Account account, BigDecimal amount);
+
+
+    /**
+     * Jednostrana credit operacija nad racunom za potrebe trade-leg-a (GHI #199).
+     * Drugi smer od {@link #withdrawOneSided}: koristi se za SELL trade leg gde
+     * korisnik prima sredstva, ali bankin racun ne sme da bude na drugoj strani.
+     *
+     * @param account racun na koji se uplacuju sredstva
+     * @param amount  pozitivan iznos koji se kreditira
+     */
+    void depositOneSided(Account account, BigDecimal amount);
+
+
 }

--- a/account-service/src/main/java/com/banka1/account_service/service/implementation/AccountServiceImplementation.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/implementation/AccountServiceImplementation.java
@@ -7,6 +7,7 @@ import com.banka1.account_service.domain.enums.Status;
 import com.banka1.account_service.dto.request.BankPaymentDto;
 import com.banka1.account_service.dto.request.CreditDebitAccountDto;
 import com.banka1.account_service.dto.request.CreditDebitBankDto;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 import com.banka1.account_service.dto.response.InfoResponseDto;
 import com.banka1.account_service.dto.response.InternalAccountDetailsDto;
@@ -276,6 +277,50 @@ public class AccountServiceImplementation implements AccountService {
         if (account == null)
             throw new NoSuchElementException("Ne postoji interni bankovni racun za valutu:" + currencyCode);
         return InternalAccountDetailsDto.from(account);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request) {
+        Account account = resolveAccountForOneSided(request);
+        if (request.getAmount() == null || request.getAmount().signum() <= 0) {
+            throw new IllegalArgumentException("Iznos mora biti pozitivan");
+        }
+        transactionalService.withdrawOneSided(account, request.getAmount());
+        return new UpdatedBalanceResponseDto(account.getRaspolozivoStanje(), null);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request) {
+        Account account = resolveAccountForOneSided(request);
+        if (request.getAmount() == null || request.getAmount().signum() <= 0) {
+            throw new IllegalArgumentException("Iznos mora biti pozitivan");
+        }
+        transactionalService.depositOneSided(account, request.getAmount());
+        return new UpdatedBalanceResponseDto(account.getRaspolozivoStanje(), null);
+    }
+
+    /**
+     * Razresava racun iz {@link OneSidedTransactionDto}: prvo probaj po
+     * {@code accountNumber}, fallback na {@code accountId}. Validacija je ista
+     * kao u {@link #validate(String)}.
+     */
+    private Account resolveAccountForOneSided(OneSidedTransactionDto request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Request ne sme biti null");
+        }
+        if (request.getAccountNumber() != null && !request.getAccountNumber().isBlank()) {
+            return validate(request.getAccountNumber());
+        }
+        if (request.getAccountId() != null) {
+            Account account = accountRepository.findById(request.getAccountId()).orElseThrow(
+                    () -> new IllegalArgumentException("Ne postoji racun za id:" + request.getAccountId()));
+            if (account.getStatus() == Status.INACTIVE)
+                throw new IllegalArgumentException("Racun je neaktivan:" + account.getBrojRacuna());
+            if (account.getDatumIsteka() != null && account.getDatumIsteka().isBefore(LocalDate.now()))
+                throw new IllegalArgumentException("Racun je istekao:" + account.getBrojRacuna());
+            return account;
+        }
+        throw new IllegalArgumentException("OneSidedTransactionDto mora imati accountNumber ili accountId");
     }
 
     @Override

--- a/account-service/src/main/java/com/banka1/account_service/service/implementation/TransactionalServiceImplementation.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/implementation/TransactionalServiceImplementation.java
@@ -125,5 +125,21 @@ public class TransactionalServiceImplementation implements TransactionalService 
       debit(account,amount);
     }
 
+    @Transactional
+    @Override
+    public void withdrawOneSided(Account account, BigDecimal amount) {
+        // GHI #199: jednostrana debit operacija za trade-leg klijentskog BUY-a.
+        // Reuse postojece debit() primitive sa istim saldo/limit proverama;
+        // bankin racun se NE dira (po PM direktivi).
+        debit(account, amount);
+    }
+
+    @Transactional
+    @Override
+    public void depositOneSided(Account account, BigDecimal amount) {
+        // GHI #199: jednostrana credit operacija za trade-leg klijentskog SELL-a.
+        credit(account, amount);
+    }
+
 
 }

--- a/order-service/src/main/java/com/banka1/order/client/AccountClient.java
+++ b/order-service/src/main/java/com/banka1/order/client/AccountClient.java
@@ -2,6 +2,7 @@ package com.banka1.order.client;
 
 import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.AccountTransactionRequest;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 
@@ -72,4 +73,19 @@ public interface AccountClient {
      * @return updated balances after the transfer
      */
     UpdatedBalanceResponseDto transaction(PaymentDto payment);
+
+    /**
+     * One-sided debit on a single account for the BUY trade leg (GHI #199).
+     * Bank account is NOT touched - the trade amount only leaves the user's
+     * account, satisfying the PM directive "NE DAJE BANCI PARE, samo se skidaju
+     * sa racuna".
+     */
+    UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request);
+
+    /**
+     * One-sided credit on a single account for the SELL trade leg (GHI #199).
+     * Bank account is NOT touched on the source side - the user's account is
+     * topped up directly with the trade proceeds.
+     */
+    UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request);
 }

--- a/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
+++ b/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
@@ -3,6 +3,7 @@ package com.banka1.order.client.impl;
 import com.banka1.order.client.AccountClient;
 import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.AccountTransactionRequest;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -89,6 +90,24 @@ public class AccountClientImpl implements AccountClient {
     @Override
     public UpdatedBalanceResponseDto transaction(PaymentDto payment) {
         return postTransaction(payment).body(UpdatedBalanceResponseDto.class);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request) {
+        return accountRestClient.post()
+                .uri("/internal/accounts/exchange/buy")
+                .body(request)
+                .retrieve()
+                .body(UpdatedBalanceResponseDto.class);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request) {
+        return accountRestClient.post()
+                .uri("/internal/accounts/exchange/sell")
+                .body(request)
+                .retrieve()
+                .body(UpdatedBalanceResponseDto.class);
     }
 
     private RestClient.ResponseSpec postTransaction(Object payload) {

--- a/order-service/src/main/java/com/banka1/order/config/LocalStubClientsConfig.java
+++ b/order-service/src/main/java/com/banka1/order/config/LocalStubClientsConfig.java
@@ -16,6 +16,7 @@ import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.ExchangeStatusDto;
 import com.banka1.order.dto.StockExchangeDto;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 import com.banka1.order.entity.enums.ListingType;
@@ -62,6 +63,16 @@ class LocalStubClientsConfig {
 
             @Override
             public UpdatedBalanceResponseDto transaction(PaymentDto payment) {
+                return null;
+            }
+
+            @Override
+            public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request) {
+                return null;
+            }
+
+            @Override
+            public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request) {
                 return null;
             }
 

--- a/order-service/src/main/java/com/banka1/order/dto/PortfolioResponse.java
+++ b/order-service/src/main/java/com/banka1/order/dto/PortfolioResponse.java
@@ -29,6 +29,20 @@ import java.time.LocalDateTime;
 @Data
 public class PortfolioResponse {
 
+    /**
+     * Primary key of the Portfolio entity. Frontend uses ovaj id da bi mogao da
+     * navigira/refresh-uje konkretnu poziciju (npr. SELL flow iz GHI #199 trazi
+     * tacno ovu vrednost da bi otvorio Create Order formu).
+     */
+    private Long id;
+
+    /**
+     * Listing ID hartije za koju se drzi pozicija. Bez ovog polja, dugme
+     * ,,Prodaj'' u UI portfolija nema dovoljno podataka za rutu
+     * /orders/create/SELL/{listingId} (vidi GHI #199 - SELL forma se ne otvara).
+     */
+    private Long listingId;
+
     /** Type of security held: STOCK, FUTURES, FOREX, or OPTION. */
     private ListingType listingType;
 

--- a/order-service/src/main/java/com/banka1/order/dto/client/OneSidedTransactionDto.java
+++ b/order-service/src/main/java/com/banka1/order/dto/client/OneSidedTransactionDto.java
@@ -1,0 +1,25 @@
+package com.banka1.order.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * Order-service mirror DTO-a iz account-service-a za one-sided debit/credit
+ * trade-leg operaciju (GHI #199). Po PM direktivi, trade leg klijentskog BUY/SELL
+ * ne sme da prolazi kroz bankin racun - ovaj DTO se posle salje na
+ * {@code /internal/accounts/exchange/buy} (debit) ili {@code .../exchange/sell}
+ * (credit).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OneSidedTransactionDto {
+    private String accountNumber;
+    private Long accountId;
+    private BigDecimal amount;
+    private Long clientId;
+    private String description;
+}

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
@@ -8,7 +8,7 @@ import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.BankAccountDto;
 import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.StockListingDto;
-import com.banka1.order.dto.client.PaymentDto;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
 import com.banka1.order.entity.Portfolio;
@@ -347,19 +347,53 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
         }
     }
 
+    /**
+     * Trade leg novca po PM direktivi iz GHI #199: <em>,,NE DAJE BANCI PARE,
+     * samo se skidaju sa racuna''</em>. Ranije se klijentski BUY zvao
+     * {@code accountClient.transaction(...)} sa korisnikom kao {@code from} i
+     * bankom kao {@code to}, sto je celokupan iznos kupovine kreditiralo banci.
+     * Nova implementacija koristi jednostrane endpointe
+     * {@code /internal/accounts/exchange/buy} (debit) i {@code .../exchange/sell}
+     * (credit) tako da bankin racun ne menja stanje za trade iznos. Provizija
+     * (commission) je zasebna i ide kroz {@code OrderCreationServiceImpl.transferFee}.
+     */
     private void transferFunds(Order order, String currency, BigDecimal amount) {
         BankAccountDto bankAccount = employeeClient.getBankAccount(currency);
         boolean actuaryOrder = bankAccount.getAccountId() != null && bankAccount.getAccountId().equals(order.getAccountId());
-
-        if (order.getDirection() == OrderDirection.BUY) {
-            if (actuaryOrder) {
-                return;
-            }
-            transferForClient(order.getAccountId(), bankAccount.getAccountId(), amount, currency, "Order execution");
+        if (actuaryOrder) {
+            // Banka je vlasnik racuna - trade leg je no-op (banka kupuje sebi).
             return;
         }
 
-        transferWithoutConversionFee(bankAccount.getAccountId(), order.getAccountId(), amount, currency, "Order execution");
+        AccountDetailsDto userAccount = accountClient.getAccountDetails(order.getAccountId());
+        BigDecimal accountAmount = convertTradeAmountToAccountCurrency(userAccount, currency, amount);
+        OneSidedTransactionDto request = new OneSidedTransactionDto(
+                userAccount.getAccountNumber(),
+                order.getAccountId(),
+                accountAmount,
+                userAccount.getOwnerId(),
+                "Order execution trade leg (one-sided, GHI #199)"
+        );
+
+        if (order.getDirection() == OrderDirection.BUY) {
+            accountClient.exchangeBuy(request);
+        } else {
+            accountClient.exchangeSell(request);
+        }
+    }
+
+    /**
+     * Ako se valuta racuna razlikuje od valute hartije (cross-currency BUY/SELL),
+     * konvertujemo trade iznos u valutu racuna pre debit/credit operacije.
+     * Konverzija ide kroz exchange-service-ov {@code /exchange/calculate} i
+     * koristi prodajni kurs po Celini 5.
+     */
+    private BigDecimal convertTradeAmountToAccountCurrency(AccountDetailsDto userAccount, String tradeCurrency, BigDecimal tradeAmount) {
+        if (userAccount.getCurrency() == null || userAccount.getCurrency().equalsIgnoreCase(tradeCurrency)) {
+            return tradeAmount;
+        }
+        ExchangeRateDto conversion = exchangeClient.calculate(tradeCurrency, userAccount.getCurrency(), tradeAmount);
+        return conversion.getConvertedAmount() == null ? tradeAmount : conversion.getConvertedAmount();
     }
 
     private void finalizeActuaryExposure(Order order, String currency, BigDecimal amount) {
@@ -440,52 +474,6 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
         }
         ExchangeRateDto conversion = exchangeClient.calculateWithoutCommission(fromCurrency, toCurrency, amount);
         return conversion.getConvertedAmount() == null ? amount : conversion.getConvertedAmount();
-    }
-
-    private void transferWithoutConversionFee(Long fromAccountId, Long toAccountId, BigDecimal amount, String currency, String description) {
-        if (fromAccountId != null && fromAccountId.equals(toAccountId)) {
-            throw new IllegalStateException("Transfer source and destination must differ");
-        }
-        AccountDetailsDto fromAccount = accountClient.getAccountDetails(fromAccountId);
-        AccountDetailsDto toAccount = accountClient.getAccountDetails(toAccountId);
-        PaymentDto payment = new PaymentDto(
-                fromAccount.getAccountNumber(),
-                toAccount.getAccountNumber(),
-                amount,
-                amount,
-                BigDecimal.ZERO,
-                orderOwnerId(fromAccount)
-        );
-        // Route by ownership: account-service /transaction rejects same-owner pairs and /transfer
-        // rejects different-owner pairs. Settlement legs that move funds between two bank-owned
-        // accounts (e.g. bank's funding account to bank's commission account) must therefore go
-        // through /transfer, while client-to-bank settlements continue to use /transaction.
-        Long fromOwner = fromAccount.getOwnerId();
-        Long toOwner = toAccount.getOwnerId();
-        if (fromOwner != null && fromOwner.equals(toOwner)) {
-            accountClient.transfer(payment);
-            return;
-        }
-        accountClient.transaction(payment);
-    }
-
-    private void transferForClient(Long fromAccountId, Long toAccountId, BigDecimal amount, String currency, String description) {
-        AccountDetailsDto fromAccount = accountClient.getAccountDetails(fromAccountId);
-        if (fromAccount.getCurrency() == null || fromAccount.getCurrency().equalsIgnoreCase(currency)) {
-            transferWithoutConversionFee(fromAccountId, toAccountId, amount, currency, description);
-            return;
-        }
-
-        // Account currency differs from listing currency: convert the trade amount to the account's currency,
-        // then pay the bank account that matches the client's currency directly.
-        ExchangeRateDto conversion = exchangeClient.calculate(currency, fromAccount.getCurrency(), amount);
-        BigDecimal convertedAmount = conversion.getConvertedAmount() == null ? amount : conversion.getConvertedAmount();
-        BankAccountDto fromCurrencyBank = employeeClient.getBankAccount(fromAccount.getCurrency());
-        transferWithoutConversionFee(fromAccountId, fromCurrencyBank.getAccountId(), convertedAmount, fromAccount.getCurrency(), description);
-    }
-
-    private Long orderOwnerId(AccountDetailsDto account) {
-        return account.getOwnerId() == null ? 0L : account.getOwnerId();
     }
 
     private int defaultInteger(Integer value) {

--- a/order-service/src/main/java/com/banka1/order/service/impl/PortfolioServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/PortfolioServiceImpl.java
@@ -235,6 +235,9 @@ public class PortfolioServiceImpl implements PortfolioService {
 
         PortfolioResponse response = new PortfolioResponse();
 
+        // GHI #199: id i listingId su potrebni frontu za SELL navigation
+        response.setId(portfolio.getId());
+        response.setListingId(portfolio.getListingId());
         response.setListingType(portfolio.getListingType());
         response.setQuantity(portfolio.getQuantity());
         response.setPublicQuantity(portfolio.getPublicQuantity());


### PR DESCRIPTION
﻿# fix(#199): SELL forma se otvara iz portfolija + trade leg ne ide kroz banku

Closes #199. Branch: `feature/199-buy-sell-fix`.

GitHub Issue #199 (Mojović) prijavljuje dva primarna PM zahteva:

1. **SELL forma se ne otvara iz "Moj Portfolio".** Klik na "Prodaj" je no-op,
   bez navigacije, bez modala, bez ikakvog feedback-a.
2. **Trade leg novca ne sme kroz bankin račun.** PM eksplicitno:
   *"NE DAJE BANCI PARE, samo se skidaju sa racuna"*.

Plus tokom verifikacije live stack-a otkrivena je treća pumpana greška u
istom flow-u — `POST /order/orders/{id}/confirm` puca **HTTP 500** zbog
`accountId` koji je 32-bit hash umesto PK.

## Tri popravke

### Greška #1 — SELL dugme iz portfolija otvara Create Order u SELL modu

**Šta je bio problem:** `PortfolioResponse` DTO nije imao `listingId`, iako
entitet `Portfolio` to polje ima. Frontend `PortfolioHolding` model nije imao
listingId, pa lista holdings nije nosila informaciju potrebnu za navigaciju
ka rutu `/orders/create/SELL/{listingId}`. `onSell()` u `portfolio.component.ts`
bio je TODO stub. HTML dugme nije prosleđivalo holding kao parametar.

**Promene:**
- `order-service/PortfolioResponse.java`: dodato `Long id` + `Long listingId`.
- `order-service/PortfolioServiceImpl.mapToResponse(...)`: populira oba iz Portfolio entiteta.
- `frontend/PortfolioHolding`: dobija `listingId: number`.
- `frontend/portfolio.component.ts`: `onSell(holding)` poziva
  `router.navigate(['/orders/create','SELL',holding.listingId])`.
- `frontend/portfolio.component.html`: dugme prosleđuje holding kao parametar.

### Greška #2 — Trade leg ne kreditira/debituje bankin račun

**Šta je bio problem:** `OrderExecutionServiceImpl.transferFunds(...)` je za
klijentski BUY zvao `accountClient.transaction(...)` sa korisnikom kao
`from` i bankom kao `to` — **ceo iznos kupovine se kreditirao banci**
(npr. +276 USD po share-u AAPL), što direktno krši PM direktivu. Za SELL
simetrično: bank → korisnik.

**Promene:**
- `account-service`: dva nova interna endpointa
  - `POST /internal/accounts/exchange/buy` — debit korisničkog računa (BUY trade leg)
  - `POST /internal/accounts/exchange/sell` — credit korisničkog računa (SELL trade leg)
- Telo: novi `OneSidedTransactionDto(accountNumber, accountId, amount, clientId, description)`.
- `TransactionalService.withdrawOneSided(Account, BigDecimal)` + `depositOneSided(...)`
  — reuse-uju postojeće `debit`/`credit` primitive sa istim saldo/limit proverama.
- `order-service/AccountClient` + impl: `exchangeBuy(...)` + `exchangeSell(...)` metode.
- `order-service/OrderExecutionServiceImpl.transferFunds`: rewrite — bira
  `exchangeBuy` ili `exchangeSell` zavisno od smera, sa cuvanjem
  cross-currency konverzije (`convertTradeAmountToAccountCurrency`). Aktuarski
  BUY ostaje no-op (banka je vlasnik računa).
- Stari `transferForClient` + `transferWithoutConversionFee` + `orderOwnerId`
  uklonjeni — služili su isključivo trade legu kroz banku.

**Provizija (commission)** NIJE menjana — i dalje ide banci kroz postojeći
`OrderCreationServiceImpl.transferFee` (po Celini 3, sa ownership-aware
routing-om).

### Greška #9 — `POST /order/orders/{id}/confirm` puca 500 zbog hash-ovanog accountId

**Šta je bio problem:** `GET /accounts/client/accounts` vraća listu računa
kroz `AccountResponseDto`. Taj DTO **nije imao polje `id`** (samo `nazivRacuna`,
`brojRacuna`, `raspolozivoStanje`, `currency`, `accountCategory`, `accountType`,
`subtype`). Frontend mapper je zato fallback-ovao na
`hashAccountNumber(item.brojRacuna)` i generisao 32-bit pseudo-ID iz hash-a.
Ta vrednost (npr. `1270307794`) ne mapira ni na PK ni na `brojRacuna`. Create
Order forma je stavljala `accounts[0].id` u request body kao `accountId`,
order-service ga je čuvao u `orders.account_id`, a pri confirm-u je zvao
`/internal/accounts/id/{accountId}/details` koji vraća **404 → 500** u browseru.

**Promene:**
- `account-service/AccountResponseDto`: dodato `Long id` polje populirano
  iz `account.getId()`. Detaljan Javadoc objašnjava istorijski kontekst.
- `frontend/account.service.ts`: `mapToAccountFromClient` koristi `item.id`
  kada je broj, hash fallback samo defenzivno za stare backend deploy-eve.

**Operativno:** korisnici koji su već ulogovani **moraju logout + login** —
u njihovoj sesiji su kesirani stari hash-bazirani ID-evi.

## Test plan

- [x] `./gradlew :account-service:test` — BUILD SUCCESSFUL.
- [x] `./gradlew :order-service:test` — BUILD SUCCESSFUL.
- [x] `tsc -p tsconfig.app.json --noEmit` — clean.

## Šta NIJE u ovom PR-u

- Tax tracking portal screenshot — to je odvojen issue i traži samo "ovaj
  portal porez tracking moze samo SS" (komentar Hpro444 na #199).
- SELL "margine" računanje za Celinu 3 — Hpro444 najavljuje zaseban issue
  za to ("svakako pravim novi Issue da se istestira njegovo skroz pre merga").

## Promenjeni fajlovi (18)

```
Backend (13):
  M  order-service/.../dto/PortfolioResponse.java                        [#1]
  A  order-service/.../dto/client/OneSidedTransactionDto.java            [#2]
  M  order-service/.../service/impl/PortfolioServiceImpl.java            [#1]
  M  order-service/.../service/impl/OrderExecutionServiceImpl.java       [#2]
  M  order-service/.../client/AccountClient.java                         [#2]
  M  order-service/.../client/impl/AccountClientImpl.java                [#2]
  M  order-service/.../config/LocalStubClientsConfig.java                [#2]
  A  account-service/.../dto/request/OneSidedTransactionDto.java         [#2]
  M  account-service/.../controller/AccountController.java               [#2]
  M  account-service/.../service/AccountService.java                     [#2]
  M  account-service/.../service/TransactionalService.java               [#2]
  M  account-service/.../service/implementation/AccountServiceImplementation.java       [#2]
  M  account-service/.../service/implementation/TransactionalServiceImplementation.java [#2]

Frontend (5):
  M  src/app/features/client/components/portfolio/portfolio.component.ts    [#1]
  M  src/app/features/client/components/portfolio/portfolio.component.html  [#1]
  M  src/app/features/client/models/portfolio.model.ts                      [#1]
  M  src/app/features/client/services/account.service.ts                    [#9]
```

Legenda: A = added, M = modified. Tagovi `[#1] [#2] [#9]` mapiraju na popravke iznad.
