### PR TITLE
fix(#199): SELL trade leg, account-id propagation, balance check, actuary settlement

### DIFF
--- a/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
+++ b/account-service/src/main/java/com/banka1/account_service/controller/AccountController.java
@@ -4,6 +4,7 @@ import com.banka1.account_service.domain.enums.CurrencyCode;
 import com.banka1.account_service.dto.request.BankPaymentDto;
 import com.banka1.account_service.dto.request.CreditDebitAccountDto;
 import com.banka1.account_service.dto.request.CreditDebitBankDto;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 import com.banka1.account_service.dto.response.InfoResponseDto;
 import com.banka1.account_service.dto.response.InternalAccountDetailsDto;
@@ -56,6 +57,31 @@ public class AccountController {
     @PostMapping("/transaction")
     public ResponseEntity<UpdatedBalanceResponseDto> transaction(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid PaymentDto paymentDto) {
         return new ResponseEntity<>(accountService.transaction(paymentDto),HttpStatus.OK);
+    }
+
+    /**
+     * One-sided debit for the funds leg of an executed BUY exchange order.
+     * <p>The matching exchange-side counter-leg is external to this system, so
+     * routing the trade amount through a paired transfer to a bank account is
+     * incorrect: it would either spuriously credit the bank or fail same-owner
+     * validation when the order is placed on a bank-owned account. This endpoint
+     * debits only the targeted account; the regulatory commission still flows
+     * through the existing paired transfer path.
+     */
+    @PostMapping("/exchange/buy")
+    public ResponseEntity<UpdatedBalanceResponseDto> exchangeBuy(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid OneSidedTransactionDto request) {
+        return new ResponseEntity<>(accountService.exchangeBuy(request), HttpStatus.OK);
+    }
+
+    /**
+     * One-sided credit for the funds leg of an executed SELL exchange order.
+     * <p>Symmetric counterpart to {@link #exchangeBuy}: credits the targeted
+     * account directly with the trade proceeds without touching a paired
+     * counterparty account.
+     */
+    @PostMapping("/exchange/sell")
+    public ResponseEntity<UpdatedBalanceResponseDto> exchangeSell(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid OneSidedTransactionDto request) {
+        return new ResponseEntity<>(accountService.exchangeSell(request), HttpStatus.OK);
     }
 
 

--- a/account-service/src/main/java/com/banka1/account_service/dto/request/OneSidedTransactionDto.java
+++ b/account-service/src/main/java/com/banka1/account_service/dto/request/OneSidedTransactionDto.java
@@ -1,0 +1,47 @@
+package com.banka1.account_service.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * Request payload for a one-sided trade-leg debit/credit operation that
+ * targets a single account. Used by the order-service to settle the
+ * <em>trade leg</em> of a BUY or SELL exchange order.
+ *
+ * <p>Trade-leg funds for a non-bank account are deliberately not routed
+ * through a paired transfer to a bank account: the matching exchange-side
+ * counter-leg is external to the system, so a paired transfer would either
+ * spuriously credit/debit the bank or fail same-owner validation. Instead,
+ * the trade amount is debited (BUY) or credited (SELL) on the targeted
+ * account directly, while the regulatory commission continues to flow
+ * through the existing paired transfer path.
+ *
+ * <p>The endpoint accepts either {@code accountNumber} or {@code accountId}
+ * to keep older API clients working while migrating from the historic
+ * hash-derived numeric identifier to the persistent primary key.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OneSidedTransactionDto {
+
+    /** 18-digit account number; service accepts either this or {@link #accountId}. */
+    private String accountNumber;
+
+    /** Database primary key of the account. Alternative to {@link #accountNumber}. */
+    private Long accountId;
+
+    /** Amount to debit/credit. Must be strictly positive. */
+    private BigDecimal amount;
+
+    /** Initiating party identifier (audit/log only). */
+    private Long clientId;
+
+    /** Free-form description for audit logs. */
+    private String description;
+}

--- a/account-service/src/main/java/com/banka1/account_service/service/AccountService.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/AccountService.java
@@ -3,6 +3,7 @@ package com.banka1.account_service.service;
 import com.banka1.account_service.dto.request.BankPaymentDto;
 import com.banka1.account_service.dto.request.CreditDebitAccountDto;
 import com.banka1.account_service.dto.request.CreditDebitBankDto;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 
 import com.banka1.account_service.domain.enums.CurrencyCode;
@@ -42,6 +43,25 @@ public interface AccountService {
 
 
     void transactionFromBank(BankPaymentDto paymentDto);
+
+    /**
+     * Executes the funds leg of an exchange BUY order as a single-side debit
+     * on the targeted account. The exchange counter-leg is external to the
+     * system, so no paired transfer is created here.
+     *
+     * @param request payload identifying the account and trade amount
+     * @return updated balance after debit
+     */
+    UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request);
+
+    /**
+     * Executes the funds leg of an exchange SELL order as a single-side credit
+     * on the targeted account. Symmetric counterpart to {@link #exchangeBuy}.
+     *
+     * @param request payload identifying the account and trade proceeds
+     * @return updated balance after credit
+     */
+    UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request);
 
     /**
      * Izvrsava transfer izmedju dva racuna istog vlasnika.

--- a/account-service/src/main/java/com/banka1/account_service/service/TransactionalService.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/TransactionalService.java
@@ -43,4 +43,27 @@ public interface TransactionalService {
     void debitTransactional(Account account, BigDecimal amount);
 
 
+    /**
+     * Single-side debit on a single account, used to settle the funds leg of a
+     * BUY exchange order. Reuses the same balance/limit primitives as
+     * {@link #debitTransactional(Account, BigDecimal)}; no counterparty leg is
+     * generated.
+     *
+     * @param account account to debit
+     * @param amount  positive amount to debit
+     */
+    void withdrawOneSided(Account account, BigDecimal amount);
+
+
+    /**
+     * Single-side credit on a single account, used to settle the funds leg of a
+     * SELL exchange order. Symmetric counterpart to
+     * {@link #withdrawOneSided(Account, BigDecimal)}.
+     *
+     * @param account account to credit
+     * @param amount  positive amount to credit
+     */
+    void depositOneSided(Account account, BigDecimal amount);
+
+
 }

--- a/account-service/src/main/java/com/banka1/account_service/service/implementation/AccountServiceImplementation.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/implementation/AccountServiceImplementation.java
@@ -7,6 +7,7 @@ import com.banka1.account_service.domain.enums.Status;
 import com.banka1.account_service.dto.request.BankPaymentDto;
 import com.banka1.account_service.dto.request.CreditDebitAccountDto;
 import com.banka1.account_service.dto.request.CreditDebitBankDto;
+import com.banka1.account_service.dto.request.OneSidedTransactionDto;
 import com.banka1.account_service.dto.request.PaymentDto;
 import com.banka1.account_service.dto.response.InfoResponseDto;
 import com.banka1.account_service.dto.response.InternalAccountDetailsDto;
@@ -276,6 +277,52 @@ public class AccountServiceImplementation implements AccountService {
         if (account == null)
             throw new NoSuchElementException("Ne postoji interni bankovni racun za valutu:" + currencyCode);
         return InternalAccountDetailsDto.from(account);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request) {
+        Account account = resolveAccountForOneSided(request);
+        if (request.getAmount() == null || request.getAmount().signum() <= 0) {
+            throw new IllegalArgumentException("Iznos mora biti pozitivan");
+        }
+        transactionalService.withdrawOneSided(account, request.getAmount());
+        return new UpdatedBalanceResponseDto(account.getRaspolozivoStanje(), null);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request) {
+        Account account = resolveAccountForOneSided(request);
+        if (request.getAmount() == null || request.getAmount().signum() <= 0) {
+            throw new IllegalArgumentException("Iznos mora biti pozitivan");
+        }
+        transactionalService.depositOneSided(account, request.getAmount());
+        return new UpdatedBalanceResponseDto(account.getRaspolozivoStanje(), null);
+    }
+
+    /**
+     * Resolves the target account from a {@link OneSidedTransactionDto}: prefers
+     * {@code accountNumber} (validated through the same path as paired
+     * transactions) and falls back to {@code accountId} so callers that already
+     * hold the database primary key avoid a redundant lookup. Both branches
+     * apply the same active/non-expired account checks.
+     */
+    private Account resolveAccountForOneSided(OneSidedTransactionDto request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Request ne sme biti null");
+        }
+        if (request.getAccountNumber() != null && !request.getAccountNumber().isBlank()) {
+            return validate(request.getAccountNumber());
+        }
+        if (request.getAccountId() != null) {
+            Account account = accountRepository.findById(request.getAccountId()).orElseThrow(
+                    () -> new IllegalArgumentException("Ne postoji racun za id:" + request.getAccountId()));
+            if (account.getStatus() == Status.INACTIVE)
+                throw new IllegalArgumentException("Racun je neaktivan:" + account.getBrojRacuna());
+            if (account.getDatumIsteka() != null && account.getDatumIsteka().isBefore(LocalDate.now()))
+                throw new IllegalArgumentException("Racun je istekao:" + account.getBrojRacuna());
+            return account;
+        }
+        throw new IllegalArgumentException("OneSidedTransactionDto mora imati accountNumber ili accountId");
     }
 
     @Override

--- a/account-service/src/main/java/com/banka1/account_service/service/implementation/TransactionalServiceImplementation.java
+++ b/account-service/src/main/java/com/banka1/account_service/service/implementation/TransactionalServiceImplementation.java
@@ -125,5 +125,20 @@ public class TransactionalServiceImplementation implements TransactionalService 
       debit(account,amount);
     }
 
+    @Transactional
+    @Override
+    public void withdrawOneSided(Account account, BigDecimal amount) {
+        // Reuses the validated debit primitive (balance + daily/monthly limit
+        // checks) without generating a paired counterparty leg: the matching
+        // exchange-side leg is external to this system.
+        debit(account, amount);
+    }
+
+    @Transactional
+    @Override
+    public void depositOneSided(Account account, BigDecimal amount) {
+        credit(account, amount);
+    }
+
 
 }

--- a/order-service/src/main/java/com/banka1/order/client/AccountClient.java
+++ b/order-service/src/main/java/com/banka1/order/client/AccountClient.java
@@ -2,6 +2,7 @@ package com.banka1.order.client;
 
 import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.AccountTransactionRequest;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 
@@ -72,4 +73,18 @@ public interface AccountClient {
      * @return updated balances after the transfer
      */
     UpdatedBalanceResponseDto transaction(PaymentDto payment);
+
+    /**
+     * Single-side debit on the funding account for the BUY trade leg of an
+     * exchange order. The matching exchange-side counter-leg is external to
+     * this system, so a paired transfer to a bank account is intentionally
+     * not produced here.
+     */
+    UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request);
+
+    /**
+     * Single-side credit on the funding account for the SELL trade leg of an
+     * exchange order. Symmetric counterpart to {@link #exchangeBuy}.
+     */
+    UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request);
 }

--- a/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
+++ b/order-service/src/main/java/com/banka1/order/client/impl/AccountClientImpl.java
@@ -3,6 +3,7 @@ package com.banka1.order.client.impl;
 import com.banka1.order.client.AccountClient;
 import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.AccountTransactionRequest;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -89,6 +90,24 @@ public class AccountClientImpl implements AccountClient {
     @Override
     public UpdatedBalanceResponseDto transaction(PaymentDto payment) {
         return postTransaction(payment).body(UpdatedBalanceResponseDto.class);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request) {
+        return accountRestClient.post()
+                .uri("/internal/accounts/exchange/buy")
+                .body(request)
+                .retrieve()
+                .body(UpdatedBalanceResponseDto.class);
+    }
+
+    @Override
+    public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request) {
+        return accountRestClient.post()
+                .uri("/internal/accounts/exchange/sell")
+                .body(request)
+                .retrieve()
+                .body(UpdatedBalanceResponseDto.class);
     }
 
     private RestClient.ResponseSpec postTransaction(Object payload) {

--- a/order-service/src/main/java/com/banka1/order/config/LocalStubClientsConfig.java
+++ b/order-service/src/main/java/com/banka1/order/config/LocalStubClientsConfig.java
@@ -16,6 +16,7 @@ import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.ExchangeStatusDto;
 import com.banka1.order.dto.StockExchangeDto;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.dto.response.UpdatedBalanceResponseDto;
 import com.banka1.order.entity.enums.ListingType;
@@ -62,6 +63,16 @@ class LocalStubClientsConfig {
 
             @Override
             public UpdatedBalanceResponseDto transaction(PaymentDto payment) {
+                return null;
+            }
+
+            @Override
+            public UpdatedBalanceResponseDto exchangeBuy(OneSidedTransactionDto request) {
+                return null;
+            }
+
+            @Override
+            public UpdatedBalanceResponseDto exchangeSell(OneSidedTransactionDto request) {
                 return null;
             }
 

--- a/order-service/src/main/java/com/banka1/order/dto/PortfolioResponse.java
+++ b/order-service/src/main/java/com/banka1/order/dto/PortfolioResponse.java
@@ -29,6 +29,22 @@ import java.time.LocalDateTime;
 @Data
 public class PortfolioResponse {
 
+    /**
+     * Database primary key of the Portfolio entity. Required by the frontend
+     * to address a specific position (e.g. exercising an option, setting a
+     * public OTC quantity, or initiating a SELL flow that needs to identify
+     * the exact holding row).
+     */
+    private Long id;
+
+    /**
+     * Listing identifier of the underlying security. Without this field the
+     * portfolio list does not carry enough information to navigate to a
+     * direction-specific Create Order route, which is the entry point for
+     * selling a held position.
+     */
+    private Long listingId;
+
     /** Type of security held: STOCK, FUTURES, FOREX, or OPTION. */
     private ListingType listingType;
 

--- a/order-service/src/main/java/com/banka1/order/dto/client/OneSidedTransactionDto.java
+++ b/order-service/src/main/java/com/banka1/order/dto/client/OneSidedTransactionDto.java
@@ -1,0 +1,24 @@
+package com.banka1.order.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * Order-service mirror of the account-service request DTO for a one-sided
+ * trade-leg debit/credit operation. Sent to {@code /internal/accounts/exchange/buy}
+ * (debit) or {@code /internal/accounts/exchange/sell} (credit) when settling
+ * the funds leg of an executed exchange order.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OneSidedTransactionDto {
+    private String accountNumber;
+    private Long accountId;
+    private BigDecimal amount;
+    private Long clientId;
+    private String description;
+}

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
@@ -231,13 +231,19 @@ public class OrderCreationServiceImpl implements OrderCreationService {
         Long fundingAccountId = user.isClient()
                 ? order.getAccountId()
                 : determineFundingAccountId(user.userId(), order.getAccountId(), listing.getCurrency());
-        if (order.getDirection() == OrderDirection.BUY && !user.isClient()) {
+        if (!user.isClient()) {
+            // Both BUY and SELL legs of a non-client order must settle against
+            // the resolved funding account. Earlier revisions only synchronised
+            // BUY, leaving SELL with whatever the form submitted (potentially
+            // null when the dropdown defaulted via auto-fill instead of an
+            // explicit selection); the executor then stalled the order on a
+            // missing or stale account identifier.
             order.setAccountId(fundingAccountId);
         }
         if (Boolean.TRUE.equals(order.getMargin())) {
             checkMarginRequirements(user, fundingAccountId, listing, order.getQuantity());
         } else if (order.getDirection() == OrderDirection.BUY) {
-            checkFunds(fundingAccountId, approximatePrice.add(fee));
+            checkFunds(fundingAccountId, approximatePrice.add(fee), listing.getCurrency());
         }
         ApprovalReservationDecision decision = user.isClient()
                 ? new ApprovalReservationDecision(OrderStatus.APPROVED, BigDecimal.ZERO)
@@ -310,10 +316,15 @@ public class OrderCreationServiceImpl implements OrderCreationService {
                 order.getQuantity(), order.getLimitValue(), order.getStopValue());
         BigDecimal fee = calculateFee(orderPricingFamily(order.getOrderType()), approximatePrice, listing.getCurrency());
         Long fundingAccountId = determineFundingAccountId(order.getUserId(), order.getAccountId(), listing.getCurrency());
+        // Lock the order's funding account to the resolved value (actuary
+        // orders always settle against the bank account regardless of the
+        // form selection) so the executor never reaches an inconsistent or
+        // missing account identifier.
+        order.setAccountId(fundingAccountId);
         transferFee(order.getUserId(), fundingAccountId, fee, listing.getCurrency());
 
         if (order.getDirection() == OrderDirection.BUY && !Boolean.TRUE.equals(order.getMargin())) {
-            checkFunds(fundingAccountId, approximatePrice);
+            checkFunds(fundingAccountId, approximatePrice, listing.getCurrency());
         }
 
         // See note in confirmOrder — keep ask/volume current so the async executor can fill.
@@ -587,10 +598,20 @@ public class OrderCreationServiceImpl implements OrderCreationService {
         }
     }
 
-    private void checkFunds(Long accountId, BigDecimal totalAmount) {
+    private void checkFunds(Long accountId, BigDecimal totalAmount, String tradeCurrency) {
         AccountDetailsDto account = accountClient.getAccountDetails(accountId);
         BigDecimal balance = account.getBalance() == null ? BigDecimal.ZERO : account.getBalance();
-        if (balance.compareTo(totalAmount) < 0) {
+        // Trade amounts are denominated in the listing's currency, while the
+        // funding account's balance is denominated in the account's currency.
+        // Comparing them numerically without conversion (legacy behaviour)
+        // approved orders that the executor could not subsequently settle,
+        // leaving them stuck in APPROVED while retrying the debit forever.
+        BigDecimal balanceCheckAmount = totalAmount;
+        String accountCurrency = account.getCurrency();
+        if (tradeCurrency != null && accountCurrency != null && !accountCurrency.equalsIgnoreCase(tradeCurrency)) {
+            balanceCheckAmount = convertAmount(tradeCurrency, accountCurrency, totalAmount);
+        }
+        if (balance.compareTo(balanceCheckAmount) < 0) {
             throw new BusinessConflictException("Insufficient funds");
         }
     }

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
@@ -8,7 +8,7 @@ import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.BankAccountDto;
 import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.StockListingDto;
-import com.banka1.order.dto.client.PaymentDto;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
 import com.banka1.order.entity.Portfolio;
@@ -347,19 +347,54 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
         }
     }
 
+    /**
+     * Settles the funds leg of an executed order against the order's funding
+     * account. The matching exchange-side counter-leg is external to this
+     * system, so the trade amount is moved with a single-side debit (BUY) or
+     * credit (SELL) on the targeted account; no paired transfer is generated.
+     *
+     * <p>Earlier revisions short-circuited this leg whenever the funding
+     * account was bank-owned, which silently skipped balance updates for
+     * supervisor/actuary trades. The bank's account participates in the trade
+     * just like any other funding account — the off-book counter-leg is the
+     * exchange — so the same one-sided debit/credit applies regardless of
+     * ownership.
+     *
+     * <p>If the trade currency differs from the funding-account currency, the
+     * amount is converted before settlement so the debit/credit lands in the
+     * correct denomination.
+     */
     private void transferFunds(Order order, String currency, BigDecimal amount) {
-        BankAccountDto bankAccount = employeeClient.getBankAccount(currency);
-        boolean actuaryOrder = bankAccount.getAccountId() != null && bankAccount.getAccountId().equals(order.getAccountId());
+        AccountDetailsDto userAccount = accountClient.getAccountDetails(order.getAccountId());
+        BigDecimal accountAmount = convertTradeAmountToAccountCurrency(userAccount, currency, amount);
+        OneSidedTransactionDto request = new OneSidedTransactionDto(
+                userAccount.getAccountNumber(),
+                order.getAccountId(),
+                accountAmount,
+                userAccount.getOwnerId(),
+                "Order execution trade leg"
+        );
 
         if (order.getDirection() == OrderDirection.BUY) {
-            if (actuaryOrder) {
-                return;
-            }
-            transferForClient(order.getAccountId(), bankAccount.getAccountId(), amount, currency, "Order execution");
-            return;
+            accountClient.exchangeBuy(request);
+        } else {
+            accountClient.exchangeSell(request);
         }
+    }
 
-        transferWithoutConversionFee(bankAccount.getAccountId(), order.getAccountId(), amount, currency, "Order execution");
+    /**
+     * Converts the trade amount into the funding-account's currency when the
+     * two differ. The conversion uses the standard exchange-service
+     * calculation (sell rate, including conversion commission) so the amount
+     * landed by {@link #transferFunds} matches what the front-end and approval
+     * flow showed to the user.
+     */
+    private BigDecimal convertTradeAmountToAccountCurrency(AccountDetailsDto userAccount, String tradeCurrency, BigDecimal tradeAmount) {
+        if (userAccount.getCurrency() == null || userAccount.getCurrency().equalsIgnoreCase(tradeCurrency)) {
+            return tradeAmount;
+        }
+        ExchangeRateDto conversion = exchangeClient.calculate(tradeCurrency, userAccount.getCurrency(), tradeAmount);
+        return conversion.getConvertedAmount() == null ? tradeAmount : conversion.getConvertedAmount();
     }
 
     private void finalizeActuaryExposure(Order order, String currency, BigDecimal amount) {
@@ -440,52 +475,6 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
         }
         ExchangeRateDto conversion = exchangeClient.calculateWithoutCommission(fromCurrency, toCurrency, amount);
         return conversion.getConvertedAmount() == null ? amount : conversion.getConvertedAmount();
-    }
-
-    private void transferWithoutConversionFee(Long fromAccountId, Long toAccountId, BigDecimal amount, String currency, String description) {
-        if (fromAccountId != null && fromAccountId.equals(toAccountId)) {
-            throw new IllegalStateException("Transfer source and destination must differ");
-        }
-        AccountDetailsDto fromAccount = accountClient.getAccountDetails(fromAccountId);
-        AccountDetailsDto toAccount = accountClient.getAccountDetails(toAccountId);
-        PaymentDto payment = new PaymentDto(
-                fromAccount.getAccountNumber(),
-                toAccount.getAccountNumber(),
-                amount,
-                amount,
-                BigDecimal.ZERO,
-                orderOwnerId(fromAccount)
-        );
-        // Route by ownership: account-service /transaction rejects same-owner pairs and /transfer
-        // rejects different-owner pairs. Settlement legs that move funds between two bank-owned
-        // accounts (e.g. bank's funding account to bank's commission account) must therefore go
-        // through /transfer, while client-to-bank settlements continue to use /transaction.
-        Long fromOwner = fromAccount.getOwnerId();
-        Long toOwner = toAccount.getOwnerId();
-        if (fromOwner != null && fromOwner.equals(toOwner)) {
-            accountClient.transfer(payment);
-            return;
-        }
-        accountClient.transaction(payment);
-    }
-
-    private void transferForClient(Long fromAccountId, Long toAccountId, BigDecimal amount, String currency, String description) {
-        AccountDetailsDto fromAccount = accountClient.getAccountDetails(fromAccountId);
-        if (fromAccount.getCurrency() == null || fromAccount.getCurrency().equalsIgnoreCase(currency)) {
-            transferWithoutConversionFee(fromAccountId, toAccountId, amount, currency, description);
-            return;
-        }
-
-        // Account currency differs from listing currency: convert the trade amount to the account's currency,
-        // then pay the bank account that matches the client's currency directly.
-        ExchangeRateDto conversion = exchangeClient.calculate(currency, fromAccount.getCurrency(), amount);
-        BigDecimal convertedAmount = conversion.getConvertedAmount() == null ? amount : conversion.getConvertedAmount();
-        BankAccountDto fromCurrencyBank = employeeClient.getBankAccount(fromAccount.getCurrency());
-        transferWithoutConversionFee(fromAccountId, fromCurrencyBank.getAccountId(), convertedAmount, fromAccount.getCurrency(), description);
-    }
-
-    private Long orderOwnerId(AccountDetailsDto account) {
-        return account.getOwnerId() == null ? 0L : account.getOwnerId();
     }
 
     private int defaultInteger(Integer value) {

--- a/order-service/src/main/java/com/banka1/order/service/impl/PortfolioServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/PortfolioServiceImpl.java
@@ -235,6 +235,11 @@ public class PortfolioServiceImpl implements PortfolioService {
 
         PortfolioResponse response = new PortfolioResponse();
 
+        // id and listingId are required by the frontend to address the holding
+        // unambiguously (exercise/public-quantity actions and the SELL flow
+        // navigate by these values).
+        response.setId(portfolio.getId());
+        response.setListingId(portfolio.getListingId());
         response.setListingType(portfolio.getListingType());
         response.setQuantity(portfolio.getQuantity());
         response.setPublicQuantity(portfolio.getPublicQuantity());

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
@@ -8,6 +8,7 @@ import com.banka1.order.dto.AccountDetailsDto;
 import com.banka1.order.dto.BankAccountDto;
 import com.banka1.order.dto.ExchangeRateDto;
 import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.dto.client.OneSidedTransactionDto;
 import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
@@ -203,10 +204,14 @@ class OrderExecutionServiceTest {
         assertThat(transactionCaptor.getValue().getPricePerUnit()).isEqualByComparingTo("101.00");
         assertThat(transactionCaptor.getValue().getTotalPrice()).isEqualByComparingTo("202.00");
 
-        ArgumentCaptor<PaymentDto> transferCaptor = ArgumentCaptor.forClass(PaymentDto.class);
-        verify(accountClient).transaction(transferCaptor.capture());
-        assertThat(transferCaptor.getValue().getFromAccountNumber()).isEqualTo("1110001400000000221");
-        assertThat(transferCaptor.getValue().getToAccountNumber()).isEqualTo("1110001000000000023");
+        // BUY trade leg is settled with a single-side debit on the funding
+        // account; no paired transfer to a bank account is generated.
+        ArgumentCaptor<OneSidedTransactionDto> transferCaptor = ArgumentCaptor.forClass(OneSidedTransactionDto.class);
+        verify(accountClient).exchangeBuy(transferCaptor.capture());
+        assertThat(transferCaptor.getValue().getAccountNumber()).isEqualTo("1110001400000000221");
+        assertThat(transferCaptor.getValue().getAccountId()).isEqualTo(5L);
+        assertThat(transferCaptor.getValue().getAmount()).isEqualByComparingTo("202.00");
+        verify(accountClient, never()).transaction(any(PaymentDto.class));
         assertThat(order.getStatus()).isEqualTo(OrderStatus.DONE);
         assertThat(order.getIsDone()).isTrue();
     }
@@ -265,7 +270,7 @@ class OrderExecutionServiceTest {
 
         assertThat(staleOrder.getRemainingPortions()).isEqualTo(5);
         assertThat(lockedOrder.getRemainingPortions()).isZero();
-        verify(accountClient).transaction(any(PaymentDto.class));
+        verify(accountClient).exchangeBuy(any(OneSidedTransactionDto.class));
         verify(transactionRepository).save(any(Transaction.class));
     }
 
@@ -376,10 +381,13 @@ class OrderExecutionServiceTest {
         service.executeOrderPortion(order);
 
         verify(portfolioRepository, atLeastOnce()).save(portfolio);
-        ArgumentCaptor<PaymentDto> captor = ArgumentCaptor.forClass(PaymentDto.class);
-        verify(accountClient).transaction(captor.capture());
-        assertThat(captor.getValue().getFromAccountNumber()).isEqualTo("1110001000000000023");
-        assertThat(captor.getValue().getToAccountNumber()).isEqualTo("1110001400000000221");
+        // SELL trade leg is settled with a single-side credit on the funding
+        // account; no paired transfer from a bank account is generated.
+        ArgumentCaptor<OneSidedTransactionDto> captor = ArgumentCaptor.forClass(OneSidedTransactionDto.class);
+        verify(accountClient).exchangeSell(captor.capture());
+        assertThat(captor.getValue().getAccountNumber()).isEqualTo("1110001400000000221");
+        assertThat(captor.getValue().getAccountId()).isEqualTo(5L);
+        verify(accountClient, never()).transaction(any(PaymentDto.class));
     }
 
     @Test
@@ -394,11 +402,25 @@ class OrderExecutionServiceTest {
     }
 
     @Test
-    void actuaryBuy_isBankFundedWithoutUserTransfer() {
-        order.setAccountId(bankAccount.getAccountId()); // actuary buys are funded from bank account
+    void actuaryBuy_debitsBankFundingAccountWithSingleSideTradeLeg() {
+        // Bank-owned funding account participates in the trade like any other
+        // funding account: the matching counter-leg is the external exchange,
+        // so the trade amount is debited on the bank account directly. Earlier
+        // revisions short-circuited this leg, leaving bank balances unchanged
+        // for actuary trades.
+        order.setAccountId(bankAccount.getAccountId());
+        AccountDetailsDto bankFunding = new AccountDetailsDto();
+        bankFunding.setAccountNumber("1110001000000000023");
+        bankFunding.setCurrency("USD");
+        bankFunding.setOwnerId(-1L);
+        when(accountClient.getAccountDetails(bankAccount.getAccountId())).thenReturn(bankFunding);
 
         service.executeOrderPortion(order);
 
+        ArgumentCaptor<OneSidedTransactionDto> captor = ArgumentCaptor.forClass(OneSidedTransactionDto.class);
+        verify(accountClient).exchangeBuy(captor.capture());
+        assertThat(captor.getValue().getAccountNumber()).isEqualTo("1110001000000000023");
+        assertThat(captor.getValue().getAccountId()).isEqualTo(bankAccount.getAccountId());
         verify(accountClient, never()).transaction(any(PaymentDto.class));
     }
 


### PR DESCRIPTION
## Sazеtak

Pull request resava cetiri medusobno povezane regresije u tokovima kreiranja,
potvrdivanja i izvrsenja ordera koje su prijavljene tokom verifikacije:

1. Klijentski BUY ostaje u statusu `APPROVED` i nikad ne odlazi u `DONE`.
2. Ne-klijentski (supervizorski/aktuarski) SELL bez eksplicitno odabranog
   racuna ostaje u `PENDING_CONFIRMATION` i ne napreduje.
3. Stanje USD/EUR racuna banke ostaje nepromenjeno nakon supervizorskog
   BUY/SELL -- debit/credit za trade leg jednostavno ne ulazi u knjizenje.
4. Trade leg klijentskog BUY/SELL nije smeo da prolazi kroz bankin racun.

## Promene

### account-service

- Novi DTO `OneSidedTransactionDto` za jednostranu (debit ili credit)
  operaciju nad jednim racunom; prihvata broj racuna ili PK i ne zahteva
  parnu kontra-stranu.
- Novi interni endpointi `POST /internal/accounts/exchange/buy` i
  `POST /internal/accounts/exchange/sell` koji izvrsavaju debit odnosno
  credit nad ciljanim racunom. Reuse-uju postojece balance/limit primitive
  (`debit` / `credit`) i SERVICE rolu.

### order-service

- Klijentski mirror `OneSidedTransactionDto` u `dto/client`.
- `AccountClient.exchangeBuy` / `.exchangeSell`.
- `OrderExecutionServiceImpl.transferFunds` prepisan: trade leg uvek ide
  kao jednostrana operacija nad funding racunom. Bank-owned funding racuni
  ucestvuju jednako -- ranija precica koja je za njih kratko-spajala leg
  uklonjena je.
- `convertTradeAmountToAccountCurrency` helper za cross-currency BUY/SELL.
- `confirmOrder` i `approveOrder` postavljaju `order.accountId` za sve
  ne-klijentske ordere (BUY i SELL).
- `checkFunds` konvertuje trade iznos u valutu racuna pre poredenja sa
  saldom. Bez ovoga cross-currency BUY je prolazio proveru i zaglavljivao
  se u APPROVED retry petlji.
- `PortfolioResponse` dobija `id` i `listingId`.
- Stub klijent u `local` profilu implementira nove metode kao no-op.
- `OrderExecutionServiceTest` azuriran da odrazava novu semantiku.

## Veza ka odbojnostima

| Prijava | Korenski uzrok | Ispravka |
|---------|----------------|----------|
| Klijentski BUY zaglavljen u `APPROVED` | `checkFunds` ne vrsi konverziju trade iznosa u valutu racuna | Konverzija u `checkFunds` |
| Ne-klijentski SELL zaglavljen u `PENDING_CONFIRMATION` | `confirmOrder` sinhronizovao `accountId` samo za BUY | Simetricno postavljanje za BUY i SELL |
| Bank USD/EUR balans nepromenjen za supervizorski trade | `transferFunds` rano izlazio za bank-owned funding | Uklonjena precica; jednostrani trade leg za sve funding racune |
| Trade leg ne sme kroz bankin racun | Stari `transferFunds` kreditirao banci | Novi jednostrani endpointi i prepisan `transferFunds` |