### PR TITLE
Portal Profit Banke #236

### DIFF
--- a/order-service/src/main/java/com/banka1/order/client/ExchangeClient.java
+++ b/order-service/src/main/java/com/banka1/order/client/ExchangeClient.java
@@ -3,6 +3,7 @@ package com.banka1.order.client;
 import com.banka1.order.dto.ExchangeRateDto;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 /**
  * Client interface for communicating with the exchange-service.
@@ -30,4 +31,17 @@ public interface ExchangeClient {
      * @return conversion result for commission-free internal flows
      */
     ExchangeRateDto calculateWithoutCommission(String fromCurrency, String toCurrency, BigDecimal amount);
+
+    /**
+     * Calculates commission-free conversion using the exchange rate valid on a specific date.
+     *
+     * @param fromCurrency source currency code
+     * @param toCurrency   target currency code
+     * @param amount       the amount to convert
+     * @param date         exchange-rate date
+     * @return conversion result for commission-free internal flows
+     */
+    default ExchangeRateDto calculateWithoutCommission(String fromCurrency, String toCurrency, BigDecimal amount, LocalDate date) {
+        return calculateWithoutCommission(fromCurrency, toCurrency, amount);
+    }
 }

--- a/order-service/src/main/java/com/banka1/order/client/impl/ExchangeClientImpl.java
+++ b/order-service/src/main/java/com/banka1/order/client/impl/ExchangeClientImpl.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
 
 /**
  * RestClient-based implementation of {@link ExchangeClient}.
@@ -40,12 +42,18 @@ public class ExchangeClientImpl implements ExchangeClient {
 
     @Override
     public ExchangeRateDto calculateWithoutCommission(String fromCurrency, String toCurrency, BigDecimal amount) {
+        return calculateWithoutCommission(fromCurrency, toCurrency, amount, null);
+    }
+
+    @Override
+    public ExchangeRateDto calculateWithoutCommission(String fromCurrency, String toCurrency, BigDecimal amount, LocalDate date) {
         return exchangeRestClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/internal/calculate/no-commission")
                         .queryParam("fromCurrency", fromCurrency)
                         .queryParam("toCurrency", toCurrency)
                         .queryParam("amount", amount)
+                        .queryParamIfPresent("date", Optional.ofNullable(date))
                         .build())
                 .retrieve()
                 .body(ExchangeRateDto.class);

--- a/order-service/src/main/java/com/banka1/order/controller/BankProfitController.java
+++ b/order-service/src/main/java/com/banka1/order/controller/BankProfitController.java
@@ -1,0 +1,26 @@
+package com.banka1.order.controller;
+
+import com.banka1.order.dto.ActuaryProfitResponse;
+import com.banka1.order.service.BankProfitService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/bank-profit")
+@RequiredArgsConstructor
+public class BankProfitController {
+
+    private final BankProfitService bankProfitService;
+
+    @GetMapping("/actuaries")
+    @PreAuthorize("hasRole('SUPERVISOR')")
+    public ResponseEntity<List<ActuaryProfitResponse>> getActuaryProfits() {
+        return ResponseEntity.ok(bankProfitService.getActuaryProfits());
+    }
+}

--- a/order-service/src/main/java/com/banka1/order/dto/ActuaryProfitResponse.java
+++ b/order-service/src/main/java/com/banka1/order/dto/ActuaryProfitResponse.java
@@ -1,0 +1,12 @@
+package com.banka1.order.dto;
+
+import java.math.BigDecimal;
+
+public record ActuaryProfitResponse(
+        Long id,
+        String ime,
+        String prezime,
+        String role,
+        BigDecimal totalProfitRsd
+) {
+}

--- a/order-service/src/main/java/com/banka1/order/entity/ActuaryProfitRollup.java
+++ b/order-service/src/main/java/com/banka1/order/entity/ActuaryProfitRollup.java
@@ -1,0 +1,39 @@
+package com.banka1.order.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "actuary_profit_rollup")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ActuaryProfitRollup {
+
+    @Id
+    @Column(name = "employee_id")
+    private Long employeeId;
+
+    @Column(nullable = false)
+    private String ime;
+
+    @Column(nullable = false)
+    private String prezime;
+
+    @Column(nullable = false, length = 16)
+    private String role;
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal totalProfitRsd = BigDecimal.ZERO;
+
+    @Column(nullable = false)
+    private LocalDateTime refreshedAt;
+}

--- a/order-service/src/main/java/com/banka1/order/repository/ActuaryProfitRollupRepository.java
+++ b/order-service/src/main/java/com/banka1/order/repository/ActuaryProfitRollupRepository.java
@@ -1,0 +1,13 @@
+package com.banka1.order.repository;
+
+import com.banka1.order.entity.ActuaryProfitRollup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ActuaryProfitRollupRepository extends JpaRepository<ActuaryProfitRollup, Long> {
+
+    List<ActuaryProfitRollup> findAllByOrderByEmployeeIdAsc();
+}

--- a/order-service/src/main/java/com/banka1/order/repository/TransactionRepository.java
+++ b/order-service/src/main/java/com/banka1/order/repository/TransactionRepository.java
@@ -22,6 +22,8 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
      */
     List<Transaction> findByOrderId(Long orderId);
 
+    List<Transaction> findByOrderIdIn(Collection<Long> orderIds);
+
     /**
      * Returns transactions executed between two timestamps (inclusive start, exclusive end).
      * Useful for monthly tax calculation.

--- a/order-service/src/main/java/com/banka1/order/scheduler/ActuaryProfitRollupScheduler.java
+++ b/order-service/src/main/java/com/banka1/order/scheduler/ActuaryProfitRollupScheduler.java
@@ -1,0 +1,24 @@
+package com.banka1.order.scheduler;
+
+import com.banka1.order.service.BankProfitService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ActuaryProfitRollupScheduler {
+
+    private final BankProfitService bankProfitService;
+
+    @Scheduled(
+            fixedDelayString = "${bank-profit.actuary-rollup-refresh-ms:300000}",
+            initialDelayString = "${bank-profit.actuary-rollup-initial-delay-ms:0}"
+    )
+    public void refreshActuaryProfitRollup() {
+        log.info("Refreshing actuary profit rollup.");
+        bankProfitService.refreshActuaryProfitRollup();
+    }
+}

--- a/order-service/src/main/java/com/banka1/order/service/BankProfitService.java
+++ b/order-service/src/main/java/com/banka1/order/service/BankProfitService.java
@@ -1,0 +1,12 @@
+package com.banka1.order.service;
+
+import com.banka1.order.dto.ActuaryProfitResponse;
+
+import java.util.List;
+
+public interface BankProfitService {
+
+    List<ActuaryProfitResponse> getActuaryProfits();
+
+    void refreshActuaryProfitRollup();
+}

--- a/order-service/src/main/java/com/banka1/order/service/impl/BankProfitServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/BankProfitServiceImpl.java
@@ -1,0 +1,288 @@
+package com.banka1.order.service.impl;
+
+import com.banka1.order.client.EmployeeClient;
+import com.banka1.order.client.ExchangeClient;
+import com.banka1.order.client.StockClient;
+import com.banka1.order.dto.ActuaryProfitResponse;
+import com.banka1.order.dto.EmployeeDto;
+import com.banka1.order.dto.EmployeePageResponse;
+import com.banka1.order.dto.ExchangeRateDto;
+import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.entity.ActuaryProfitRollup;
+import com.banka1.order.entity.Order;
+import com.banka1.order.entity.Transaction;
+import com.banka1.order.entity.enums.OrderDirection;
+import com.banka1.order.repository.ActuaryProfitRollupRepository;
+import com.banka1.order.repository.OrderRepository;
+import com.banka1.order.repository.TransactionRepository;
+import com.banka1.order.service.BankProfitService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BankProfitServiceImpl implements BankProfitService {
+
+    private static final int EMPLOYEE_PAGE_SIZE = 100;
+    private static final String RSD = "RSD";
+    private static final Set<String> ACTUARY_ROLES = Set.of("AGENT", "SUPERVISOR", "ADMIN");
+
+    private final ActuaryProfitRollupRepository rollupRepository;
+    private final OrderRepository orderRepository;
+    private final TransactionRepository transactionRepository;
+    private final EmployeeClient employeeClient;
+    private final StockClient stockClient;
+    private final ExchangeClient exchangeClient;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ActuaryProfitResponse> getActuaryProfits() {
+        return rollupRepository.findAllByOrderByEmployeeIdAsc().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void refreshActuaryProfitRollup() {
+        Map<Long, EmployeeDto> actuaries = loadActuaries();
+        Map<Long, BigDecimal> profitsByEmployee = calculateOrderProfits(actuaries.keySet());
+        LocalDateTime refreshedAt = LocalDateTime.now();
+
+        Map<Long, ActuaryProfitRollup> existing = rollupRepository.findAll().stream()
+                .collect(Collectors.toMap(ActuaryProfitRollup::getEmployeeId, Function.identity()));
+        List<ActuaryProfitRollup> refreshed = new ArrayList<>();
+
+        for (EmployeeDto employee : actuaries.values()) {
+            ActuaryProfitRollup rollup = existing.remove(employee.getId());
+            if (rollup == null) {
+                rollup = new ActuaryProfitRollup();
+                rollup.setEmployeeId(employee.getId());
+            }
+            rollup.setIme(defaultString(employee.getIme()));
+            rollup.setPrezime(defaultString(employee.getPrezime()));
+            rollup.setRole(normalizeRole(employee.getRole()));
+            rollup.setTotalProfitRsd(profitsByEmployee.getOrDefault(employee.getId(), BigDecimal.ZERO));
+            rollup.setRefreshedAt(refreshedAt);
+            refreshed.add(rollup);
+        }
+
+        if (!existing.isEmpty()) {
+            rollupRepository.deleteAll(existing.values());
+        }
+        rollupRepository.saveAll(refreshed);
+    }
+
+    private Map<Long, EmployeeDto> loadActuaries() {
+        Map<Long, EmployeeDto> actuaries = new LinkedHashMap<>();
+        int pageIndex = 0;
+        while (true) {
+            EmployeePageResponse page = employeeClient.searchEmployees(null, null, null, null, pageIndex, EMPLOYEE_PAGE_SIZE);
+            if (page == null || page.getContent() == null || page.getContent().isEmpty()) {
+                break;
+            }
+            page.getContent().stream()
+                    .filter(employee -> employee != null && employee.getId() != null)
+                    .filter(employee -> ACTUARY_ROLES.contains(upper(employee.getRole())))
+                    .forEach(employee -> actuaries.putIfAbsent(employee.getId(), employee));
+
+            pageIndex++;
+            if (pageIndex >= page.getTotalPages()) {
+                break;
+            }
+        }
+        return actuaries;
+    }
+
+    private Map<Long, BigDecimal> calculateOrderProfits(Set<Long> employeeIds) {
+        if (employeeIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Order> orders = orderRepository.findByUserIdIn(new HashSet<>(employeeIds));
+        if (orders.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, Order> ordersById = orders.stream()
+                .filter(order -> order.getId() != null)
+                .collect(Collectors.toMap(Order::getId, Function.identity()));
+        List<Long> orderIds = new ArrayList<>(ordersById.keySet());
+        if (orderIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Transaction> transactions = new ArrayList<>(transactionRepository.findByOrderIdIn(orderIds));
+        transactions.sort(Comparator
+                .comparing(Transaction::getTimestamp, Comparator.nullsLast(LocalDateTime::compareTo))
+                .thenComparing(transaction -> orderDirectionRank(ordersById.get(transaction.getOrderId())))
+                .thenComparing(Transaction::getId, Comparator.nullsLast(Long::compareTo)));
+
+        Map<UserListingKey, Deque<BuyLot>> lotsByUserListing = new HashMap<>();
+        Map<Long, BigDecimal> profitByEmployee = new HashMap<>();
+        Map<Long, String> currencyByListing = new HashMap<>();
+
+        for (Transaction transaction : transactions) {
+            Order order = ordersById.get(transaction.getOrderId());
+            if (!valid(order, transaction)) {
+                continue;
+            }
+            UserListingKey key = new UserListingKey(order.getUserId(), order.getListingId());
+            Deque<BuyLot> lots = lotsByUserListing.computeIfAbsent(key, ignored -> new ArrayDeque<>());
+
+            if (order.getDirection() == OrderDirection.BUY) {
+                lots.addLast(new BuyLot(transaction.getQuantity(), transaction.getPricePerUnit()));
+                continue;
+            }
+            if (order.getDirection() == OrderDirection.SELL) {
+                BigDecimal profit = calculateSellProfit(lots, order, transaction);
+                if (profit.compareTo(BigDecimal.ZERO) != 0) {
+                    String currency = currencyByListing.computeIfAbsent(order.getListingId(), this::resolveCurrency);
+                    BigDecimal profitRsd = convertToRsd(currency, profit, transaction.getTimestamp().toLocalDate());
+                    profitByEmployee.merge(order.getUserId(), profitRsd, BigDecimal::add);
+                }
+            }
+        }
+
+        // TODO: Add otc-service OptionContract.realizedProfit to this rollup once that service/API exists.
+        return profitByEmployee;
+    }
+
+    private BigDecimal calculateSellProfit(Deque<BuyLot> lots, Order sellOrder, Transaction sellTransaction) {
+        int quantityToMatch = sellTransaction.getQuantity();
+        BigDecimal profit = BigDecimal.ZERO;
+
+        while (quantityToMatch > 0 && !lots.isEmpty()) {
+            BuyLot lot = lots.peekFirst();
+            int matchedQuantity = Math.min(quantityToMatch, lot.remainingQuantity());
+            BigDecimal matchedProfit = sellTransaction.getPricePerUnit()
+                    .subtract(lot.purchasePricePerUnit())
+                    .multiply(BigDecimal.valueOf(matchedQuantity))
+                    .multiply(BigDecimal.valueOf(sellOrder.getContractSize()));
+            profit = profit.add(matchedProfit);
+
+            quantityToMatch -= matchedQuantity;
+            lot.remainingQuantity(lot.remainingQuantity() - matchedQuantity);
+            if (lot.remainingQuantity() == 0) {
+                lots.removeFirst();
+            }
+        }
+
+        if (quantityToMatch > 0) {
+            log.warn("Unable to fully match sell transaction {} while calculating actuary profit", sellTransaction.getId());
+        }
+        return profit;
+    }
+
+    private BigDecimal convertToRsd(String currency, BigDecimal amount, LocalDate date) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        if (currency == null || RSD.equalsIgnoreCase(currency)) {
+            return amount;
+        }
+        BigDecimal sign = amount.signum() < 0 ? BigDecimal.valueOf(-1) : BigDecimal.ONE;
+        BigDecimal convertibleAmount = amount.abs();
+        ExchangeRateDto conversion = exchangeClient.calculateWithoutCommission(currency, RSD, convertibleAmount, date);
+        BigDecimal converted = conversion == null || conversion.getConvertedAmount() == null
+                ? convertibleAmount
+                : conversion.getConvertedAmount();
+        return converted.multiply(sign);
+    }
+
+    private String resolveCurrency(Long listingId) {
+        try {
+            StockListingDto listing = stockClient.getListing(listingId);
+            return listing == null ? RSD : listing.getCurrency();
+        } catch (Exception ex) {
+            log.warn("Unable to resolve listing currency for {} while calculating actuary profit", listingId, ex);
+            return RSD;
+        }
+    }
+
+    private boolean valid(Order order, Transaction transaction) {
+        return order != null
+                && order.getUserId() != null
+                && order.getListingId() != null
+                && order.getDirection() != null
+                && order.getContractSize() != null
+                && transaction.getQuantity() != null
+                && transaction.getQuantity() > 0
+                && transaction.getPricePerUnit() != null
+                && transaction.getTimestamp() != null;
+    }
+
+    private int orderDirectionRank(Order order) {
+        if (order == null || order.getDirection() == null) {
+            return 2;
+        }
+        return order.getDirection() == OrderDirection.BUY ? 0 : 1;
+    }
+
+    private ActuaryProfitResponse toResponse(ActuaryProfitRollup rollup) {
+        return new ActuaryProfitResponse(
+                rollup.getEmployeeId(),
+                rollup.getIme(),
+                rollup.getPrezime(),
+                rollup.getRole(),
+                rollup.getTotalProfitRsd()
+        );
+    }
+
+    private String normalizeRole(String role) {
+        String value = upper(role);
+        return "ADMIN".equals(value) ? "SUPERVISOR" : value;
+    }
+
+    private String upper(String value) {
+        return value == null ? "" : value.toUpperCase(Locale.ROOT);
+    }
+
+    private String defaultString(String value) {
+        return value == null ? "" : value;
+    }
+
+    private record UserListingKey(Long userId, Long listingId) {
+    }
+
+    private static final class BuyLot {
+        private int remainingQuantity;
+        private final BigDecimal purchasePricePerUnit;
+
+        private BuyLot(int remainingQuantity, BigDecimal purchasePricePerUnit) {
+            this.remainingQuantity = remainingQuantity;
+            this.purchasePricePerUnit = purchasePricePerUnit;
+        }
+
+        int remainingQuantity() {
+            return remainingQuantity;
+        }
+
+        void remainingQuantity(int remainingQuantity) {
+            this.remainingQuantity = remainingQuantity;
+        }
+
+        BigDecimal purchasePricePerUnit() {
+            return purchasePricePerUnit;
+        }
+    }
+}

--- a/order-service/src/main/resources/db/changelog/009-actuary-profit-rollup.sql
+++ b/order-service/src/main/resources/db/changelog/009-actuary-profit-rollup.sql
@@ -1,0 +1,11 @@
+-- liquibase formatted sql
+
+-- changeset order:9
+CREATE TABLE actuary_profit_rollup (
+    employee_id       BIGINT          PRIMARY KEY,
+    ime               VARCHAR(255)    NOT NULL,
+    prezime           VARCHAR(255)    NOT NULL,
+    role              VARCHAR(16)     NOT NULL,
+    total_profit_rsd  DECIMAL(19, 4)  NOT NULL DEFAULT 0,
+    refreshed_at      TIMESTAMP       NOT NULL
+);

--- a/order-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/order-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -12,4 +12,5 @@
     <include file="db/changelog/005-tax-charge-schema.sql"/>
     <include file="db/changelog/006-order-reservations.sql"/>
     <include file="db/changelog/007-portfolio-reservations.sql"/>
+    <include file="db/changelog/009-actuary-profit-rollup.sql"/>
 </databaseChangeLog>

--- a/order-service/src/test/java/com/banka1/order/controller/BankProfitControllerTest.java
+++ b/order-service/src/test/java/com/banka1/order/controller/BankProfitControllerTest.java
@@ -1,0 +1,60 @@
+package com.banka1.order.controller;
+
+import com.banka1.order.dto.ActuaryProfitResponse;
+import com.banka1.order.service.BankProfitService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BankProfitControllerTest {
+
+    @Mock
+    private BankProfitService bankProfitService;
+
+    private BankProfitController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new BankProfitController(bankProfitService);
+    }
+
+    @Test
+    void getActuaryProfits_delegatesToService() {
+        List<ActuaryProfitResponse> profits = List.of(
+                new ActuaryProfitResponse(1L, "Pera", "Peric", "AGENT", new BigDecimal("100.00"))
+        );
+        when(bankProfitService.getActuaryProfits()).thenReturn(profits);
+
+        ResponseEntity<List<ActuaryProfitResponse>> response = controller.getActuaryProfits();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(profits);
+        verify(bankProfitService).getActuaryProfits();
+    }
+
+    @Test
+    void getActuaryProfits_hasExpectedMappingAndSecurity() throws Exception {
+        RequestMapping requestMapping = BankProfitController.class.getAnnotation(RequestMapping.class);
+        assertThat(requestMapping.value()).containsExactly("/bank-profit");
+
+        Method method = BankProfitController.class.getDeclaredMethod("getActuaryProfits");
+        assertThat(method.getAnnotation(GetMapping.class).value()).containsExactly("/actuaries");
+        assertThat(method.getAnnotation(PreAuthorize.class).value()).isEqualTo("hasRole('SUPERVISOR')");
+    }
+}

--- a/order-service/src/test/java/com/banka1/order/scheduler/ActuaryProfitRollupSchedulerTest.java
+++ b/order-service/src/test/java/com/banka1/order/scheduler/ActuaryProfitRollupSchedulerTest.java
@@ -1,0 +1,45 @@
+package com.banka1.order.scheduler;
+
+import com.banka1.order.service.BankProfitService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ActuaryProfitRollupSchedulerTest {
+
+    @Mock
+    private BankProfitService bankProfitService;
+
+    private ActuaryProfitRollupScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new ActuaryProfitRollupScheduler(bankProfitService);
+    }
+
+    @Test
+    void refreshActuaryProfitRollup_delegatesToService() {
+        scheduler.refreshActuaryProfitRollup();
+
+        verify(bankProfitService).refreshActuaryProfitRollup();
+    }
+
+    @Test
+    void refreshActuaryProfitRollup_hasExpectedSchedule() throws Exception {
+        Method method = ActuaryProfitRollupScheduler.class.getDeclaredMethod("refreshActuaryProfitRollup");
+        Scheduled scheduled = method.getAnnotation(Scheduled.class);
+
+        assertThat(scheduled).isNotNull();
+        assertThat(scheduled.fixedDelayString()).isEqualTo("${bank-profit.actuary-rollup-refresh-ms:300000}");
+        assertThat(scheduled.initialDelayString()).isEqualTo("${bank-profit.actuary-rollup-initial-delay-ms:0}");
+    }
+}

--- a/order-service/src/test/java/com/banka1/order/service/BankProfitServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/BankProfitServiceTest.java
@@ -1,0 +1,193 @@
+package com.banka1.order.service;
+
+import com.banka1.order.client.EmployeeClient;
+import com.banka1.order.client.ExchangeClient;
+import com.banka1.order.client.StockClient;
+import com.banka1.order.dto.EmployeeDto;
+import com.banka1.order.dto.EmployeePageResponse;
+import com.banka1.order.dto.ExchangeRateDto;
+import com.banka1.order.dto.StockListingDto;
+import com.banka1.order.entity.ActuaryProfitRollup;
+import com.banka1.order.entity.Order;
+import com.banka1.order.entity.Transaction;
+import com.banka1.order.entity.enums.OrderDirection;
+import com.banka1.order.repository.ActuaryProfitRollupRepository;
+import com.banka1.order.repository.OrderRepository;
+import com.banka1.order.repository.TransactionRepository;
+import com.banka1.order.service.impl.BankProfitServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BankProfitServiceTest {
+
+    @Mock
+    private ActuaryProfitRollupRepository rollupRepository;
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private TransactionRepository transactionRepository;
+    @Mock
+    private EmployeeClient employeeClient;
+    @Mock
+    private StockClient stockClient;
+    @Mock
+    private ExchangeClient exchangeClient;
+
+    @InjectMocks
+    private BankProfitServiceImpl bankProfitService;
+
+    @Test
+    void refreshActuaryProfitRollup_calculatesMultiCurrencyRealizedProfitInRsd() {
+        EmployeeDto agent = employee(1L, "Pera", "Peric", "AGENT");
+        EmployeeDto supervisor = employee(2L, "Mika", "Mikic", "SUPERVISOR");
+        when(employeeClient.searchEmployees(null, null, null, null, 0, 100))
+                .thenReturn(employeePage(List.of(agent, supervisor)));
+
+        Order usdBuy = order(10L, 1L, 100L, OrderDirection.BUY, 1);
+        Order usdSell = order(11L, 1L, 100L, OrderDirection.SELL, 1);
+        Order eurBuy = order(12L, 1L, 200L, OrderDirection.BUY, 1);
+        Order eurSell = order(13L, 1L, 200L, OrderDirection.SELL, 1);
+        when(orderRepository.findByUserIdIn(any())).thenReturn(List.of(usdBuy, usdSell, eurBuy, eurSell));
+
+        LocalDateTime usdBuyTime = LocalDateTime.of(2026, 1, 1, 10, 0);
+        LocalDateTime usdSellTime = LocalDateTime.of(2026, 1, 3, 10, 0);
+        LocalDateTime eurBuyTime = LocalDateTime.of(2026, 2, 1, 10, 0);
+        LocalDateTime eurSellTime = LocalDateTime.of(2026, 2, 5, 10, 0);
+        when(transactionRepository.findByOrderIdIn(any())).thenReturn(List.of(
+                transaction(10L, 10, "10.00", usdBuyTime),
+                transaction(11L, 4, "15.00", usdSellTime),
+                transaction(12L, 2, "20.00", eurBuyTime),
+                transaction(13L, 2, "30.00", eurSellTime)
+        ));
+
+        when(stockClient.getListing(100L)).thenReturn(listing("USD"));
+        when(stockClient.getListing(200L)).thenReturn(listing("EUR"));
+        when(exchangeClient.calculateWithoutCommission(eq("USD"), eq("RSD"), amountEq("20.00"), eq(LocalDate.of(2026, 1, 3))))
+                .thenReturn(conversion("2000.00"));
+        when(exchangeClient.calculateWithoutCommission(eq("EUR"), eq("RSD"), amountEq("20.00"), eq(LocalDate.of(2026, 2, 5))))
+                .thenReturn(conversion("2400.00"));
+        when(rollupRepository.findAll()).thenReturn(List.of());
+
+        bankProfitService.refreshActuaryProfitRollup();
+
+        List<ActuaryProfitRollup> savedRows = savedRows();
+        assertThat(savedRows).hasSize(2);
+        assertThat(savedRows)
+                .filteredOn(row -> row.getEmployeeId().equals(1L))
+                .singleElement()
+                .satisfies(row -> assertThat(row.getTotalProfitRsd()).isEqualByComparingTo("4400.00"));
+        assertThat(savedRows)
+                .filteredOn(row -> row.getEmployeeId().equals(2L))
+                .singleElement()
+                .satisfies(row -> assertThat(row.getTotalProfitRsd()).isEqualByComparingTo("0"));
+    }
+
+    @Test
+    void refreshActuaryProfitRollup_includesAgentsAndSupervisorsOnly() {
+        when(employeeClient.searchEmployees(null, null, null, null, 0, 100)).thenReturn(employeePage(List.of(
+                employee(1L, "Agent", "Jedan", "AGENT"),
+                employee(2L, "Supervisor", "Jedan", "SUPERVISOR"),
+                employee(3L, "Admin", "Jedan", "ADMIN"),
+                employee(4L, "Client", "Jedan", "CLIENT")
+        )));
+        when(orderRepository.findByUserIdIn(any())).thenReturn(List.of());
+        when(rollupRepository.findAll()).thenReturn(List.of());
+
+        bankProfitService.refreshActuaryProfitRollup();
+
+        List<ActuaryProfitRollup> savedRows = savedRows();
+        assertThat(savedRows).extracting(ActuaryProfitRollup::getEmployeeId)
+                .containsExactlyInAnyOrder(1L, 2L, 3L);
+        assertThat(savedRows)
+                .filteredOn(row -> row.getEmployeeId().equals(1L))
+                .singleElement()
+                .satisfies(row -> assertThat(row.getRole()).isEqualTo("AGENT"));
+        assertThat(savedRows)
+                .filteredOn(row -> row.getEmployeeId().equals(2L))
+                .singleElement()
+                .satisfies(row -> assertThat(row.getRole()).isEqualTo("SUPERVISOR"));
+        assertThat(savedRows)
+                .filteredOn(row -> row.getEmployeeId().equals(3L))
+                .singleElement()
+                .satisfies(row -> assertThat(row.getRole()).isEqualTo("SUPERVISOR"));
+        verifyNoInteractions(transactionRepository, stockClient, exchangeClient);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ActuaryProfitRollup> savedRows() {
+        ArgumentCaptor<Iterable<ActuaryProfitRollup>> captor = ArgumentCaptor.forClass(Iterable.class);
+        verify(rollupRepository).saveAll(captor.capture());
+        return StreamSupport.stream(captor.getValue().spliterator(), false).toList();
+    }
+
+    private EmployeePageResponse employeePage(List<EmployeeDto> employees) {
+        EmployeePageResponse response = new EmployeePageResponse();
+        response.setContent(employees);
+        response.setTotalPages(1);
+        response.setTotalElements(employees.size());
+        return response;
+    }
+
+    private EmployeeDto employee(Long id, String ime, String prezime, String role) {
+        EmployeeDto employee = new EmployeeDto();
+        employee.setId(id);
+        employee.setIme(ime);
+        employee.setPrezime(prezime);
+        employee.setRole(role);
+        return employee;
+    }
+
+    private Order order(Long id, Long userId, Long listingId, OrderDirection direction, int contractSize) {
+        Order order = new Order();
+        order.setId(id);
+        order.setUserId(userId);
+        order.setListingId(listingId);
+        order.setDirection(direction);
+        order.setContractSize(contractSize);
+        return order;
+    }
+
+    private Transaction transaction(Long orderId, int quantity, String pricePerUnit, LocalDateTime timestamp) {
+        Transaction transaction = new Transaction();
+        transaction.setOrderId(orderId);
+        transaction.setQuantity(quantity);
+        transaction.setPricePerUnit(new BigDecimal(pricePerUnit));
+        transaction.setTimestamp(timestamp);
+        return transaction;
+    }
+
+    private StockListingDto listing(String currency) {
+        StockListingDto listing = new StockListingDto();
+        listing.setCurrency(currency);
+        return listing;
+    }
+
+    private ExchangeRateDto conversion(String convertedAmount) {
+        ExchangeRateDto dto = new ExchangeRateDto();
+        dto.setConvertedAmount(new BigDecimal(convertedAmount));
+        return dto;
+    }
+
+    private BigDecimal amountEq(String expected) {
+        return argThat(actual -> actual != null && actual.compareTo(new BigDecimal(expected)) == 0);
+    }
+}


### PR DESCRIPTION
Implementirana je stranica "Profit aktuara" sa endpointom `GET /bank-profit/actuaries`.

Kalkulacija: Suma realizovanih profita iz order-service.Transaction i otc-service.OptionContract.realizedProfit koje je on lično izvršio (ne za fond, ne za banku).

Konverzija u RSD prema kursu na trenutku izvršenja (kroz exchange podatke).

U trenutku implementacije otc-servis nije bio gotov, pa je ostavljen TODO u `BankProfitServiceImpl.java` da se doda otc-service.OptionContract.realizedProfit u formulu u kodu.

Tabela actuary_profit_rollup inicijalizovana u `009-actuary-profit-rollup.sql`