### PR TITLE
feat: add Spark analytics for trading data

### DIFF
--- a/analytics-spark-job/Dockerfile
+++ b/analytics-spark-job/Dockerfile
@@ -1,0 +1,7 @@
+FROM apache/spark-py:v3.5.3
+
+WORKDIR /opt/spark/work-dir
+
+COPY app/analytics_job.py /opt/spark/work-dir/analytics_job.py
+
+USER 185

--- a/analytics-spark-job/README.md
+++ b/analytics-spark-job/README.md
@@ -1,0 +1,40 @@
+# Analytics Spark Job
+
+Batch analytics job for the Banka 1 project. The job is designed to run on Kubernetes
+through the Spark Operator and materialize analytics results into the `trading`
+Postgres database.
+
+## Outputs
+
+- `analytics_job_runs`
+- `analytics_client_segments`
+- `analytics_portfolio_risk`
+- `analytics_top_tickers`
+
+## Required environment
+
+- `TRADING_JDBC_URL`
+- `TRADING_DB_USER`
+- `TRADING_DB_PASSWORD`
+- `MARKET_JDBC_URL`
+- `MARKET_DB_USER`
+- `MARKET_DB_PASSWORD`
+
+Optional:
+
+- `ANALYTICS_KMEANS_K` defaults to `4`
+- `POSTGRES_JDBC_DRIVER` defaults to `org.postgresql.Driver`
+
+## Kubernetes
+
+`k8s/scheduled-spark-application.yaml` expects the Spark Operator CRDs and a
+`banka-analytics-db` secret in the same namespace. `k8s/secret.example.yaml`
+shows the required keys.
+
+## Local submit example
+
+```bash
+spark-submit \
+  --packages org.postgresql:postgresql:42.7.4 \
+  analytics-spark-job/app/analytics_job.py
+```

--- a/analytics-spark-job/app/analytics_job.py
+++ b/analytics-spark-job/app/analytics_job.py
@@ -1,0 +1,428 @@
+import os
+import uuid
+from datetime import datetime, timezone
+
+from pyspark.ml.clustering import KMeans
+from pyspark.ml.feature import StandardScaler, VectorAssembler
+from pyspark.sql import SparkSession, Window
+from pyspark.sql import functions as F
+from pyspark.sql.types import (
+    DecimalType,
+    IntegerType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+
+JOB_NAME = "trading-analytics-spark"
+
+
+def getenv(name, default=None):
+    value = os.getenv(name, default)
+    if value is None or value == "":
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def jdbc_options(url, user, password):
+    return {
+        "url": url,
+        "user": user,
+        "password": password,
+        "driver": os.getenv("POSTGRES_JDBC_DRIVER", "org.postgresql.Driver"),
+    }
+
+
+def read_query(spark, options, query):
+    return (
+        spark.read.format("jdbc")
+        .options(**options)
+        .option("dbtable", f"({query}) q")
+        .load()
+    )
+
+
+def write_table(df, options, table):
+    (
+        df.write.format("jdbc")
+        .options(**options)
+        .option("dbtable", table)
+        .mode("append")
+        .save()
+    )
+
+
+def empty_df(spark, schema):
+    return spark.createDataFrame([], schema)
+
+
+def add_run_columns(df, run_id, computed_at):
+    return df.withColumn("run_id", F.lit(run_id)).withColumn("computed_at", F.lit(computed_at))
+
+
+def load_sources(spark, trading_options, market_options):
+    portfolio = read_query(
+        spark,
+        trading_options,
+        """
+        select user_id, listing_id, listing_type, quantity, average_purchase_price
+        from portfolio
+        where quantity > 0
+        """,
+    )
+    orders = read_query(
+        spark,
+        trading_options,
+        """
+        select id, user_id, listing_id, quantity, price_per_unit, direction, status
+        from orders
+        """,
+    )
+    transactions = read_query(
+        spark,
+        trading_options,
+        """
+        select id, order_id, quantity, price_per_unit, total_price
+        from transactions
+        """,
+    )
+    listings = read_query(
+        spark,
+        market_options,
+        """
+        select id, ticker, listing_type, price
+        from listing
+        """,
+    )
+    return portfolio, orders, transactions, listings
+
+
+def build_portfolio_risk(spark, portfolio, listings, run_id, computed_at):
+    schema = StructType(
+        [
+            StructField("run_id", StringType(), False),
+            StructField("user_id", LongType(), False),
+            StructField("total_market_value", DecimalType(19, 4), False),
+            StructField("total_cost_basis", DecimalType(19, 4), False),
+            StructField("unrealized_pnl", DecimalType(19, 4), False),
+            StructField("holdings_count", IntegerType(), False),
+            StructField("max_holding_percent", DecimalType(9, 4), False),
+            StructField("diversification_score", DecimalType(9, 4), False),
+            StructField("risk_score", DecimalType(9, 4), False),
+            StructField("risk_level", StringType(), False),
+            StructField("computed_at", TimestampType(), False),
+        ]
+    )
+    if portfolio.rdd.isEmpty():
+        return empty_df(spark, schema)
+
+    holdings = (
+        portfolio.alias("p")
+        .join(listings.alias("l"), F.col("p.listing_id") == F.col("l.id"), "left")
+        .withColumn("market_price", F.coalesce(F.col("l.price"), F.lit(0)))
+        .withColumn("market_value", F.col("p.quantity") * F.col("market_price"))
+        .withColumn("cost_basis", F.col("p.quantity") * F.col("p.average_purchase_price"))
+    )
+
+    aggregate = holdings.groupBy("user_id").agg(
+        F.sum("market_value").alias("total_market_value"),
+        F.sum("cost_basis").alias("total_cost_basis"),
+        F.countDistinct("listing_id").cast("int").alias("holdings_count"),
+    )
+
+    by_holding = holdings.join(
+        aggregate.select("user_id", "total_market_value"),
+        "user_id",
+        "inner",
+    ).withColumn(
+        "holding_percent",
+        F.when(F.col("total_market_value") > 0, F.col("market_value") * 100 / F.col("total_market_value")).otherwise(0),
+    )
+
+    concentration = by_holding.groupBy("user_id").agg(F.max("holding_percent").alias("max_holding_percent"))
+
+    risk = (
+        aggregate.join(concentration, "user_id", "left")
+        .withColumn("unrealized_pnl", F.col("total_market_value") - F.col("total_cost_basis"))
+        .withColumn(
+            "diversification_score",
+            F.least(F.lit(100.0), F.col("holdings_count") * F.lit(20.0))
+            * (F.lit(1.0) - F.coalesce(F.col("max_holding_percent"), F.lit(0.0)) / F.lit(100.0)),
+        )
+        .withColumn(
+            "risk_score",
+            F.least(
+                F.lit(100.0),
+                F.coalesce(F.col("max_holding_percent"), F.lit(0.0)) * F.lit(0.65)
+                + (F.lit(100.0) - F.col("diversification_score")) * F.lit(0.35),
+            ),
+        )
+        .withColumn(
+            "risk_level",
+            F.when(F.col("risk_score") >= 70, F.lit("HIGH"))
+            .when(F.col("risk_score") >= 40, F.lit("MEDIUM"))
+            .otherwise(F.lit("LOW")),
+        )
+    )
+
+    return (
+        add_run_columns(risk, run_id, computed_at)
+        .select(
+            "run_id",
+            F.col("user_id").cast("long"),
+            F.round("total_market_value", 4).cast("decimal(19,4)").alias("total_market_value"),
+            F.round("total_cost_basis", 4).cast("decimal(19,4)").alias("total_cost_basis"),
+            F.round("unrealized_pnl", 4).cast("decimal(19,4)").alias("unrealized_pnl"),
+            F.col("holdings_count").cast("int"),
+            F.round("max_holding_percent", 4).cast("decimal(9,4)").alias("max_holding_percent"),
+            F.round("diversification_score", 4).cast("decimal(9,4)").alias("diversification_score"),
+            F.round("risk_score", 4).cast("decimal(9,4)").alias("risk_score"),
+            "risk_level",
+            "computed_at",
+        )
+    )
+
+
+def build_top_tickers(spark, orders, transactions, listings, run_id, computed_at):
+    schema = StructType(
+        [
+            StructField("run_id", StringType(), False),
+            StructField("ticker_rank", IntegerType(), False),
+            StructField("listing_id", LongType(), False),
+            StructField("ticker", StringType(), False),
+            StructField("traded_quantity", LongType(), False),
+            StructField("traded_notional", DecimalType(19, 4), False),
+            StructField("order_count", IntegerType(), False),
+            StructField("transaction_count", IntegerType(), False),
+            StructField("computed_at", TimestampType(), False),
+        ]
+    )
+    if orders.rdd.isEmpty():
+        return empty_df(spark, schema)
+
+    order_metrics = (
+        orders.withColumn("order_notional", F.col("quantity") * F.col("price_per_unit"))
+        .groupBy("listing_id")
+        .agg(
+            F.sum("quantity").cast("long").alias("traded_quantity"),
+            F.sum("order_notional").alias("traded_notional"),
+            F.count("*").cast("int").alias("order_count"),
+        )
+    )
+
+    transaction_metrics = (
+        transactions.alias("t")
+        .join(orders.select(F.col("id").alias("order_id"), "listing_id"), "order_id", "inner")
+        .groupBy("listing_id")
+        .agg(F.count("*").cast("int").alias("transaction_count"))
+    )
+
+    ranked = (
+        order_metrics.join(transaction_metrics, "listing_id", "left")
+        .join(listings.select(F.col("id").alias("listing_id"), "ticker"), "listing_id", "left")
+        .withColumn("transaction_count", F.coalesce(F.col("transaction_count"), F.lit(0)))
+        .withColumn("ticker", F.coalesce(F.col("ticker"), F.concat(F.lit("LISTING-"), F.col("listing_id"))))
+        .withColumn("ticker_rank", F.row_number().over(Window.orderBy(F.col("traded_notional").desc(), F.col("listing_id").asc())))
+    )
+
+    return (
+        add_run_columns(ranked, run_id, computed_at)
+        .select(
+            "run_id",
+            F.col("ticker_rank").cast("int"),
+            F.col("listing_id").cast("long"),
+            "ticker",
+            F.col("traded_quantity").cast("long"),
+            F.round("traded_notional", 4).cast("decimal(19,4)").alias("traded_notional"),
+            F.col("order_count").cast("int"),
+            F.col("transaction_count").cast("int"),
+            "computed_at",
+        )
+    )
+
+
+def build_client_segments(spark, portfolio_risk, orders, run_id, computed_at):
+    schema = StructType(
+        [
+            StructField("run_id", StringType(), False),
+            StructField("user_id", LongType(), False),
+            StructField("cluster_id", IntegerType(), False),
+            StructField("segment_label", StringType(), False),
+            StructField("total_portfolio_value", DecimalType(19, 4), False),
+            StructField("total_cost_basis", DecimalType(19, 4), False),
+            StructField("unrealized_pnl", DecimalType(19, 4), False),
+            StructField("holdings_count", IntegerType(), False),
+            StructField("max_holding_percent", DecimalType(9, 4), False),
+            StructField("order_count", IntegerType(), False),
+            StructField("average_order_value", DecimalType(19, 4), False),
+            StructField("buy_sell_ratio", DecimalType(19, 4), False),
+            StructField("risk_score", DecimalType(9, 4), False),
+            StructField("computed_at", TimestampType(), False),
+        ]
+    )
+    if portfolio_risk.rdd.isEmpty():
+        return empty_df(spark, schema)
+
+    order_features = (
+        orders.withColumn("order_value", F.col("quantity") * F.col("price_per_unit"))
+        .groupBy("user_id")
+        .agg(
+            F.count("*").cast("int").alias("order_count"),
+            F.avg("order_value").alias("average_order_value"),
+            F.sum(F.when(F.col("direction") == "BUY", 1).otherwise(0)).alias("buy_count"),
+            F.sum(F.when(F.col("direction") == "SELL", 1).otherwise(0)).alias("sell_count"),
+        )
+        .withColumn("buy_sell_ratio", F.col("buy_count") / F.greatest(F.col("sell_count"), F.lit(1)))
+    )
+
+    features = (
+        portfolio_risk.alias("r")
+        .join(order_features.alias("o"), F.col("r.user_id") == F.col("o.user_id"), "left")
+        .select(
+            F.col("r.user_id").cast("long").alias("user_id"),
+            F.col("r.total_market_value").cast("double").alias("total_portfolio_value"),
+            F.col("r.total_cost_basis").cast("double").alias("total_cost_basis"),
+            F.col("r.unrealized_pnl").cast("double").alias("unrealized_pnl"),
+            F.col("r.holdings_count").cast("int").alias("holdings_count"),
+            F.col("r.max_holding_percent").cast("double").alias("max_holding_percent"),
+            F.col("r.risk_score").cast("double").alias("risk_score"),
+            F.coalesce(F.col("o.order_count"), F.lit(0)).cast("int").alias("order_count"),
+            F.coalesce(F.col("o.average_order_value"), F.lit(0.0)).cast("double").alias("average_order_value"),
+            F.coalesce(F.col("o.buy_sell_ratio"), F.lit(0.0)).cast("double").alias("buy_sell_ratio"),
+        )
+    )
+
+    feature_columns = [
+        "total_portfolio_value",
+        "holdings_count",
+        "max_holding_percent",
+        "order_count",
+        "average_order_value",
+        "buy_sell_ratio",
+        "risk_score",
+    ]
+    count = features.count()
+    if count > 1:
+        k = min(int(os.getenv("ANALYTICS_KMEANS_K", "4")), count)
+        assembler = VectorAssembler(inputCols=feature_columns, outputCol="raw_features")
+        scaler = StandardScaler(inputCol="raw_features", outputCol="features", withMean=True, withStd=True)
+        assembled = assembler.transform(features)
+        scaled_model = scaler.fit(assembled)
+        scaled = scaled_model.transform(assembled)
+        model = KMeans(k=k, seed=42, featuresCol="features", predictionCol="cluster_id").fit(scaled)
+        clustered = model.transform(scaled)
+    else:
+        clustered = features.withColumn("cluster_id", F.lit(0))
+
+    labelled = clustered.withColumn(
+        "segment_label",
+        F.when((F.col("order_count") <= 1) & (F.col("total_portfolio_value") < 10000), F.lit("LOW_ACTIVITY"))
+        .when((F.col("max_holding_percent") >= 70) | (F.col("risk_score") >= 70), F.lit("CONCENTRATED_RISK"))
+        .when((F.col("total_portfolio_value") >= 100000) | (F.col("order_count") >= 10), F.lit("HIGH_EXPOSURE_TRADER"))
+        .otherwise(F.lit("DIVERSIFIED_INVESTOR")),
+    )
+
+    return (
+        add_run_columns(labelled, run_id, computed_at)
+        .select(
+            "run_id",
+            "user_id",
+            F.col("cluster_id").cast("int"),
+            "segment_label",
+            F.round("total_portfolio_value", 4).cast("decimal(19,4)").alias("total_portfolio_value"),
+            F.round("total_cost_basis", 4).cast("decimal(19,4)").alias("total_cost_basis"),
+            F.round("unrealized_pnl", 4).cast("decimal(19,4)").alias("unrealized_pnl"),
+            F.col("holdings_count").cast("int"),
+            F.round("max_holding_percent", 4).cast("decimal(9,4)").alias("max_holding_percent"),
+            F.col("order_count").cast("int"),
+            F.round("average_order_value", 4).cast("decimal(19,4)").alias("average_order_value"),
+            F.round("buy_sell_ratio", 4).cast("decimal(19,4)").alias("buy_sell_ratio"),
+            F.round("risk_score", 4).cast("decimal(9,4)").alias("risk_score"),
+            "computed_at",
+        )
+    )
+
+
+def build_run_row(spark, run_id, started_at, completed_at, status, message):
+    schema = StructType(
+        [
+            StructField("run_id", StringType(), False),
+            StructField("job_name", StringType(), False),
+            StructField("status", StringType(), False),
+            StructField("started_at", TimestampType(), False),
+            StructField("completed_at", TimestampType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+    return spark.createDataFrame([(run_id, JOB_NAME, status, started_at, completed_at, message)], schema)
+
+
+def run_analytics(spark, trading_options, market_options, run_id, started_at):
+    portfolio, orders, transactions, listings = load_sources(spark, trading_options, market_options)
+    computed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    portfolio_risk = build_portfolio_risk(spark, portfolio, listings, run_id, computed_at)
+    top_tickers = build_top_tickers(spark, orders, transactions, listings, run_id, computed_at)
+    client_segments = build_client_segments(spark, portfolio_risk, orders, run_id, computed_at)
+
+    write_table(portfolio_risk, trading_options, "analytics_portfolio_risk")
+    write_table(top_tickers, trading_options, "analytics_top_tickers")
+    write_table(client_segments, trading_options, "analytics_client_segments")
+
+    completed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    run_row = build_run_row(
+        spark,
+        run_id,
+        started_at,
+        completed_at,
+        "COMPLETED",
+        "Analytics run completed.",
+    )
+    write_table(run_row, trading_options, "analytics_job_runs")
+
+
+def main():
+    started_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    run_id = str(uuid.uuid4())
+    spark = None
+    trading_options = None
+
+    try:
+        spark = (
+            SparkSession.builder.appName(JOB_NAME)
+            .config("spark.sql.session.timeZone", "UTC")
+            .getOrCreate()
+        )
+
+        trading_options = jdbc_options(
+            getenv("TRADING_JDBC_URL"),
+            getenv("TRADING_DB_USER"),
+            getenv("TRADING_DB_PASSWORD"),
+        )
+        market_options = jdbc_options(
+            getenv("MARKET_JDBC_URL"),
+            getenv("MARKET_DB_USER"),
+            getenv("MARKET_DB_PASSWORD"),
+        )
+
+        run_analytics(spark, trading_options, market_options, run_id, started_at)
+    except Exception as exc:
+        if spark is not None and trading_options is not None:
+            try:
+                completed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+                message = f"Analytics run failed: {exc}"[:512]
+                failed_row = build_run_row(spark, run_id, started_at, completed_at, "FAILED", message)
+                write_table(failed_row, trading_options, "analytics_job_runs")
+            except Exception as write_exc:
+                print(f"Failed to write analytics failure row: {write_exc}")
+        raise
+    finally:
+        if spark is not None:
+            spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/analytics-spark-job/k8s/scheduled-spark-application.yaml
+++ b/analytics-spark-job/k8s/scheduled-spark-application.yaml
@@ -1,0 +1,89 @@
+#noinspection KubernetesUnknownResourcesInspection
+apiVersion: sparkoperator.k8s.io/v1beta2
+#noinspection KubernetesUnknownResourcesInspection
+kind: ScheduledSparkApplication
+metadata:
+  name: banka-analytics-spark
+  namespace: default
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  successfulRunHistoryLimit: 3
+  failedRunHistoryLimit: 3
+  template:
+    type: Python
+    mode: cluster
+    image: banka1/analytics-spark-job:latest
+    imagePullPolicy: IfNotPresent
+    mainApplicationFile: local:///opt/spark/work-dir/analytics_job.py
+    sparkVersion: 3.5.3
+    restartPolicy:
+      type: OnFailure
+      onFailureRetries: 1
+      onFailureRetryInterval: 60
+      onSubmissionFailureRetries: 1
+      onSubmissionFailureRetryInterval: 60
+    deps:
+      packages:
+        - org.postgresql:postgresql:42.7.4
+    driver:
+      cores: 1
+      coreLimit: "1200m"
+      memory: "1g"
+      serviceAccount: spark
+      env:
+        - name: TRADING_JDBC_URL
+          value: jdbc:postgresql://postgres:5432/trading
+        - name: MARKET_JDBC_URL
+          value: jdbc:postgresql://postgres:5432/market_service
+        - name: TRADING_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: banka-analytics-db
+              key: trading-user
+        - name: TRADING_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: banka-analytics-db
+              key: trading-password
+        - name: MARKET_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: banka-analytics-db
+              key: market-user
+        - name: MARKET_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: banka-analytics-db
+              key: market-password
+        - name: ANALYTICS_KMEANS_K
+          value: "4"
+    executor:
+      instances: 2
+      cores: 1
+      memory: "1g"
+      env:
+        - name: TRADING_JDBC_URL
+          value: jdbc:postgresql://postgres:5432/trading
+        - name: MARKET_JDBC_URL
+          value: jdbc:postgresql://postgres:5432/market_service
+        - name: TRADING_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: banka-analytics-db
+              key: trading-user
+        - name: TRADING_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: banka-analytics-db
+              key: trading-password
+        - name: MARKET_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: banka-analytics-db
+              key: market-user
+        - name: MARKET_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: banka-analytics-db
+              key: market-password

--- a/analytics-spark-job/k8s/secret.example.yaml
+++ b/analytics-spark-job/k8s/secret.example.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: banka-analytics-db
+  namespace: default
+type: Opaque
+stringData:
+  trading-user: postgres
+  trading-password: postgres
+  market-user: postgres
+  market-password: postgres

--- a/api-gateway/default.conf.template
+++ b/api-gateway/default.conf.template
@@ -185,7 +185,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # === Trading domain (order/portfolio/actuaries + margin/otc/funds) ===
+    # === Trading domain (order/portfolio/actuaries + margin/otc/funds/analytics) ===
 
     # /order/* — frontend prefix; trading-service controllers at /orders, /portfolio, /actuaries, /tax (no prefix). Strip.
     location = /order {
@@ -283,6 +283,21 @@ server {
     }
 
     location /margin/ {
+        proxy_pass http://trading_service;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /analytics {
+        proxy_pass http://trading_service/analytics$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /analytics/ {
         proxy_pass http://trading_service;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/controller/AnalyticsController.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/controller/AnalyticsController.java
@@ -1,0 +1,42 @@
+package com.banka1.tradingservice.analytics.controller;
+
+import com.banka1.tradingservice.analytics.dto.AnalyticsRunResponse;
+import com.banka1.tradingservice.analytics.dto.ClientSegmentsResponse;
+import com.banka1.tradingservice.analytics.dto.PortfolioRiskResponse;
+import com.banka1.tradingservice.analytics.dto.TopTickersResponse;
+import com.banka1.tradingservice.analytics.service.AnalyticsQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/analytics")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyRole('ADMIN', 'SUPERVISOR', 'AGENT', 'SERVICE')")
+public class AnalyticsController {
+
+    private final AnalyticsQueryService analyticsQueryService;
+
+    @GetMapping("/runs/latest")
+    public AnalyticsRunResponse getLatestRun() {
+        return analyticsQueryService.getLatestRun();
+    }
+
+    @GetMapping("/clients/segments")
+    public ClientSegmentsResponse getClientSegments() {
+        return analyticsQueryService.getClientSegments();
+    }
+
+    @GetMapping("/users/{userId}/portfolio-risk")
+    public PortfolioRiskResponse getPortfolioRisk(@PathVariable Long userId) {
+        return analyticsQueryService.getPortfolioRisk(userId);
+    }
+
+    @GetMapping("/tickers/top")
+    public TopTickersResponse getTopTickers() {
+        return analyticsQueryService.getTopTickers();
+    }
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/domain/AnalyticsClientSegment.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/domain/AnalyticsClientSegment.java
@@ -1,0 +1,69 @@
+package com.banka1.tradingservice.analytics.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "analytics_client_segments")
+@Getter
+@Setter
+@NoArgsConstructor
+@SuppressWarnings("JpaDataSourceORMInspection")
+public class AnalyticsClientSegment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "run_id", length = 36, nullable = false)
+    private String runId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "cluster_id", nullable = false)
+    private Integer clusterId;
+
+    @Column(name = "segment_label", length = 48, nullable = false)
+    private String segmentLabel;
+
+    @Column(name = "total_portfolio_value", precision = 19, scale = 4, nullable = false)
+    private BigDecimal totalPortfolioValue;
+
+    @Column(name = "total_cost_basis", precision = 19, scale = 4, nullable = false)
+    private BigDecimal totalCostBasis;
+
+    @Column(name = "unrealized_pnl", precision = 19, scale = 4, nullable = false)
+    private BigDecimal unrealizedPnl;
+
+    @Column(name = "holdings_count", nullable = false)
+    private Integer holdingsCount;
+
+    @Column(name = "max_holding_percent", precision = 9, scale = 4, nullable = false)
+    private BigDecimal maxHoldingPercent;
+
+    @Column(name = "order_count", nullable = false)
+    private Integer orderCount;
+
+    @Column(name = "average_order_value", precision = 19, scale = 4, nullable = false)
+    private BigDecimal averageOrderValue;
+
+    @Column(name = "buy_sell_ratio", precision = 19, scale = 4, nullable = false)
+    private BigDecimal buySellRatio;
+
+    @Column(name = "risk_score", precision = 9, scale = 4, nullable = false)
+    private BigDecimal riskScore;
+
+    @Column(name = "computed_at", nullable = false)
+    private LocalDateTime computedAt;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/domain/AnalyticsJobRun.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/domain/AnalyticsJobRun.java
@@ -1,0 +1,39 @@
+package com.banka1.tradingservice.analytics.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "analytics_job_runs")
+@Getter
+@Setter
+@NoArgsConstructor
+@SuppressWarnings("JpaDataSourceORMInspection")
+public class AnalyticsJobRun {
+
+    @Id
+    @Column(name = "run_id", length = 36, nullable = false)
+    private String runId;
+
+    @Column(name = "job_name", length = 80, nullable = false)
+    private String jobName;
+
+    @Column(name = "status", length = 20, nullable = false)
+    private String status;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "message", length = 512)
+    private String message;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/domain/AnalyticsPortfolioRisk.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/domain/AnalyticsPortfolioRisk.java
@@ -1,0 +1,60 @@
+package com.banka1.tradingservice.analytics.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "analytics_portfolio_risk")
+@Getter
+@Setter
+@NoArgsConstructor
+@SuppressWarnings("JpaDataSourceORMInspection")
+public class AnalyticsPortfolioRisk {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "run_id", length = 36, nullable = false)
+    private String runId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "total_market_value", precision = 19, scale = 4, nullable = false)
+    private BigDecimal totalMarketValue;
+
+    @Column(name = "total_cost_basis", precision = 19, scale = 4, nullable = false)
+    private BigDecimal totalCostBasis;
+
+    @Column(name = "unrealized_pnl", precision = 19, scale = 4, nullable = false)
+    private BigDecimal unrealizedPnl;
+
+    @Column(name = "holdings_count", nullable = false)
+    private Integer holdingsCount;
+
+    @Column(name = "max_holding_percent", precision = 9, scale = 4, nullable = false)
+    private BigDecimal maxHoldingPercent;
+
+    @Column(name = "diversification_score", precision = 9, scale = 4, nullable = false)
+    private BigDecimal diversificationScore;
+
+    @Column(name = "risk_score", precision = 9, scale = 4, nullable = false)
+    private BigDecimal riskScore;
+
+    @Column(name = "risk_level", length = 16, nullable = false)
+    private String riskLevel;
+
+    @Column(name = "computed_at", nullable = false)
+    private LocalDateTime computedAt;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/domain/AnalyticsTopTicker.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/domain/AnalyticsTopTicker.java
@@ -1,0 +1,54 @@
+package com.banka1.tradingservice.analytics.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "analytics_top_tickers")
+@Getter
+@Setter
+@NoArgsConstructor
+@SuppressWarnings("JpaDataSourceORMInspection")
+public class AnalyticsTopTicker {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "run_id", length = 36, nullable = false)
+    private String runId;
+
+    @Column(name = "ticker_rank", nullable = false)
+    private Integer tickerRank;
+
+    @Column(name = "listing_id", nullable = false)
+    private Long listingId;
+
+    @Column(name = "ticker", length = 64, nullable = false)
+    private String ticker;
+
+    @Column(name = "traded_quantity", nullable = false)
+    private Long tradedQuantity;
+
+    @Column(name = "traded_notional", precision = 19, scale = 4, nullable = false)
+    private BigDecimal tradedNotional;
+
+    @Column(name = "order_count", nullable = false)
+    private Integer orderCount;
+
+    @Column(name = "transaction_count", nullable = false)
+    private Integer transactionCount;
+
+    @Column(name = "computed_at", nullable = false)
+    private LocalDateTime computedAt;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/AnalyticsRunResponse.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/AnalyticsRunResponse.java
@@ -1,0 +1,13 @@
+package com.banka1.tradingservice.analytics.dto;
+
+import java.time.LocalDateTime;
+
+public record AnalyticsRunResponse(
+        String runId,
+        String jobName,
+        String status,
+        LocalDateTime startedAt,
+        LocalDateTime completedAt,
+        String message
+) {
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/ClientSegmentItemResponse.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/ClientSegmentItemResponse.java
@@ -1,0 +1,19 @@
+package com.banka1.tradingservice.analytics.dto;
+
+import java.math.BigDecimal;
+
+public record ClientSegmentItemResponse(
+        Long userId,
+        Integer clusterId,
+        String segmentLabel,
+        BigDecimal totalPortfolioValue,
+        BigDecimal totalCostBasis,
+        BigDecimal unrealizedPnl,
+        Integer holdingsCount,
+        BigDecimal maxHoldingPercent,
+        Integer orderCount,
+        BigDecimal averageOrderValue,
+        BigDecimal buySellRatio,
+        BigDecimal riskScore
+) {
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/ClientSegmentsResponse.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/ClientSegmentsResponse.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.analytics.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ClientSegmentsResponse(
+        String runId,
+        LocalDateTime computedAt,
+        List<ClientSegmentItemResponse> segments
+) {
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/PortfolioRiskResponse.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/PortfolioRiskResponse.java
@@ -1,0 +1,19 @@
+package com.banka1.tradingservice.analytics.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record PortfolioRiskResponse(
+        String runId,
+        LocalDateTime computedAt,
+        Long userId,
+        BigDecimal totalMarketValue,
+        BigDecimal totalCostBasis,
+        BigDecimal unrealizedPnl,
+        Integer holdingsCount,
+        BigDecimal maxHoldingPercent,
+        BigDecimal diversificationScore,
+        BigDecimal riskScore,
+        String riskLevel
+) {
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/TopTickerItemResponse.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/TopTickerItemResponse.java
@@ -1,0 +1,14 @@
+package com.banka1.tradingservice.analytics.dto;
+
+import java.math.BigDecimal;
+
+public record TopTickerItemResponse(
+        Integer rank,
+        Long listingId,
+        String ticker,
+        Long tradedQuantity,
+        BigDecimal tradedNotional,
+        Integer orderCount,
+        Integer transactionCount
+) {
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/TopTickersResponse.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/dto/TopTickersResponse.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.analytics.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TopTickersResponse(
+        String runId,
+        LocalDateTime computedAt,
+        List<TopTickerItemResponse> tickers
+) {
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/repository/AnalyticsClientSegmentRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/repository/AnalyticsClientSegmentRepository.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.analytics.repository;
+
+import com.banka1.tradingservice.analytics.domain.AnalyticsClientSegment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AnalyticsClientSegmentRepository extends JpaRepository<AnalyticsClientSegment, Long> {
+
+    List<AnalyticsClientSegment> findAllByRunIdOrderByRiskScoreDescUserIdAsc(String runId);
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/repository/AnalyticsJobRunRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/repository/AnalyticsJobRunRepository.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.analytics.repository;
+
+import com.banka1.tradingservice.analytics.domain.AnalyticsJobRun;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AnalyticsJobRunRepository extends JpaRepository<AnalyticsJobRun, String> {
+
+    Optional<AnalyticsJobRun> findFirstByStatusOrderByCompletedAtDesc(String status);
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/repository/AnalyticsPortfolioRiskRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/repository/AnalyticsPortfolioRiskRepository.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.analytics.repository;
+
+import com.banka1.tradingservice.analytics.domain.AnalyticsPortfolioRisk;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AnalyticsPortfolioRiskRepository extends JpaRepository<AnalyticsPortfolioRisk, Long> {
+
+    Optional<AnalyticsPortfolioRisk> findByRunIdAndUserId(String runId, Long userId);
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/repository/AnalyticsTopTickerRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/repository/AnalyticsTopTickerRepository.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.analytics.repository;
+
+import com.banka1.tradingservice.analytics.domain.AnalyticsTopTicker;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AnalyticsTopTickerRepository extends JpaRepository<AnalyticsTopTicker, Long> {
+
+    List<AnalyticsTopTicker> findAllByRunIdOrderByTickerRankAsc(String runId);
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/analytics/service/AnalyticsQueryService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/analytics/service/AnalyticsQueryService.java
@@ -1,0 +1,148 @@
+package com.banka1.tradingservice.analytics.service;
+
+import com.banka1.tradingservice.analytics.domain.AnalyticsClientSegment;
+import com.banka1.tradingservice.analytics.domain.AnalyticsJobRun;
+import com.banka1.tradingservice.analytics.domain.AnalyticsPortfolioRisk;
+import com.banka1.tradingservice.analytics.domain.AnalyticsTopTicker;
+import com.banka1.tradingservice.analytics.dto.AnalyticsRunResponse;
+import com.banka1.tradingservice.analytics.dto.ClientSegmentItemResponse;
+import com.banka1.tradingservice.analytics.dto.ClientSegmentsResponse;
+import com.banka1.tradingservice.analytics.dto.PortfolioRiskResponse;
+import com.banka1.tradingservice.analytics.dto.TopTickerItemResponse;
+import com.banka1.tradingservice.analytics.dto.TopTickersResponse;
+import com.banka1.tradingservice.analytics.repository.AnalyticsClientSegmentRepository;
+import com.banka1.tradingservice.analytics.repository.AnalyticsJobRunRepository;
+import com.banka1.tradingservice.analytics.repository.AnalyticsPortfolioRiskRepository;
+import com.banka1.tradingservice.analytics.repository.AnalyticsTopTickerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalyticsQueryService {
+
+    private static final String COMPLETED = "COMPLETED";
+
+    private final AnalyticsJobRunRepository analyticsJobRunRepository;
+    private final AnalyticsClientSegmentRepository analyticsClientSegmentRepository;
+    private final AnalyticsPortfolioRiskRepository analyticsPortfolioRiskRepository;
+    private final AnalyticsTopTickerRepository analyticsTopTickerRepository;
+
+    public AnalyticsRunResponse getLatestRun() {
+        return latestCompletedRun()
+                .map(this::toRunResponse)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "No completed analytics run exists."));
+    }
+
+    public ClientSegmentsResponse getClientSegments() {
+        Optional<AnalyticsJobRun> latestRun = latestCompletedRun();
+        if (latestRun.isEmpty()) {
+            return new ClientSegmentsResponse(null, null, List.of());
+        }
+
+        AnalyticsJobRun run = latestRun.get();
+        List<ClientSegmentItemResponse> segments = analyticsClientSegmentRepository
+                .findAllByRunIdOrderByRiskScoreDescUserIdAsc(run.getRunId())
+                .stream()
+                .map(this::toClientSegmentResponse)
+                .toList();
+
+        return new ClientSegmentsResponse(run.getRunId(), run.getCompletedAt(), segments);
+    }
+
+    public PortfolioRiskResponse getPortfolioRisk(Long userId) {
+        AnalyticsJobRun run = latestCompletedRun()
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "No completed analytics run exists."));
+
+        return analyticsPortfolioRiskRepository.findByRunIdAndUserId(run.getRunId(), userId)
+                .map(risk -> toPortfolioRiskResponse(run, risk))
+                .orElseThrow(() -> new ResponseStatusException(
+                        NOT_FOUND,
+                        "No portfolio risk analytics found for userId=%d.".formatted(userId)
+                ));
+    }
+
+    public TopTickersResponse getTopTickers() {
+        Optional<AnalyticsJobRun> latestRun = latestCompletedRun();
+        if (latestRun.isEmpty()) {
+            return new TopTickersResponse(null, null, List.of());
+        }
+
+        AnalyticsJobRun run = latestRun.get();
+        List<TopTickerItemResponse> tickers = analyticsTopTickerRepository
+                .findAllByRunIdOrderByTickerRankAsc(run.getRunId())
+                .stream()
+                .map(this::toTopTickerResponse)
+                .toList();
+
+        return new TopTickersResponse(run.getRunId(), run.getCompletedAt(), tickers);
+    }
+
+    private Optional<AnalyticsJobRun> latestCompletedRun() {
+        return analyticsJobRunRepository.findFirstByStatusOrderByCompletedAtDesc(COMPLETED);
+    }
+
+    private AnalyticsRunResponse toRunResponse(AnalyticsJobRun run) {
+        return new AnalyticsRunResponse(
+                run.getRunId(),
+                run.getJobName(),
+                run.getStatus(),
+                run.getStartedAt(),
+                run.getCompletedAt(),
+                run.getMessage()
+        );
+    }
+
+    private ClientSegmentItemResponse toClientSegmentResponse(AnalyticsClientSegment segment) {
+        return new ClientSegmentItemResponse(
+                segment.getUserId(),
+                segment.getClusterId(),
+                segment.getSegmentLabel(),
+                segment.getTotalPortfolioValue(),
+                segment.getTotalCostBasis(),
+                segment.getUnrealizedPnl(),
+                segment.getHoldingsCount(),
+                segment.getMaxHoldingPercent(),
+                segment.getOrderCount(),
+                segment.getAverageOrderValue(),
+                segment.getBuySellRatio(),
+                segment.getRiskScore()
+        );
+    }
+
+    private PortfolioRiskResponse toPortfolioRiskResponse(AnalyticsJobRun run, AnalyticsPortfolioRisk risk) {
+        return new PortfolioRiskResponse(
+                run.getRunId(),
+                run.getCompletedAt(),
+                risk.getUserId(),
+                risk.getTotalMarketValue(),
+                risk.getTotalCostBasis(),
+                risk.getUnrealizedPnl(),
+                risk.getHoldingsCount(),
+                risk.getMaxHoldingPercent(),
+                risk.getDiversificationScore(),
+                risk.getRiskScore(),
+                risk.getRiskLevel()
+        );
+    }
+
+    private TopTickerItemResponse toTopTickerResponse(AnalyticsTopTicker ticker) {
+        return new TopTickerItemResponse(
+                ticker.getTickerRank(),
+                ticker.getListingId(),
+                ticker.getTicker(),
+                ticker.getTradedQuantity(),
+                ticker.getTradedNotional(),
+                ticker.getOrderCount(),
+                ticker.getTransactionCount()
+        );
+    }
+}

--- a/trading-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/trading-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -45,4 +45,7 @@
     <!-- DEV-only normalized RSD-only multi-fund fixtures. -->
     <include file="db/changelog/trading-otc/010-fund-seed-rsd-multi-funds.sql"/>
 
+    <!-- Spark analytics materialized results. -->
+    <include file="db/changelog/trading-analytics/011-create-analytics-results.sql"/>
+
 </databaseChangeLog>

--- a/trading-service/src/main/resources/db/changelog/trading-analytics/011-create-analytics-results.sql
+++ b/trading-service/src/main/resources/db/changelog/trading-analytics/011-create-analytics-results.sql
@@ -1,0 +1,94 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+-- liquibase formatted sql
+
+-- changeset codex:011-create-analytics-job-runs
+CREATE TABLE analytics_job_runs (
+    run_id       VARCHAR(36)   PRIMARY KEY,
+    job_name     VARCHAR(80)   NOT NULL,
+    status       VARCHAR(20)   NOT NULL,
+    started_at   TIMESTAMP     NOT NULL,
+    completed_at TIMESTAMP,
+    message      VARCHAR(512)
+);
+
+CREATE INDEX idx_analytics_job_runs_status_completed
+    ON analytics_job_runs (status, completed_at DESC);
+
+-- rollback DROP TABLE IF EXISTS analytics_job_runs;
+
+
+-- changeset codex:011-create-analytics-client-segments
+CREATE TABLE analytics_client_segments (
+    id                    BIGSERIAL       PRIMARY KEY,
+    run_id                VARCHAR(36)     NOT NULL,
+    user_id               BIGINT          NOT NULL,
+    cluster_id            INTEGER         NOT NULL,
+    segment_label         VARCHAR(48)     NOT NULL,
+    total_portfolio_value NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    total_cost_basis      NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    unrealized_pnl        NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    holdings_count        INTEGER         NOT NULL DEFAULT 0,
+    max_holding_percent   NUMERIC(9, 4)   NOT NULL DEFAULT 0,
+    order_count           INTEGER         NOT NULL DEFAULT 0,
+    average_order_value   NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    buy_sell_ratio        NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    risk_score            NUMERIC(9, 4)   NOT NULL DEFAULT 0,
+    computed_at           TIMESTAMP       NOT NULL
+);
+
+CREATE INDEX idx_analytics_client_segments_run
+    ON analytics_client_segments (run_id);
+CREATE INDEX idx_analytics_client_segments_run_risk
+    ON analytics_client_segments (run_id, risk_score DESC, user_id ASC);
+CREATE UNIQUE INDEX uk_analytics_client_segments_run_user
+    ON analytics_client_segments (run_id, user_id);
+
+-- rollback DROP TABLE IF EXISTS analytics_client_segments;
+
+
+-- changeset codex:011-create-analytics-portfolio-risk
+CREATE TABLE analytics_portfolio_risk (
+    id                    BIGSERIAL       PRIMARY KEY,
+    run_id                VARCHAR(36)     NOT NULL,
+    user_id               BIGINT          NOT NULL,
+    total_market_value    NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    total_cost_basis      NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    unrealized_pnl        NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    holdings_count        INTEGER         NOT NULL DEFAULT 0,
+    max_holding_percent   NUMERIC(9, 4)   NOT NULL DEFAULT 0,
+    diversification_score NUMERIC(9, 4)   NOT NULL DEFAULT 0,
+    risk_score            NUMERIC(9, 4)   NOT NULL DEFAULT 0,
+    risk_level            VARCHAR(16)     NOT NULL,
+    computed_at           TIMESTAMP       NOT NULL
+);
+
+CREATE INDEX idx_analytics_portfolio_risk_run
+    ON analytics_portfolio_risk (run_id);
+CREATE INDEX idx_analytics_portfolio_risk_run_score
+    ON analytics_portfolio_risk (run_id, risk_score DESC, user_id ASC);
+CREATE UNIQUE INDEX uk_analytics_portfolio_risk_run_user
+    ON analytics_portfolio_risk (run_id, user_id);
+
+-- rollback DROP TABLE IF EXISTS analytics_portfolio_risk;
+
+
+-- changeset codex:011-create-analytics-top-tickers
+CREATE TABLE analytics_top_tickers (
+    id                BIGSERIAL       PRIMARY KEY,
+    run_id            VARCHAR(36)     NOT NULL,
+    ticker_rank       INTEGER         NOT NULL,
+    listing_id        BIGINT          NOT NULL,
+    ticker            VARCHAR(64)     NOT NULL,
+    traded_quantity   BIGINT          NOT NULL DEFAULT 0,
+    traded_notional   NUMERIC(19, 4)  NOT NULL DEFAULT 0,
+    order_count       INTEGER         NOT NULL DEFAULT 0,
+    transaction_count INTEGER         NOT NULL DEFAULT 0,
+    computed_at       TIMESTAMP       NOT NULL
+);
+
+CREATE INDEX idx_analytics_top_tickers_run
+    ON analytics_top_tickers (run_id, ticker_rank ASC);
+CREATE UNIQUE INDEX uk_analytics_top_tickers_run_rank
+    ON analytics_top_tickers (run_id, ticker_rank);
+
+-- rollback DROP TABLE IF EXISTS analytics_top_tickers;

--- a/trading-service/src/test/java/com/banka1/tradingservice/analytics/service/AnalyticsQueryServiceTest.java
+++ b/trading-service/src/test/java/com/banka1/tradingservice/analytics/service/AnalyticsQueryServiceTest.java
@@ -1,0 +1,169 @@
+package com.banka1.tradingservice.analytics.service;
+
+import com.banka1.tradingservice.analytics.domain.AnalyticsClientSegment;
+import com.banka1.tradingservice.analytics.domain.AnalyticsJobRun;
+import com.banka1.tradingservice.analytics.domain.AnalyticsPortfolioRisk;
+import com.banka1.tradingservice.analytics.domain.AnalyticsTopTicker;
+import com.banka1.tradingservice.analytics.dto.ClientSegmentsResponse;
+import com.banka1.tradingservice.analytics.dto.PortfolioRiskResponse;
+import com.banka1.tradingservice.analytics.dto.TopTickersResponse;
+import com.banka1.tradingservice.analytics.repository.AnalyticsClientSegmentRepository;
+import com.banka1.tradingservice.analytics.repository.AnalyticsJobRunRepository;
+import com.banka1.tradingservice.analytics.repository.AnalyticsPortfolioRiskRepository;
+import com.banka1.tradingservice.analytics.repository.AnalyticsTopTickerRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsQueryServiceTest {
+
+    @Mock
+    private AnalyticsJobRunRepository analyticsJobRunRepository;
+
+    @Mock
+    private AnalyticsClientSegmentRepository analyticsClientSegmentRepository;
+
+    @Mock
+    private AnalyticsPortfolioRiskRepository analyticsPortfolioRiskRepository;
+
+    @Mock
+    private AnalyticsTopTickerRepository analyticsTopTickerRepository;
+
+    @Test
+    void getClientSegmentsReturnsEmptyResponseWhenNoCompletedRunExists() {
+        when(analyticsJobRunRepository.findFirstByStatusOrderByCompletedAtDesc("COMPLETED"))
+                .thenReturn(Optional.empty());
+
+        ClientSegmentsResponse response = service().getClientSegments();
+
+        assertThat(response.runId()).isNull();
+        assertThat(response.computedAt()).isNull();
+        assertThat(response.segments()).isEmpty();
+    }
+
+    @Test
+    void getClientSegmentsReturnsLatestRunSegments() {
+        AnalyticsJobRun run = run("run-1", LocalDateTime.of(2026, 5, 20, 10, 0));
+        AnalyticsClientSegment segment = new AnalyticsClientSegment();
+        segment.setUserId(42L);
+        segment.setClusterId(2);
+        segment.setSegmentLabel("HIGH_EXPOSURE_TRADER");
+        segment.setTotalPortfolioValue(new BigDecimal("100000.0000"));
+        segment.setTotalCostBasis(new BigDecimal("80000.0000"));
+        segment.setUnrealizedPnl(new BigDecimal("20000.0000"));
+        segment.setHoldingsCount(4);
+        segment.setMaxHoldingPercent(new BigDecimal("45.0000"));
+        segment.setOrderCount(12);
+        segment.setAverageOrderValue(new BigDecimal("5500.0000"));
+        segment.setBuySellRatio(new BigDecimal("2.0000"));
+        segment.setRiskScore(new BigDecimal("52.2500"));
+
+        when(analyticsJobRunRepository.findFirstByStatusOrderByCompletedAtDesc("COMPLETED"))
+                .thenReturn(Optional.of(run));
+        when(analyticsClientSegmentRepository.findAllByRunIdOrderByRiskScoreDescUserIdAsc("run-1"))
+                .thenReturn(List.of(segment));
+
+        ClientSegmentsResponse response = service().getClientSegments();
+
+        assertThat(response.runId()).isEqualTo("run-1");
+        assertThat(response.computedAt()).isEqualTo(LocalDateTime.of(2026, 5, 20, 10, 0));
+        assertThat(response.segments()).hasSize(1);
+        assertThat(response.segments().getFirst().userId()).isEqualTo(42L);
+        assertThat(response.segments().getFirst().segmentLabel()).isEqualTo("HIGH_EXPOSURE_TRADER");
+    }
+
+    @Test
+    void getPortfolioRiskReturnsUserSpecificRiskFromLatestRun() {
+        AnalyticsJobRun run = run("run-2", LocalDateTime.of(2026, 5, 20, 11, 0));
+        AnalyticsPortfolioRisk risk = new AnalyticsPortfolioRisk();
+        risk.setUserId(7L);
+        risk.setTotalMarketValue(new BigDecimal("25000.0000"));
+        risk.setTotalCostBasis(new BigDecimal("22000.0000"));
+        risk.setUnrealizedPnl(new BigDecimal("3000.0000"));
+        risk.setHoldingsCount(2);
+        risk.setMaxHoldingPercent(new BigDecimal("80.0000"));
+        risk.setDiversificationScore(new BigDecimal("8.0000"));
+        risk.setRiskScore(new BigDecimal("84.2000"));
+        risk.setRiskLevel("HIGH");
+
+        when(analyticsJobRunRepository.findFirstByStatusOrderByCompletedAtDesc("COMPLETED"))
+                .thenReturn(Optional.of(run));
+        when(analyticsPortfolioRiskRepository.findByRunIdAndUserId("run-2", 7L))
+                .thenReturn(Optional.of(risk));
+
+        PortfolioRiskResponse response = service().getPortfolioRisk(7L);
+
+        assertThat(response.runId()).isEqualTo("run-2");
+        assertThat(response.userId()).isEqualTo(7L);
+        assertThat(response.riskLevel()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void getPortfolioRiskThrowsWhenUserResultDoesNotExist() {
+        AnalyticsJobRun run = run("run-3", LocalDateTime.of(2026, 5, 20, 12, 0));
+        when(analyticsJobRunRepository.findFirstByStatusOrderByCompletedAtDesc("COMPLETED"))
+                .thenReturn(Optional.of(run));
+        when(analyticsPortfolioRiskRepository.findByRunIdAndUserId("run-3", 99L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().getPortfolioRisk(99L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("No portfolio risk analytics found");
+    }
+
+    @Test
+    void getTopTickersReturnsLatestRunTickers() {
+        AnalyticsJobRun run = run("run-4", LocalDateTime.of(2026, 5, 20, 13, 0));
+        AnalyticsTopTicker ticker = new AnalyticsTopTicker();
+        ticker.setTickerRank(1);
+        ticker.setListingId(5L);
+        ticker.setTicker("AAPL");
+        ticker.setTradedQuantity(150L);
+        ticker.setTradedNotional(new BigDecimal("30000.0000"));
+        ticker.setOrderCount(3);
+        ticker.setTransactionCount(2);
+
+        when(analyticsJobRunRepository.findFirstByStatusOrderByCompletedAtDesc("COMPLETED"))
+                .thenReturn(Optional.of(run));
+        when(analyticsTopTickerRepository.findAllByRunIdOrderByTickerRankAsc("run-4"))
+                .thenReturn(List.of(ticker));
+
+        TopTickersResponse response = service().getTopTickers();
+
+        assertThat(response.runId()).isEqualTo("run-4");
+        assertThat(response.tickers()).hasSize(1);
+        assertThat(response.tickers().getFirst().ticker()).isEqualTo("AAPL");
+    }
+
+    private AnalyticsQueryService service() {
+        return new AnalyticsQueryService(
+                analyticsJobRunRepository,
+                analyticsClientSegmentRepository,
+                analyticsPortfolioRiskRepository,
+                analyticsTopTickerRepository
+        );
+    }
+
+    private AnalyticsJobRun run(String runId, LocalDateTime completedAt) {
+        AnalyticsJobRun run = new AnalyticsJobRun();
+        run.setRunId(runId);
+        run.setJobName("trading-analytics-spark");
+        run.setStatus("COMPLETED");
+        run.setStartedAt(completedAt.minusMinutes(2));
+        run.setCompletedAt(completedAt);
+        run.setMessage("Analytics run completed.");
+        return run;
+    }
+}


### PR DESCRIPTION
Add a PySpark batch job that reads portfolio, order, transaction, and listing data through JDBC,
 computes trading analytics with Spark, and writes materialized results back into the trading database.

The analytics include:
  - client segmentation with Spark ML KMeans
  - per-user portfolio risk scoring
  - top traded ticker rankings
  - analytics run metadata with completed/failed status tracking

Add Liquibase migrations, JPA entities, repositories, DTOs, and secured trading-service endpoints
 for fetching the latest analytics results. Also add API gateway routing for /analytics and Kubernetes
 Spark Operator manifests for scheduled execution.