### PR TITLE
Issues 13,14,15,16

### DIFF
--- a/notification-service/src/main/java/app/config/RabbitConfig.java
+++ b/notification-service/src/main/java/app/config/RabbitConfig.java
@@ -170,6 +170,17 @@ public class RabbitConfig {
                 .with(taxRoutingKey);
     }
 
+    @Bean
+    public Binding otcNotificationBinding(
+            Queue notificationServiceQueue,
+            TopicExchange employeeEventsExchange,
+            @Value("${notification.rabbit.otc-routing-key}") String otcRoutingKey
+    ) {
+        return BindingBuilder.bind(notificationServiceQueue)
+                .to(employeeEventsExchange)
+                .with(otcRoutingKey);
+    }
+
     /**
      * Converts RabbitMQ JSON payloads ==> to/from ==> Java objects.
      *

--- a/notification-service/src/main/java/app/entities/RoutingKeys.java
+++ b/notification-service/src/main/java/app/entities/RoutingKeys.java
@@ -77,6 +77,10 @@ public final class RoutingKeys {
      * Routing key za uspesno naplaceni porez.
      */
     public static final String TAX_COLLECTED = "tax.collected";
+    public static final String OTC_COUNTERED = "otc.countered";
+    public static final String OTC_ACCEPTED = "otc.accepted";
+    public static final String OTC_CANCELED = "otc.canceled";
+    public static final String OTC_EXPIRY_REMINDER = "otc.expiry_reminder";
 
     private RoutingKeys() {}
 }

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -16,6 +16,7 @@ notification.rabbit.card-routing-key=${NOTIFICATION_CARD_ROUTING_KEY:card.#}
 notification.rabbit.credit-routing-key=${NOTIFICATION_CREDIT_ROUTING_KEY:credit.#}
 notification.rabbit.order-routing-key=${NOTIFICATION_ORDER_ROUTING_KEY:order.#}
 notification.rabbit.tax-routing-key=${NOTIFICATION_TAX_ROUTING_KEY:tax.#}
+notification.rabbit.otc-routing-key=${NOTIFICATION_OTC_ROUTING_KEY:otc.#}
 
 notification.retry.max-retries=${NOTIFICATION_RETRY_MAX_RETRIES:4}
 notification.retry.delay-seconds=${NOTIFICATION_RETRY_DELAY_SECONDS:5}
@@ -90,6 +91,14 @@ notification.templates.ORDER_DECLINED.subject=Order Declined
 notification.templates.ORDER_DECLINED.body-template=Zdravo {{name}}, order {{orderId}} za listing {{listingId}} je odbijen. Tip: {{orderType}}, smer: {{direction}}, supervisor: {{supervisorId}}.
 notification.templates.TAX_COLLECTED.subject=Tax Collected
 notification.templates.TAX_COLLECTED.body-template=Zdravo {{name}}, naplacen je porez za listing {{listingId}}. Transakcija: {{transactionId}}, porez: {{tax}}, porez u RSD: {{taxRsd}}.
+notification.templates.OTC_COUNTER_OFFERED.subject=OTC Counter Offer
+notification.templates.OTC_COUNTER_OFFERED.body-template=Zdravo {{name}}, druga strana je poslala kontraponudu za OTC pregovor {{offerId}}. Ticker: {{stockTicker}}, kolicina: {{amount}}, cena: {{pricePerStock}}, premija: {{premium}}, status: {{status}}, rok: {{expiryDate}}, vreme: {{timestamp}}.
+notification.templates.OTC_ACCEPTED.subject=OTC Offer Accepted
+notification.templates.OTC_ACCEPTED.body-template=Zdravo {{name}}, OTC pregovor {{offerId}} je prihvacen. Ticker: {{stockTicker}}, kolicina: {{amount}}, cena: {{pricePerStock}}, status: {{status}}, rok: {{expiryDate}}, vreme: {{timestamp}}.
+notification.templates.OTC_CANCELED.subject=OTC Offer Closed
+notification.templates.OTC_CANCELED.body-template=Zdravo {{name}}, OTC pregovor {{offerId}} je zatvoren. Dogadjaj: {{eventType}}, ticker: {{stockTicker}}, status: {{status}}, rok: {{expiryDate}}, vreme: {{timestamp}}.
+notification.templates.OTC_EXPIRY_REMINDER.subject=OTC Contract Expiry Reminder
+notification.templates.OTC_EXPIRY_REMINDER.body-template=Zdravo {{name}}, OTC ugovor {{contractId}} za ticker {{stockTicker}} istice za {{reminderDays}} dana, na datum {{expiryDate}}. Status: {{status}}, vreme obavestenja: {{timestamp}}.
 
 
 # RabbitMQ routing keys
@@ -117,3 +126,7 @@ notification.routing-keys.credit.installment_failed=CREDIT_INSTALLMENT_FAILED
 notification.routing-keys.order.approved=ORDER_APPROVED
 notification.routing-keys.order.declined=ORDER_DECLINED
 notification.routing-keys.tax.collected=TAX_COLLECTED
+notification.routing-keys.otc.countered=OTC_COUNTER_OFFERED
+notification.routing-keys.otc.accepted=OTC_ACCEPTED
+notification.routing-keys.otc.canceled=OTC_CANCELED
+notification.routing-keys.otc.expiry_reminder=OTC_EXPIRY_REMINDER

--- a/notification-service/src/test/java/app/integration/RoutingKeysConfigValidationTest.java
+++ b/notification-service/src/test/java/app/integration/RoutingKeysConfigValidationTest.java
@@ -82,6 +82,14 @@ class RoutingKeysConfigValidationTest {
                 "Missing routing key mapping for: " + RoutingKeys.ORDER_DECLINED);
         assertTrue(routingKeys.containsKey(RoutingKeys.TAX_COLLECTED),
                 "Missing routing key mapping for: " + RoutingKeys.TAX_COLLECTED);
+        assertTrue(routingKeys.containsKey(RoutingKeys.OTC_COUNTERED),
+                "Missing routing key mapping for: " + RoutingKeys.OTC_COUNTERED);
+        assertTrue(routingKeys.containsKey(RoutingKeys.OTC_ACCEPTED),
+                "Missing routing key mapping for: " + RoutingKeys.OTC_ACCEPTED);
+        assertTrue(routingKeys.containsKey(RoutingKeys.OTC_CANCELED),
+                "Missing routing key mapping for: " + RoutingKeys.OTC_CANCELED);
+        assertTrue(routingKeys.containsKey(RoutingKeys.OTC_EXPIRY_REMINDER),
+                "Missing routing key mapping for: " + RoutingKeys.OTC_EXPIRY_REMINDER);
     }
 
     /**

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/client/AccountServiceClient.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/client/AccountServiceClient.java
@@ -85,6 +85,22 @@ public class AccountServiceClient {
                 .block();
     }
 
+    public void debitAccount(String accountNumber, BigDecimal amount, Long ownerId) {
+        log.info("[account-service] debitAccount accountNumber={} ownerId={} amount={}",
+                accountNumber, ownerId, amount);
+
+        webClient(jwtService.generateJwtToken()).post()
+                .uri("/internal/accounts/debit")
+                .bodyValue(Map.of(
+                        "accountNumber", accountNumber,
+                        "amount", amount,
+                        "clientId", ownerId))
+                .retrieve()
+                .toBodilessEntity()
+                .timeout(Duration.ofSeconds(10))
+                .block();
+    }
+
     public AccountDetails getByNumber(String accountNumber) {
         return webClient(currentBearerOrServiceToken()).get()
                 .uri("/internal/accounts/{accountNumber}/details", accountNumber)

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/controller/FundLiquidationController.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/controller/FundLiquidationController.java
@@ -4,6 +4,7 @@ import com.banka1.tradingservice.funds.domain.FundHolding;
 import com.banka1.tradingservice.funds.service.FundHoldingService;
 import com.banka1.tradingservice.funds.service.InvestmentFundService;
 import com.banka1.tradingservice.funds.service.FundLiquidationService;
+import com.banka1.tradingservice.funds.service.FundValueSnapshotService;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -34,6 +35,7 @@ public class FundLiquidationController {
     private final FundLiquidationService liquidationService;
     private final FundHoldingService fundHoldingService;
     private final InvestmentFundService investmentFundService;
+    private final FundValueSnapshotService snapshotService;
 
     @PostMapping("/{fundId}/liquidate")
     @PreAuthorize("hasRole('SERVICE')")
@@ -53,8 +55,9 @@ public class FundLiquidationController {
     public ResponseEntity<FundHolding> addHolding(
             @PathVariable Long fundId,
             @RequestBody AddHoldingRequest req) {
-        return ResponseEntity.ok(
-                fundHoldingService.addOrUpdate(fundId, req.getTicker(), req.getQuantity(), req.getUnitPrice()));
+        FundHolding holding = fundHoldingService.addOrUpdate(fundId, req.getTicker(), req.getQuantity(), req.getUnitPrice());
+        snapshotService.recordSnapshot(fundId, java.time.LocalDate.now());
+        return ResponseEntity.ok(holding);
     }
 
     /** Called by order-service when a fund's bank account is debited for an order. */

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/controller/InvestmentFundController.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/controller/InvestmentFundController.java
@@ -1,14 +1,19 @@
 package com.banka1.tradingservice.funds.controller;
 
 import com.banka1.tradingservice.funds.domain.ClientFundTransaction;
+import com.banka1.tradingservice.funds.dto.FundDetailsAnalyticsDto;
+import com.banka1.tradingservice.funds.dto.FundDividendDistributionDto;
+import com.banka1.tradingservice.funds.dto.FundSortField;
 import com.banka1.tradingservice.funds.dto.ClientFundPositionDto;
 import com.banka1.tradingservice.funds.dto.CreateFundRequest;
 import com.banka1.tradingservice.funds.dto.FundHoldingDto;
 import com.banka1.tradingservice.funds.dto.FundPerformancePointDto;
 import com.banka1.tradingservice.funds.dto.InvestmentFundDto;
 import com.banka1.tradingservice.funds.dto.InvestmentRequest;
+import com.banka1.tradingservice.funds.dto.RecordFundDividendRequest;
 import com.banka1.tradingservice.funds.dto.ReassignManagerRequest;
 import com.banka1.tradingservice.funds.dto.RedemptionRequest;
+import com.banka1.tradingservice.funds.service.FundDividendService;
 import com.banka1.tradingservice.funds.service.FundLiquidationService;
 import com.banka1.tradingservice.funds.service.InvestmentFundService;
 import jakarta.validation.Valid;
@@ -24,6 +29,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import org.springframework.data.domain.Sort;
 
 @RestController
 @RequestMapping("/funds")
@@ -32,17 +38,25 @@ public class InvestmentFundController {
 
     private final InvestmentFundService fundService;
     private final FundLiquidationService fundLiquidationService;
+    private final FundDividendService fundDividendService;
 
     // -------------------- discovery --------------------
 
     @GetMapping
-    public ResponseEntity<List<InvestmentFundDto>> discovery() {
-        return ResponseEntity.ok(fundService.discovery());
+    public ResponseEntity<List<InvestmentFundDto>> discovery(
+            @RequestParam(required = false) FundSortField sortField,
+            @RequestParam(required = false) Sort.Direction sortDirection) {
+        return ResponseEntity.ok(fundService.discovery(sortField, sortDirection));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<InvestmentFundDto> details(@PathVariable Long id) {
         return ResponseEntity.ok(fundService.details(id));
+    }
+
+    @GetMapping("/{id}/analytics")
+    public ResponseEntity<FundDetailsAnalyticsDto> analytics(@PathVariable Long id) {
+        return ResponseEntity.ok(fundService.analytics(id));
     }
 
     // -------------------- supervisor fund mgmt --------------------
@@ -165,6 +179,14 @@ public class InvestmentFundController {
     @GetMapping("/{id}/performance")
     public ResponseEntity<List<FundPerformancePointDto>> fundPerformance(@PathVariable("id") Long fundId) {
         return ResponseEntity.ok(fundService.fundPerformance(fundId));
+    }
+
+    @PostMapping("/{id}/dividends")
+    @PreAuthorize("hasAuthority('FUND_AGENT_MANAGE') or hasRole('SERVICE')")
+    public ResponseEntity<FundDividendDistributionDto> recordDividend(
+            @PathVariable("id") Long fundId,
+            @RequestBody @Valid RecordFundDividendRequest request) {
+        return new ResponseEntity<>(fundDividendService.recordDividend(fundId, request), HttpStatus.CREATED);
     }
 
     // -------------------- admin --------------------

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendDistribution.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendDistribution.java
@@ -1,0 +1,82 @@
+package com.banka1.tradingservice.funds.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fund_dividend_distributions",
+        uniqueConstraints = @UniqueConstraint(name = "uk_fund_dividend_distribution",
+                columnNames = {"fund_id", "stock_ticker", "payment_date"}),
+        indexes = {
+                @Index(name = "idx_fund_dividend_distribution_fund_id", columnList = "fund_id"),
+                @Index(name = "idx_fund_dividend_distribution_payment_date", columnList = "payment_date")
+        })
+@Getter
+@Setter
+public class FundDividendDistribution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "fund_id", nullable = false)
+    private Long fundId;
+
+    @Column(name = "stock_ticker", nullable = false, length = 16)
+    private String stockTicker;
+
+    @Column(name = "payment_date", nullable = false)
+    private LocalDate paymentDate;
+
+    @Column(name = "dividend_per_share", nullable = false, precision = 19, scale = 8)
+    private BigDecimal dividendPerShare;
+
+    @Column(name = "source_currency", nullable = false, length = 8)
+    private String sourceCurrency;
+
+    @Column(name = "holding_quantity", nullable = false)
+    private Integer holdingQuantity;
+
+    @Column(name = "gross_amount_source", nullable = false, precision = 19, scale = 8)
+    private BigDecimal grossAmountSource;
+
+    @Column(name = "gross_amount_rsd", nullable = false, precision = 19, scale = 2)
+    private BigDecimal grossAmountRsd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "strategy", nullable = false, length = 24)
+    private FundDividendStrategy strategy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 24)
+    private FundDividendDistributionStatus status;
+
+    @Column(name = "reinvested_shares")
+    private Integer reinvestedShares;
+
+    @Column(name = "reinvested_amount_rsd", precision = 19, scale = 2)
+    private BigDecimal reinvestedAmountRsd;
+
+    @Column(name = "distributed_amount_rsd", precision = 19, scale = 2)
+    private BigDecimal distributedAmountRsd;
+
+    @Column(name = "note", length = 255)
+    private String note;
+
+    @Column(name = "processed_at", nullable = false)
+    private LocalDateTime processedAt = LocalDateTime.now();
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendDistributionStatus.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendDistributionStatus.java
@@ -1,0 +1,6 @@
+package com.banka1.tradingservice.funds.domain;
+
+public enum FundDividendDistributionStatus {
+    COMPLETED,
+    COMPLETED_WITH_WARNINGS
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendPayout.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendPayout.java
@@ -1,0 +1,59 @@
+package com.banka1.tradingservice.funds.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fund_dividend_payouts",
+        uniqueConstraints = @UniqueConstraint(name = "uk_fund_dividend_payout_distribution_client",
+                columnNames = {"distribution_id", "client_id"}),
+        indexes = {
+                @Index(name = "idx_fund_dividend_payout_distribution_id", columnList = "distribution_id"),
+                @Index(name = "idx_fund_dividend_payout_client_id", columnList = "client_id")
+        })
+@Getter
+@Setter
+public class FundDividendPayout {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "distribution_id", nullable = false)
+    private Long distributionId;
+
+    @Column(name = "client_id", nullable = false)
+    private Long clientId;
+
+    @Column(name = "client_account_number", length = 32)
+    private String clientAccountNumber;
+
+    @Column(name = "ownership_ratio", nullable = false, precision = 19, scale = 8)
+    private BigDecimal ownershipRatio;
+
+    @Column(name = "amount_rsd", nullable = false, precision = 19, scale = 2)
+    private BigDecimal amountRsd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 24)
+    private FundDividendPayoutStatus status;
+
+    @Column(name = "failure_reason", length = 255)
+    private String failureReason;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendPayoutStatus.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendPayoutStatus.java
@@ -1,0 +1,7 @@
+package com.banka1.tradingservice.funds.domain;
+
+public enum FundDividendPayoutStatus {
+    COMPLETED,
+    FAILED,
+    SKIPPED
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendStrategy.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundDividendStrategy.java
@@ -1,0 +1,6 @@
+package com.banka1.tradingservice.funds.domain;
+
+public enum FundDividendStrategy {
+    REINVEST,
+    PAYOUT_CLIENTS
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundValueSnapshot.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/FundValueSnapshot.java
@@ -1,0 +1,51 @@
+package com.banka1.tradingservice.funds.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fund_value_snapshots",
+        uniqueConstraints = @UniqueConstraint(name = "uk_fund_value_snapshot_fund_date",
+                columnNames = {"fund_id", "snapshot_date"}),
+        indexes = {
+                @Index(name = "idx_fund_value_snapshots_fund_id", columnList = "fund_id"),
+                @Index(name = "idx_fund_value_snapshots_snapshot_date", columnList = "snapshot_date")
+        })
+@Getter
+@Setter
+public class FundValueSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "fund_id", nullable = false)
+    private Long fundId;
+
+    @Column(name = "snapshot_date", nullable = false)
+    private LocalDate snapshotDate;
+
+    @Column(name = "liquidity_value", nullable = false, precision = 19, scale = 2)
+    private BigDecimal liquidityValue;
+
+    @Column(name = "holdings_value", nullable = false, precision = 19, scale = 2)
+    private BigDecimal holdingsValue;
+
+    @Column(name = "total_value", nullable = false, precision = 19, scale = 2)
+    private BigDecimal totalValue;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/InvestmentFund.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/domain/InvestmentFund.java
@@ -71,6 +71,11 @@ public class InvestmentFund {
     private String accountNumber;
 
     @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dividend_strategy", nullable = false, length = 24)
+    private FundDividendStrategy dividendStrategy = FundDividendStrategy.REINVEST;
+
+    @NotNull
     @Column(name = "datum_kreiranja", nullable = false)
     private LocalDate datumKreiranja = LocalDate.now();
 

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/CreateFundRequest.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/CreateFundRequest.java
@@ -1,5 +1,6 @@
 package com.banka1.tradingservice.funds.dto;
 
+import com.banka1.tradingservice.funds.domain.FundDividendStrategy;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -26,4 +27,6 @@ public class CreateFundRequest {
     @NotNull
     @DecimalMin(value = "0.00")
     private BigDecimal minimumContribution;
+
+    private FundDividendStrategy dividendStrategy;
 }

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundDetailsAnalyticsDto.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundDetailsAnalyticsDto.java
@@ -1,0 +1,15 @@
+package com.banka1.tradingservice.funds.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class FundDetailsAnalyticsDto {
+    private InvestmentFundDto fund;
+    private FundMetricValuesDto metrics;
+    private List<FundValueSnapshotPointDto> historicalValuePoints;
+    private List<FundPerformanceComparisonPointDto> averageFundPerformancePoints;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundDividendDistributionDto.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundDividendDistributionDto.java
@@ -1,0 +1,33 @@
+package com.banka1.tradingservice.funds.dto;
+
+import com.banka1.tradingservice.funds.domain.FundDividendDistributionStatus;
+import com.banka1.tradingservice.funds.domain.FundDividendStrategy;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class FundDividendDistributionDto {
+    private Long id;
+    private Long fundId;
+    private String stockTicker;
+    private LocalDate paymentDate;
+    private BigDecimal dividendPerShare;
+    private String sourceCurrency;
+    private Integer holdingQuantity;
+    private BigDecimal grossAmountSource;
+    private BigDecimal grossAmountRsd;
+    private FundDividendStrategy strategy;
+    private FundDividendDistributionStatus status;
+    private Integer reinvestedShares;
+    private BigDecimal reinvestedAmountRsd;
+    private BigDecimal distributedAmountRsd;
+    private String note;
+    private LocalDateTime processedAt;
+    private List<FundDividendPayoutDto> payouts;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundDividendPayoutDto.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundDividendPayoutDto.java
@@ -1,0 +1,18 @@
+package com.banka1.tradingservice.funds.dto;
+
+import com.banka1.tradingservice.funds.domain.FundDividendPayoutStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class FundDividendPayoutDto {
+    private Long clientId;
+    private String clientAccountNumber;
+    private BigDecimal ownershipRatio;
+    private BigDecimal amountRsd;
+    private FundDividendPayoutStatus status;
+    private String failureReason;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundMetricValuesDto.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundMetricValuesDto.java
@@ -1,0 +1,16 @@
+package com.banka1.tradingservice.funds.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class FundMetricValuesDto {
+    private Integer monthlySnapshotsUsed;
+    private BigDecimal annualizedReturn;
+    private BigDecimal rewardToVariabilityRatio;
+    private BigDecimal maxDrawdown;
+    private BigDecimal volatility;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundPerformanceComparisonPointDto.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundPerformanceComparisonPointDto.java
@@ -1,0 +1,15 @@
+package com.banka1.tradingservice.funds.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class FundPerformanceComparisonPointDto {
+    private LocalDate snapshotDate;
+    private BigDecimal fundPerformanceIndex;
+    private BigDecimal averagePerformanceIndex;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundSortField.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundSortField.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.funds.dto;
+
+public enum FundSortField {
+    NAME,
+    TOTAL_VALUE,
+    PROFIT,
+    ANNUALIZED_RETURN,
+    REWARD_TO_VARIABILITY_RATIO,
+    MAX_DRAWDOWN,
+    VOLATILITY
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundValueSnapshotPointDto.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/FundValueSnapshotPointDto.java
@@ -1,0 +1,16 @@
+package com.banka1.tradingservice.funds.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class FundValueSnapshotPointDto {
+    private LocalDate snapshotDate;
+    private BigDecimal liquidityValue;
+    private BigDecimal holdingsValue;
+    private BigDecimal totalValue;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/InvestmentFundDto.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/InvestmentFundDto.java
@@ -1,5 +1,6 @@
 package com.banka1.tradingservice.funds.dto;
 
+import com.banka1.tradingservice.funds.domain.FundDividendStrategy;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,9 +28,14 @@ public class InvestmentFundDto {
     private BigDecimal likvidnaSredstva;
     private Long accountId;
     private String accountNumber;
+    private FundDividendStrategy dividendStrategy;
     private LocalDate datumKreiranja;
     /** Izvedeno: likvidnaSredstva + suma vrednosti hartija. */
     private BigDecimal totalValue;
     /** Izvedeno: totalValue - sumOfClientInvestments. */
     private BigDecimal profit;
+    private BigDecimal annualizedReturn;
+    private BigDecimal rewardToVariabilityRatio;
+    private BigDecimal maxDrawdown;
+    private BigDecimal volatility;
 }

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/RecordFundDividendRequest.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/dto/RecordFundDividendRequest.java
@@ -1,0 +1,31 @@
+package com.banka1.tradingservice.funds.dto;
+
+import com.banka1.tradingservice.funds.domain.FundDividendStrategy;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+public class RecordFundDividendRequest {
+
+    @NotBlank
+    private String stockTicker;
+
+    @NotNull
+    @DecimalMin(value = "0.00000001", inclusive = true)
+    private BigDecimal dividendPerShare;
+
+    @NotBlank
+    private String currency;
+
+    @NotNull
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate paymentDate;
+
+    private FundDividendStrategy strategy;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/repository/FundDividendDistributionRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/repository/FundDividendDistributionRepository.java
@@ -1,0 +1,14 @@
+package com.banka1.tradingservice.funds.repository;
+
+import com.banka1.tradingservice.funds.domain.FundDividendDistribution;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface FundDividendDistributionRepository extends JpaRepository<FundDividendDistribution, Long> {
+
+    Optional<FundDividendDistribution> findByFundIdAndStockTickerAndPaymentDate(Long fundId, String stockTicker, LocalDate paymentDate);
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/repository/FundDividendPayoutRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/repository/FundDividendPayoutRepository.java
@@ -1,0 +1,13 @@
+package com.banka1.tradingservice.funds.repository;
+
+import com.banka1.tradingservice.funds.domain.FundDividendPayout;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FundDividendPayoutRepository extends JpaRepository<FundDividendPayout, Long> {
+
+    List<FundDividendPayout> findByDistributionId(Long distributionId);
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/repository/FundValueSnapshotRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/repository/FundValueSnapshotRepository.java
@@ -1,0 +1,19 @@
+package com.banka1.tradingservice.funds.repository;
+
+import com.banka1.tradingservice.funds.domain.FundValueSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FundValueSnapshotRepository extends JpaRepository<FundValueSnapshot, Long> {
+
+    Optional<FundValueSnapshot> findByFundIdAndSnapshotDate(Long fundId, LocalDate snapshotDate);
+
+    List<FundValueSnapshot> findByFundIdOrderBySnapshotDateAsc(Long fundId);
+
+    List<FundValueSnapshot> findBySnapshotDateGreaterThanEqualOrderBySnapshotDateAsc(LocalDate snapshotDate);
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundAccountNumberGenerator.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundAccountNumberGenerator.java
@@ -5,21 +5,17 @@ import org.springframework.stereotype.Component;
 import java.security.SecureRandom;
 
 /**
- * Generator za 19-cifrene RSD racune fondova (PR_04 C4.7).
- *
- * <p>Banking-core ima slican generator za korisnicke racune; trading-service
- * ne moze da ga importuje (cross-modul), pa drzi svoju lightweight implementaciju
- * koja generise 18 random cifara + mod-11 check-digit.
+ * Generator za 16-cifrene racune fondova.
  */
 @Component
 public class FundAccountNumberGenerator {
 
     private final SecureRandom random = new SecureRandom();
 
-    /** 18 random + 1 check-digit = 19 cifara. Mod-11 check-digit (kao ISO 11649 lite). */
+    /** 15 random + 1 check-digit = 16 cifara. */
     public String generate() {
-        StringBuilder sb = new StringBuilder(19);
-        for (int i = 0; i < 18; i++) sb.append(random.nextInt(10));
+        StringBuilder sb = new StringBuilder(16);
+        for (int i = 0; i < 15; i++) sb.append(random.nextInt(10));
         sb.append(checkDigit(sb.toString()));
         return sb.toString();
     }

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundDividendService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundDividendService.java
@@ -1,0 +1,269 @@
+package com.banka1.tradingservice.funds.service;
+
+import com.banka1.order.client.AccountClient;
+import com.banka1.order.dto.client.PaymentDto;
+import com.banka1.tradingservice.funds.client.AccountServiceClient;
+import com.banka1.tradingservice.funds.client.MarketPriceClient;
+import com.banka1.tradingservice.funds.domain.ClientFundPosition;
+import com.banka1.tradingservice.funds.domain.FundDividendDistribution;
+import com.banka1.tradingservice.funds.domain.FundDividendDistributionStatus;
+import com.banka1.tradingservice.funds.domain.FundDividendPayout;
+import com.banka1.tradingservice.funds.domain.FundDividendPayoutStatus;
+import com.banka1.tradingservice.funds.domain.FundDividendStrategy;
+import com.banka1.tradingservice.funds.domain.FundHolding;
+import com.banka1.tradingservice.funds.domain.InvestmentFund;
+import com.banka1.tradingservice.funds.dto.FundDividendDistributionDto;
+import com.banka1.tradingservice.funds.dto.FundDividendPayoutDto;
+import com.banka1.tradingservice.funds.dto.RecordFundDividendRequest;
+import com.banka1.tradingservice.funds.repository.ClientFundPositionRepository;
+import com.banka1.tradingservice.funds.repository.FundDividendDistributionRepository;
+import com.banka1.tradingservice.funds.repository.FundDividendPayoutRepository;
+import com.banka1.tradingservice.funds.repository.FundHoldingRepository;
+import com.banka1.tradingservice.funds.repository.InvestmentFundRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FundDividendService {
+
+    private static final String FUND_BASE_CURRENCY = "RSD";
+
+    private final InvestmentFundRepository fundRepository;
+    private final FundHoldingRepository holdingRepository;
+    private final FundDividendDistributionRepository distributionRepository;
+    private final FundDividendPayoutRepository payoutRepository;
+    private final ClientFundPositionRepository positionRepository;
+    private final FundHoldingService fundHoldingService;
+    private final InvestmentFundService investmentFundService;
+    private final FundValueSnapshotService snapshotService;
+    private final MarketPriceClient marketPriceClient;
+    private final AccountServiceClient accountServiceClient;
+    private final AccountClient accountClient;
+
+    @Transactional
+    public FundDividendDistributionDto recordDividend(Long fundId, RecordFundDividendRequest request) {
+        InvestmentFund fund = fundRepository.findByIdForUpdate(fundId)
+                .orElseThrow(() -> new IllegalArgumentException("Fond " + fundId + " ne postoji."));
+        String ticker = request.getStockTicker().toUpperCase(Locale.ROOT);
+
+        Optional<FundDividendDistribution> existing = distributionRepository.findByFundIdAndStockTickerAndPaymentDate(
+                fundId, ticker, request.getPaymentDate());
+        if (existing.isPresent()) {
+            throw new IllegalStateException("Dividenda za fond " + fundId + ", ticker " + ticker
+                    + " i datum " + request.getPaymentDate() + " je vec evidentirana.");
+        }
+
+        FundHolding holding = holdingRepository.findByFundIdAndStockTickerAndDeletedFalse(fundId, ticker)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Fond " + fundId + " ne poseduje holding za ticker " + ticker + "."));
+        if (holding.getQuantity() == null || holding.getQuantity() <= 0) {
+            throw new IllegalArgumentException("Holding za ticker " + ticker + " nema raspolozivu kolicinu.");
+        }
+
+        FundDividendStrategy strategy = request.getStrategy() != null ? request.getStrategy() : fund.getDividendStrategy();
+        BigDecimal grossSource = request.getDividendPerShare()
+                .multiply(BigDecimal.valueOf(holding.getQuantity()))
+                .setScale(8, RoundingMode.HALF_UP);
+        BigDecimal grossRsd = convertToRsd(grossSource, request.getCurrency()).setScale(2, RoundingMode.HALF_UP);
+
+        creditFundDividend(fund, grossRsd);
+
+        FundDividendDistribution distribution = new FundDividendDistribution();
+        distribution.setFundId(fundId);
+        distribution.setStockTicker(ticker);
+        distribution.setPaymentDate(request.getPaymentDate() != null ? request.getPaymentDate() : LocalDate.now());
+        distribution.setDividendPerShare(request.getDividendPerShare());
+        distribution.setSourceCurrency(request.getCurrency().toUpperCase(Locale.ROOT));
+        distribution.setHoldingQuantity(holding.getQuantity());
+        distribution.setGrossAmountSource(grossSource);
+        distribution.setGrossAmountRsd(grossRsd);
+        distribution.setStrategy(strategy);
+        distribution.setStatus(FundDividendDistributionStatus.COMPLETED);
+
+        List<FundDividendPayout> payoutRows = switch (strategy) {
+            case REINVEST -> handleReinvestment(distribution, fund, holding, grossRsd);
+            case PAYOUT_CLIENTS -> handleClientPayouts(distribution, fund, grossRsd);
+        };
+
+        FundDividendDistribution saved = distributionRepository.save(distribution);
+        for (FundDividendPayout payout : payoutRows) {
+            payout.setDistributionId(saved.getId());
+        }
+        if (!payoutRows.isEmpty()) {
+            payoutRepository.saveAll(payoutRows);
+        }
+
+        snapshotService.recordSnapshot(fundId, LocalDate.now());
+        return toDto(saved, payoutRows);
+    }
+
+    private List<FundDividendPayout> handleReinvestment(FundDividendDistribution distribution,
+                                                        InvestmentFund fund,
+                                                        FundHolding holding,
+                                                        BigDecimal grossRsd) {
+        List<FundDividendPayout> payouts = List.of();
+        BigDecimal currentPriceUsd = marketPriceClient.currentPrice(holding.getStockTicker())
+                .orElse(holding.getAvgUnitPrice());
+        if (currentPriceUsd == null || currentPriceUsd.signum() <= 0) {
+            distribution.setStatus(FundDividendDistributionStatus.COMPLETED_WITH_WARNINGS);
+            distribution.setNote("Dividenda knjizena u likvidnost; nema validne trzisne cene za reinvestiranje.");
+            distribution.setReinvestedShares(0);
+            distribution.setReinvestedAmountRsd(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+            return payouts;
+        }
+        BigDecimal priceRsd = convertToRsd(currentPriceUsd, "USD").setScale(8, RoundingMode.HALF_UP);
+        int sharesToBuy = grossRsd.divide(priceRsd, 0, RoundingMode.DOWN).intValue();
+        if (sharesToBuy <= 0) {
+            distribution.setNote("Dividenda knjizena u likvidnost; iznos nije dovoljan za kupovinu cele akcije.");
+            distribution.setReinvestedShares(0);
+            distribution.setReinvestedAmountRsd(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+            return payouts;
+        }
+        BigDecimal reinvestAmount = priceRsd.multiply(BigDecimal.valueOf(sharesToBuy)).setScale(2, RoundingMode.HALF_UP);
+        fundHoldingService.addOrUpdate(fund.getId(), holding.getStockTicker(), sharesToBuy, currentPriceUsd);
+        investmentFundService.debitLiquidity(fund.getId(), reinvestAmount, "Fund dividend reinvestment");
+        accountServiceClient.debitAccount(fund.getAccountNumber(), reinvestAmount, -1000L - fund.getId());
+        distribution.setReinvestedShares(sharesToBuy);
+        distribution.setReinvestedAmountRsd(reinvestAmount);
+        distribution.setDistributedAmountRsd(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+        distribution.setNote("Dividenda reinvestirana u dodatne hartije.");
+        return payouts;
+    }
+
+    private List<FundDividendPayout> handleClientPayouts(FundDividendDistribution distribution,
+                                                         InvestmentFund fund,
+                                                         BigDecimal grossRsd) {
+        List<ClientFundPosition> clientPositions = positionRepository.findByFundId(fund.getId()).stream()
+                .filter(position -> !InvestmentFundService.BANK_INVESTOR_ID.equals(position.getClientId()))
+                .sorted(Comparator.comparing(ClientFundPosition::getClientId))
+                .toList();
+
+        if (clientPositions.isEmpty()) {
+            distribution.setStatus(FundDividendDistributionStatus.COMPLETED_WITH_WARNINGS);
+            distribution.setDistributedAmountRsd(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+            distribution.setNote("Fond nema klijentske ucesnike; dividenda ostaje u likvidnim sredstvima fonda.");
+            return List.of();
+        }
+
+        BigDecimal fundValueBeforeDividend = fund.getLikvidnaSredstva()
+                .add(fundHoldingService.calculateHoldingsValue(fund.getId()))
+                .subtract(grossRsd)
+                .max(BigDecimal.ZERO);
+        BigDecimal totalInvested = clientPositions.stream()
+                .map(ClientFundPosition::getTotalInvested)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal denominator = totalInvested.max(fundValueBeforeDividend);
+        if (denominator.signum() <= 0) {
+            distribution.setStatus(FundDividendDistributionStatus.COMPLETED_WITH_WARNINGS);
+            distribution.setDistributedAmountRsd(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP));
+            distribution.setNote("Nema dovoljno osnova za proporcionalnu raspodelu dividende.");
+            return List.of();
+        }
+
+        BigDecimal distributed = BigDecimal.ZERO;
+        List<FundDividendPayout> result = new ArrayList<>();
+        for (int i = 0; i < clientPositions.size(); i++) {
+            ClientFundPosition position = clientPositions.get(i);
+            BigDecimal ownershipRatio = position.getTotalInvested()
+                    .divide(denominator, 8, RoundingMode.HALF_UP);
+            BigDecimal payoutAmount = i == clientPositions.size() - 1
+                    ? grossRsd.subtract(distributed)
+                    : grossRsd.multiply(ownershipRatio).setScale(2, RoundingMode.HALF_UP);
+            if (payoutAmount.signum() <= 0) {
+                continue;
+            }
+            FundDividendPayout payout = new FundDividendPayout();
+            payout.setClientId(position.getClientId());
+            payout.setOwnershipRatio(ownershipRatio);
+            payout.setAmountRsd(payoutAmount);
+            String clientAccountNumber = accountClient.getDefaultRsdAccountNumberForOwner(position.getClientId());
+            payout.setClientAccountNumber(clientAccountNumber);
+            if (clientAccountNumber == null || clientAccountNumber.isBlank()) {
+                payout.setStatus(FundDividendPayoutStatus.SKIPPED);
+                payout.setFailureReason("Klijent nema podrazumevani RSD racun.");
+                distribution.setStatus(FundDividendDistributionStatus.COMPLETED_WITH_WARNINGS);
+            } else {
+                try {
+                    accountClient.transaction(new PaymentDto(
+                            fund.getAccountNumber(),
+                            clientAccountNumber,
+                            payoutAmount,
+                            payoutAmount,
+                            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+                            -1000L - fund.getId()
+                    ));
+                    investmentFundService.debitLiquidity(fund.getId(), payoutAmount, "Fund dividend payout");
+                    payout.setStatus(FundDividendPayoutStatus.COMPLETED);
+                    distributed = distributed.add(payoutAmount);
+                } catch (Exception ex) {
+                    payout.setStatus(FundDividendPayoutStatus.FAILED);
+                    payout.setFailureReason(ex.getMessage());
+                    distribution.setStatus(FundDividendDistributionStatus.COMPLETED_WITH_WARNINGS);
+                }
+            }
+            result.add(payout);
+        }
+        distribution.setDistributedAmountRsd(distributed.setScale(2, RoundingMode.HALF_UP));
+        if (distribution.getNote() == null) {
+            distribution.setNote("Dividenda raspodeljena klijentima proporcionalno udelu.");
+        }
+        return result;
+    }
+
+    private void creditFundDividend(InvestmentFund fund, BigDecimal grossRsd) {
+        fund.setLikvidnaSredstva(fund.getLikvidnaSredstva().add(grossRsd).setScale(2, RoundingMode.HALF_UP));
+        fundRepository.save(fund);
+        accountServiceClient.creditAccount(fund.getAccountNumber(), grossRsd, -1000L - fund.getId());
+    }
+
+    private BigDecimal convertToRsd(BigDecimal amount, String fromCurrency) {
+        if (amount == null) {
+            return BigDecimal.ZERO;
+        }
+        if (fromCurrency == null || FUND_BASE_CURRENCY.equalsIgnoreCase(fromCurrency)) {
+            return amount;
+        }
+        return marketPriceClient.convertNoCommission(amount, fromCurrency.toUpperCase(Locale.ROOT), FUND_BASE_CURRENCY)
+                .orElse(amount);
+    }
+
+    private FundDividendDistributionDto toDto(FundDividendDistribution distribution, List<FundDividendPayout> payouts) {
+        return FundDividendDistributionDto.builder()
+                .id(distribution.getId())
+                .fundId(distribution.getFundId())
+                .stockTicker(distribution.getStockTicker())
+                .paymentDate(distribution.getPaymentDate())
+                .dividendPerShare(distribution.getDividendPerShare())
+                .sourceCurrency(distribution.getSourceCurrency())
+                .holdingQuantity(distribution.getHoldingQuantity())
+                .grossAmountSource(distribution.getGrossAmountSource())
+                .grossAmountRsd(distribution.getGrossAmountRsd())
+                .strategy(distribution.getStrategy())
+                .status(distribution.getStatus())
+                .reinvestedShares(distribution.getReinvestedShares())
+                .reinvestedAmountRsd(distribution.getReinvestedAmountRsd())
+                .distributedAmountRsd(distribution.getDistributedAmountRsd())
+                .note(distribution.getNote())
+                .processedAt(distribution.getProcessedAt())
+                .payouts(payouts.stream().map(payout -> FundDividendPayoutDto.builder()
+                        .clientId(payout.getClientId())
+                        .clientAccountNumber(payout.getClientAccountNumber())
+                        .ownershipRatio(payout.getOwnershipRatio())
+                        .amountRsd(payout.getAmountRsd())
+                        .status(payout.getStatus())
+                        .failureReason(payout.getFailureReason())
+                        .build()).toList())
+                .build();
+    }
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundLiquidationService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundLiquidationService.java
@@ -54,6 +54,7 @@ public class FundLiquidationService {
      */
     private final ObjectProvider<MarketPriceClient> marketPriceClientProvider;
     private final ObjectProvider<AccountServiceClient> accountServiceClientProvider;
+    private final FundValueSnapshotService snapshotService;
 
     @Transactional
     public Result liquidateForFund(Long fundId, BigDecimal targetAmount, String correlationId) {
@@ -126,6 +127,7 @@ public class FundLiquidationService {
         fund.setLikvidnaSredstva(fund.getLikvidnaSredstva().add(liquidatedTotal));
         fundRepository.save(fund);
         creditFundAccount(fund, liquidatedTotal, correlationId);
+        snapshotService.recordSnapshot(fundId, java.time.LocalDate.now());
 
         String liquidationId = UUID.randomUUID().toString();
         log.info("FundLiquidation: fundId={} target={} liquidatedRsd={} liquidatedUsd={} holdings={} live={} fallback={} liquidationId={} correlationId={}",
@@ -175,6 +177,7 @@ public class FundLiquidationService {
         fund.setLikvidnaSredstva(fund.getLikvidnaSredstva().add(proceeds));
         fundRepository.save(fund);
         creditFundAccount(fund, proceeds, "supervisor-sell");
+        snapshotService.recordSnapshot(fundId, java.time.LocalDate.now());
 
         log.info("Supervisor sold {}x {} from fund {} at {} = {} USD / {} RSD",
                 quantity, ticker, fundId, unitPrice, proceedsUsd, proceeds);

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundStatisticsService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundStatisticsService.java
@@ -1,0 +1,145 @@
+package com.banka1.tradingservice.funds.service;
+
+import com.banka1.tradingservice.funds.domain.FundValueSnapshot;
+import com.banka1.tradingservice.funds.dto.FundMetricValuesDto;
+import com.banka1.tradingservice.funds.dto.FundSortField;
+import com.banka1.tradingservice.funds.dto.InvestmentFundDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FundStatisticsService {
+
+    static final int MIN_MONTHLY_SNAPSHOTS = 12;
+    private static final MathContext MC = new MathContext(12, RoundingMode.HALF_UP);
+    private static final BigDecimal HUNDRED = new BigDecimal("100");
+
+    private final FundValueSnapshotService snapshotService;
+
+    public FundMetricValuesDto metricsFor(Long fundId) {
+        return metricsFromSnapshots(snapshotService.monthlySnapshots(fundId));
+    }
+
+    public List<InvestmentFundDto> sort(List<InvestmentFundDto> funds, FundSortField sortField, Sort.Direction sortDirection) {
+        Comparator<BigDecimal> moneyComparator = sortDirection == Sort.Direction.DESC
+                ? Comparator.nullsLast(Comparator.reverseOrder())
+                : Comparator.nullsLast(Comparator.naturalOrder());
+        Comparator<InvestmentFundDto> comparator = switch (sortField) {
+            case TOTAL_VALUE -> Comparator.comparing(InvestmentFundDto::getTotalValue, moneyComparator);
+            case PROFIT -> Comparator.comparing(InvestmentFundDto::getProfit, moneyComparator);
+            case ANNUALIZED_RETURN -> Comparator.comparing(InvestmentFundDto::getAnnualizedReturn, moneyComparator);
+            case REWARD_TO_VARIABILITY_RATIO -> Comparator.comparing(
+                    InvestmentFundDto::getRewardToVariabilityRatio, moneyComparator);
+            case MAX_DRAWDOWN -> Comparator.comparing(InvestmentFundDto::getMaxDrawdown, moneyComparator);
+            case VOLATILITY -> Comparator.comparing(InvestmentFundDto::getVolatility, moneyComparator);
+            case NAME -> Comparator.comparing(InvestmentFundDto::getNaziv, String.CASE_INSENSITIVE_ORDER);
+        };
+        if (sortDirection == Sort.Direction.DESC && sortField == FundSortField.NAME) {
+            comparator = comparator.reversed();
+        }
+        return funds.stream()
+                .sorted(comparator.thenComparing(InvestmentFundDto::getNaziv, String.CASE_INSENSITIVE_ORDER))
+                .toList();
+    }
+
+    FundMetricValuesDto metricsFromSnapshots(List<FundValueSnapshot> monthlySnapshots) {
+        if (monthlySnapshots == null || monthlySnapshots.size() < MIN_MONTHLY_SNAPSHOTS) {
+            return FundMetricValuesDto.builder()
+                    .monthlySnapshotsUsed(monthlySnapshots == null ? 0 : monthlySnapshots.size())
+                    .annualizedReturn(null)
+                    .rewardToVariabilityRatio(null)
+                    .maxDrawdown(null)
+                    .volatility(null)
+                    .build();
+        }
+
+        List<BigDecimal> values = monthlySnapshots.stream().map(FundValueSnapshot::getTotalValue).toList();
+        BigDecimal annualizedReturn = calculateAnnualizedReturn(values);
+        BigDecimal volatility = calculateVolatility(values);
+        BigDecimal rewardRatio = (annualizedReturn == null || volatility == null || volatility.signum() == 0)
+                ? null
+                : annualizedReturn.divide(volatility, 6, RoundingMode.HALF_UP);
+        BigDecimal maxDrawdown = calculateMaxDrawdown(values);
+
+        return FundMetricValuesDto.builder()
+                .monthlySnapshotsUsed(monthlySnapshots.size())
+                .annualizedReturn(scaleOrNull(annualizedReturn))
+                .rewardToVariabilityRatio(scaleOrNull(rewardRatio))
+                .maxDrawdown(scaleOrNull(maxDrawdown))
+                .volatility(scaleOrNull(volatility))
+                .build();
+    }
+
+    private BigDecimal calculateAnnualizedReturn(List<BigDecimal> values) {
+        BigDecimal start = values.get(0);
+        BigDecimal end = values.get(values.size() - 1);
+        if (start == null || end == null || start.signum() <= 0) {
+            return null;
+        }
+        double ratio = end.divide(start, MC).doubleValue();
+        double years = (double) (values.size() - 1) / 12.0d;
+        if (years <= 0d) {
+            return null;
+        }
+        return BigDecimal.valueOf(Math.pow(ratio, 1.0d / years) - 1.0d).multiply(HUNDRED);
+    }
+
+    private BigDecimal calculateVolatility(List<BigDecimal> values) {
+        List<BigDecimal> returns = monthlyReturns(values);
+        if (returns.isEmpty()) {
+            return null;
+        }
+        double mean = returns.stream().mapToDouble(BigDecimal::doubleValue).average().orElse(0d);
+        double variance = returns.stream()
+                .mapToDouble(value -> Math.pow(value.doubleValue() - mean, 2))
+                .average()
+                .orElse(0d);
+        return BigDecimal.valueOf(Math.sqrt(variance)).multiply(HUNDRED);
+    }
+
+    private BigDecimal calculateMaxDrawdown(List<BigDecimal> values) {
+        BigDecimal peak = values.get(0);
+        BigDecimal maxDrawdown = BigDecimal.ZERO;
+        for (BigDecimal value : values) {
+            if (value.compareTo(peak) > 0) {
+                peak = value;
+            }
+            if (peak.signum() > 0) {
+                BigDecimal drawdown = peak.subtract(value)
+                        .divide(peak, 8, RoundingMode.HALF_UP)
+                        .multiply(HUNDRED);
+                if (drawdown.compareTo(maxDrawdown) > 0) {
+                    maxDrawdown = drawdown;
+                }
+            }
+        }
+        return maxDrawdown;
+    }
+
+    private List<BigDecimal> monthlyReturns(List<BigDecimal> values) {
+        List<BigDecimal> returns = new ArrayList<>();
+        for (int i = 1; i < values.size(); i++) {
+            BigDecimal previous = values.get(i - 1);
+            BigDecimal current = values.get(i);
+            if (previous == null || current == null || previous.signum() <= 0) {
+                continue;
+            }
+            returns.add(current.subtract(previous)
+                    .divide(previous, 8, RoundingMode.HALF_UP));
+        }
+        return returns;
+    }
+
+    private BigDecimal scaleOrNull(BigDecimal value) {
+        return value == null ? null : value.setScale(4, RoundingMode.HALF_UP);
+    }
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundValueSnapshotService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/service/FundValueSnapshotService.java
@@ -1,0 +1,143 @@
+package com.banka1.tradingservice.funds.service;
+
+import com.banka1.tradingservice.funds.domain.FundValueSnapshot;
+import com.banka1.tradingservice.funds.domain.InvestmentFund;
+import com.banka1.tradingservice.funds.dto.FundPerformanceComparisonPointDto;
+import com.banka1.tradingservice.funds.dto.FundValueSnapshotPointDto;
+import com.banka1.tradingservice.funds.repository.FundValueSnapshotRepository;
+import com.banka1.tradingservice.funds.repository.InvestmentFundRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FundValueSnapshotService {
+
+    private final FundValueSnapshotRepository snapshotRepository;
+    private final InvestmentFundRepository fundRepository;
+    private final FundHoldingService fundHoldingService;
+
+    @Transactional
+    public FundValueSnapshot recordSnapshot(Long fundId, LocalDate snapshotDate) {
+        InvestmentFund fund = fundRepository.findById(fundId)
+                .orElseThrow(() -> new IllegalArgumentException("Fond " + fundId + " ne postoji."));
+        BigDecimal liquidity = safeMoney(fund.getLikvidnaSredstva());
+        BigDecimal holdings = safeMoney(fundHoldingService.calculateHoldingsValue(fundId));
+        BigDecimal total = liquidity.add(holdings).setScale(2, RoundingMode.HALF_UP);
+
+        FundValueSnapshot snapshot = snapshotRepository.findByFundIdAndSnapshotDate(fundId, snapshotDate)
+                .orElseGet(FundValueSnapshot::new);
+        snapshot.setFundId(fundId);
+        snapshot.setSnapshotDate(snapshotDate);
+        snapshot.setLiquidityValue(liquidity);
+        snapshot.setHoldingsValue(holdings);
+        snapshot.setTotalValue(total);
+        return snapshotRepository.save(snapshot);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FundValueSnapshotPointDto> history(Long fundId) {
+        return snapshotRepository.findByFundIdOrderBySnapshotDateAsc(fundId).stream()
+                .map(snapshot -> FundValueSnapshotPointDto.builder()
+                        .snapshotDate(snapshot.getSnapshotDate())
+                        .liquidityValue(snapshot.getLiquidityValue())
+                        .holdingsValue(snapshot.getHoldingsValue())
+                        .totalValue(snapshot.getTotalValue())
+                        .build())
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<FundValueSnapshot> monthlySnapshots(Long fundId) {
+        Map<YearMonth, FundValueSnapshot> lastPerMonth = new LinkedHashMap<>();
+        for (FundValueSnapshot snapshot : snapshotRepository.findByFundIdOrderBySnapshotDateAsc(fundId)) {
+            lastPerMonth.put(YearMonth.from(snapshot.getSnapshotDate()), snapshot);
+        }
+        return lastPerMonth.values().stream()
+                .sorted(Comparator.comparing(FundValueSnapshot::getSnapshotDate))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<FundPerformanceComparisonPointDto> averagePerformance(Long fundId) {
+        List<FundValueSnapshot> baseFund = snapshotRepository.findByFundIdOrderBySnapshotDateAsc(fundId);
+        if (baseFund.isEmpty()) {
+            return List.of();
+        }
+        BigDecimal baseFundValue = baseFund.get(0).getTotalValue();
+        if (baseFundValue == null || baseFundValue.signum() <= 0) {
+            return List.of();
+        }
+
+        List<InvestmentFund> funds = fundRepository.findByDeletedFalseOrderByNazivAsc();
+        Map<Long, List<FundValueSnapshot>> allSnapshots = new LinkedHashMap<>();
+        for (InvestmentFund fund : funds) {
+            allSnapshots.put(fund.getId(), snapshotRepository.findByFundIdOrderBySnapshotDateAsc(fund.getId()));
+        }
+
+        List<LocalDate> dates = baseFund.stream().map(FundValueSnapshot::getSnapshotDate).toList();
+        return dates.stream().map(date -> {
+            BigDecimal fundIndex = indexForDate(baseFund, date);
+            BigDecimal sum = BigDecimal.ZERO;
+            int count = 0;
+            for (List<FundValueSnapshot> snapshots : allSnapshots.values()) {
+                BigDecimal idx = indexForDate(snapshots, date);
+                if (idx != null) {
+                    sum = sum.add(idx);
+                    count++;
+                }
+            }
+            BigDecimal average = count == 0 ? null
+                    : sum.divide(BigDecimal.valueOf(count), 4, RoundingMode.HALF_UP);
+            return FundPerformanceComparisonPointDto.builder()
+                    .snapshotDate(date)
+                    .fundPerformanceIndex(fundIndex)
+                    .averagePerformanceIndex(average)
+                    .build();
+        }).toList();
+    }
+
+    @Scheduled(cron = "${fund.snapshot.cron:0 10 0 * * *}")
+    @Transactional
+    public void captureDailySnapshots() {
+        LocalDate today = LocalDate.now();
+        for (InvestmentFund fund : fundRepository.findByDeletedFalseOrderByNazivAsc()) {
+            recordSnapshot(fund.getId(), today);
+        }
+        log.debug("Captured daily fund snapshots for {}", today);
+    }
+
+    private BigDecimal indexForDate(List<FundValueSnapshot> snapshots, LocalDate date) {
+        if (snapshots == null || snapshots.isEmpty()) {
+            return null;
+        }
+        BigDecimal base = snapshots.get(0).getTotalValue();
+        if (base == null || base.signum() <= 0) {
+            return null;
+        }
+        return snapshots.stream()
+                .filter(snapshot -> snapshot.getSnapshotDate().equals(date))
+                .findFirst()
+                .map(snapshot -> snapshot.getTotalValue()
+                        .divide(base, 4, RoundingMode.HALF_UP)
+                        .multiply(new BigDecimal("100")))
+                .orElse(null);
+    }
+
+    private BigDecimal safeMoney(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value.setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/funds/service/InvestmentFundService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/funds/service/InvestmentFundService.java
@@ -5,12 +5,16 @@ import com.banka1.tradingservice.funds.client.UserServiceClient;
 import com.banka1.tradingservice.funds.domain.ClientFundPosition;
 import com.banka1.tradingservice.funds.domain.ClientFundTransaction;
 import com.banka1.tradingservice.funds.domain.ClientFundTransactionStatus;
+import com.banka1.tradingservice.funds.domain.FundDividendStrategy;
 import com.banka1.tradingservice.funds.domain.FundHolding;
 import com.banka1.tradingservice.funds.domain.InvestmentFund;
 import com.banka1.tradingservice.funds.dto.ClientFundPositionDto;
 import com.banka1.tradingservice.funds.dto.CreateFundRequest;
 import com.banka1.tradingservice.funds.dto.FundHoldingDto;
 import com.banka1.tradingservice.funds.dto.FundPerformancePointDto;
+import com.banka1.tradingservice.funds.dto.FundDetailsAnalyticsDto;
+import com.banka1.tradingservice.funds.dto.FundMetricValuesDto;
+import com.banka1.tradingservice.funds.dto.FundSortField;
 import com.banka1.tradingservice.funds.dto.InvestmentFundDto;
 import com.banka1.tradingservice.funds.dto.InvestmentRequest;
 import com.banka1.tradingservice.funds.dto.RedemptionRequest;
@@ -28,6 +32,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -45,6 +50,8 @@ public class InvestmentFundService {
     private final RabbitTemplate rabbitTemplate;
     private final FundAccountNumberGenerator accountNumberGenerator;
     private final FundHoldingService fundHoldingService;
+    private final FundValueSnapshotService snapshotService;
+    private final FundStatisticsService statisticsService;
     private final ObjectProvider<AccountServiceClient> accountServiceClientProvider;
     private final ObjectProvider<UserServiceClient> userServiceClientProvider;
 
@@ -63,6 +70,7 @@ public class InvestmentFundService {
         fund.setManagerId(managerId);
         fund.setLikvidnaSredstva(BigDecimal.ZERO);
         fund.setAccountNumber(accountNumber);
+        fund.setDividendStrategy(req.getDividendStrategy() != null ? req.getDividendStrategy() : FundDividendStrategy.REINVEST);
 
         InvestmentFund saved = fundRepository.save(fund);
 
@@ -85,22 +93,39 @@ public class InvestmentFundService {
         }
 
         log.info("Created InvestmentFund {} ('{}') by manager {}", saved.getId(), saved.getNaziv(), managerId);
-        return toDto(saved);
+        snapshotService.recordSnapshot(saved.getId(), LocalDate.now());
+        return toDto(saved, statisticsService.metricsFor(saved.getId()));
     }
 
     // ----------------------------- read ------------------------------
 
     @Transactional(readOnly = true)
-    public List<InvestmentFundDto> discovery() {
-        return fundRepository.findByDeletedFalseOrderByNazivAsc()
-                .stream().map(this::toDto).toList();
+    public List<InvestmentFundDto> discovery(FundSortField sortField, org.springframework.data.domain.Sort.Direction sortDirection) {
+        List<InvestmentFundDto> funds = fundRepository.findByDeletedFalseOrderByNazivAsc()
+                .stream()
+                .map(fund -> toDto(fund, statisticsService.metricsFor(fund.getId())))
+                .toList();
+        return statisticsService.sort(funds,
+                sortField != null ? sortField : FundSortField.NAME,
+                sortDirection != null ? sortDirection : org.springframework.data.domain.Sort.Direction.ASC);
     }
 
     @Transactional(readOnly = true)
     public InvestmentFundDto details(Long fundId) {
         return fundRepository.findById(fundId)
-                .map(this::toDto)
+                .map(fund -> toDto(fund, statisticsService.metricsFor(fundId)))
                 .orElseThrow(() -> new IllegalArgumentException("Fond " + fundId + " ne postoji."));
+    }
+
+    @Transactional(readOnly = true)
+    public FundDetailsAnalyticsDto analytics(Long fundId) {
+        InvestmentFundDto fund = details(fundId);
+        return FundDetailsAnalyticsDto.builder()
+                .fund(fund)
+                .metrics(statisticsService.metricsFor(fundId))
+                .historicalValuePoints(snapshotService.history(fundId))
+                .averageFundPerformancePoints(snapshotService.averagePerformance(fundId))
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -112,7 +137,9 @@ public class InvestmentFundService {
     @Transactional(readOnly = true)
     public List<InvestmentFundDto> supervisedBy(Long managerId) {
         return fundRepository.findByManagerIdAndDeletedFalse(managerId)
-                .stream().map(this::toDto).toList();
+                .stream()
+                .map(fund -> toDto(fund, statisticsService.metricsFor(fund.getId())))
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -192,6 +219,7 @@ public class InvestmentFundService {
         BigDecimal current = fund.getLikvidnaSredstva() == null ? BigDecimal.ZERO : fund.getLikvidnaSredstva();
         fund.setLikvidnaSredstva(current.subtract(amount).setScale(2, RoundingMode.HALF_UP));
         fundRepository.save(fund);
+        snapshotService.recordSnapshot(fundId, LocalDate.now());
         log.info("Fund liquidity debited: fundId={} amount={} newLiquidity={} reason={}",
                 fundId, amount, fund.getLikvidnaSredstva(), reason);
     }
@@ -365,6 +393,7 @@ public class InvestmentFundService {
             fund.setLikvidnaSredstva(fund.getLikvidnaSredstva().add(amount));
             fundRepository.save(fund);
         });
+        snapshotService.recordSnapshot(fundId, LocalDate.now());
 
         log.info("completeInvest: txId={} clientId={} fundId={} amount={}", txId, clientId, fundId, amount);
     }
@@ -419,6 +448,7 @@ public class InvestmentFundService {
             fund.setLikvidnaSredstva(newLiquidity.max(BigDecimal.ZERO));
             fundRepository.save(fund);
         });
+        snapshotService.recordSnapshot(fundId, LocalDate.now());
 
         log.info("completeRedeem: txId={} clientId={} fundId={} amount={}", txId, clientId, fundId, amount);
     }
@@ -477,7 +507,7 @@ public class InvestmentFundService {
         return pct.multiply(fundValue).setScale(2, RoundingMode.HALF_UP);
     }
 
-    private InvestmentFundDto toDto(InvestmentFund f) {
+    private InvestmentFundDto toDto(InvestmentFund f, FundMetricValuesDto metrics) {
         BigDecimal holdingsValue = fundHoldingService.calculateHoldingsValue(f.getId());
         BigDecimal totalValue = f.getLikvidnaSredstva().add(holdingsValue);
         BigDecimal investedSum = positionRepository.findByFundId(f.getId()).stream()
@@ -510,9 +540,14 @@ public class InvestmentFundService {
                 .likvidnaSredstva(f.getLikvidnaSredstva())
                 .accountId(accountId)
                 .accountNumber(f.getAccountNumber())
+                .dividendStrategy(f.getDividendStrategy())
                 .datumKreiranja(f.getDatumKreiranja())
                 .totalValue(totalValue)
                 .profit(profit)
+                .annualizedReturn(metrics != null ? metrics.getAnnualizedReturn() : null)
+                .rewardToVariabilityRatio(metrics != null ? metrics.getRewardToVariabilityRatio() : null)
+                .maxDrawdown(metrics != null ? metrics.getMaxDrawdown() : null)
+                .volatility(metrics != null ? metrics.getVolatility() : null)
                 .build();
     }
 

--- a/trading-service/src/main/java/com/banka1/tradingservice/notification/TradingNotificationProducer.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/notification/TradingNotificationProducer.java
@@ -1,0 +1,30 @@
+package com.banka1.tradingservice.notification;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class TradingNotificationProducer {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @Value("${rabbitmq.exchange}")
+    private String exchange;
+
+    public void send(String routingKey, String username, String userEmail, Map<String, String> variables) {
+        rabbitTemplate.convertAndSend(exchange, routingKey,
+                new TradingNotificationRequest(username, userEmail, variables == null ? Map.of() : new HashMap<>(variables)));
+    }
+
+    public record TradingNotificationRequest(
+            String username,
+            String userEmail,
+            Map<String, String> templateVariables
+    ) {}
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/controller/OtcController.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/controller/OtcController.java
@@ -3,10 +3,13 @@ package com.banka1.tradingservice.otc.controller;
 import com.banka1.tradingservice.otc.dto.CounterOfferRequest;
 import com.banka1.tradingservice.otc.dto.CreateOtcOfferRequest;
 import com.banka1.tradingservice.otc.dto.CreateOtcPositionRequest;
+import com.banka1.tradingservice.otc.dto.OtcNegotiationHistoryFilterRequest;
+import com.banka1.tradingservice.otc.dto.OtcNegotiationHistoryResponse;
 import com.banka1.tradingservice.otc.dto.OtcOfferDto;
 import com.banka1.tradingservice.otc.dto.OtcPositionDto;
 import com.banka1.tradingservice.otc.dto.PublicStockDto;
 import com.banka1.tradingservice.otc.dto.UpdateOtcPositionRequest;
+import com.banka1.tradingservice.otc.service.OtcNegotiationHistoryService;
 import com.banka1.tradingservice.otc.service.OtcService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +31,7 @@ import java.util.List;
 public class OtcController {
 
     private final OtcService otcService;
+    private final OtcNegotiationHistoryService historyService;
 
     /**
      * Inicijalna ponuda kupca prodavcu (status PENDING_SELLER).
@@ -154,5 +158,13 @@ public class OtcController {
             @RequestParam(required = false) com.banka1.tradingservice.otc.domain.OptionContractStatus status) {
         Long userId = jwt.getClaim("id");
         return ResponseEntity.ok(otcService.myContracts(userId, status));
+    }
+
+    @GetMapping("/offers/history")
+    public ResponseEntity<List<OtcNegotiationHistoryResponse>> negotiationHistory(
+            @AuthenticationPrincipal Jwt jwt,
+            OtcNegotiationHistoryFilterRequest filter) {
+        Long userId = jwt.getClaim("id");
+        return ResponseEntity.ok(historyService.historyForUser(userId, filter));
     }
 }

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/domain/OtcContractExpiryReminder.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/domain/OtcContractExpiryReminder.java
@@ -1,0 +1,37 @@
+package com.banka1.tradingservice.otc.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "otc_contract_expiry_reminders",
+        uniqueConstraints = @UniqueConstraint(name = "uk_otc_contract_expiry_reminder",
+                columnNames = {"contract_id", "reminder_days"}),
+        indexes = @Index(name = "idx_otc_expiry_reminders_sent_at", columnList = "sent_at"))
+@Getter
+@Setter
+public class OtcContractExpiryReminder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "contract_id", nullable = false)
+    private Long contractId;
+
+    @Column(name = "reminder_days", nullable = false)
+    private Integer reminderDays;
+
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt = LocalDateTime.now();
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/domain/OtcNegotiationEventType.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/domain/OtcNegotiationEventType.java
@@ -1,0 +1,10 @@
+package com.banka1.tradingservice.otc.domain;
+
+public enum OtcNegotiationEventType {
+    CREATED,
+    COUNTER_OFFERED,
+    ACCEPTED,
+    REJECTED,
+    WITHDRAWN,
+    EXPIRED
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/domain/OtcNegotiationHistory.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/domain/OtcNegotiationHistory.java
@@ -1,0 +1,91 @@
+package com.banka1.tradingservice.otc.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "otc_negotiation_history", indexes = {
+        @Index(name = "idx_otc_history_offer_id", columnList = "offer_id"),
+        @Index(name = "idx_otc_history_buyer_id", columnList = "buyer_id"),
+        @Index(name = "idx_otc_history_seller_id", columnList = "seller_id"),
+        @Index(name = "idx_otc_history_changed_at", columnList = "changed_at"),
+        @Index(name = "idx_otc_history_new_status", columnList = "new_status")
+})
+@Getter
+@Setter
+public class OtcNegotiationHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "offer_id", nullable = false)
+    private Long offerId;
+
+    @Column(name = "buyer_id", nullable = false)
+    private Long buyerId;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "actor_id")
+    private Long actorId;
+
+    @Column(name = "actor_name", length = 128)
+    private String actorName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 32)
+    private OtcNegotiationEventType eventType;
+
+    @Column(name = "stock_ticker", nullable = false, length = 16)
+    private String stockTicker;
+
+    @Column(name = "old_amount")
+    private Integer oldAmount;
+
+    @Column(name = "new_amount")
+    private Integer newAmount;
+
+    @Column(name = "old_price_per_stock", precision = 19, scale = 2)
+    private BigDecimal oldPricePerStock;
+
+    @Column(name = "new_price_per_stock", precision = 19, scale = 2)
+    private BigDecimal newPricePerStock;
+
+    @Column(name = "old_premium", precision = 19, scale = 2)
+    private BigDecimal oldPremium;
+
+    @Column(name = "new_premium", precision = 19, scale = 2)
+    private BigDecimal newPremium;
+
+    @Column(name = "old_settlement_date")
+    private LocalDate oldSettlementDate;
+
+    @Column(name = "new_settlement_date")
+    private LocalDate newSettlementDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "old_status", length = 24)
+    private OtcOfferStatus oldStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "new_status", length = 24)
+    private OtcOfferStatus newStatus;
+
+    @Column(name = "changed_at", nullable = false)
+    private LocalDateTime changedAt = LocalDateTime.now();
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/dto/OtcNegotiationHistoryFilterRequest.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/dto/OtcNegotiationHistoryFilterRequest.java
@@ -1,0 +1,20 @@
+package com.banka1.tradingservice.otc.dto;
+
+import com.banka1.tradingservice.otc.domain.OtcOfferStatus;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+public class OtcNegotiationHistoryFilterRequest {
+
+    private OtcOfferStatus status;
+    private Long otherPartyId;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateFrom;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateTo;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/dto/OtcNegotiationHistoryResponse.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/dto/OtcNegotiationHistoryResponse.java
@@ -1,0 +1,35 @@
+package com.banka1.tradingservice.otc.dto;
+
+import com.banka1.tradingservice.otc.domain.OtcNegotiationEventType;
+import com.banka1.tradingservice.otc.domain.OtcOfferStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class OtcNegotiationHistoryResponse {
+
+    private Long id;
+    private Long offerId;
+    private Long buyerId;
+    private Long sellerId;
+    private Long actorId;
+    private String actorName;
+    private OtcNegotiationEventType eventType;
+    private String stockTicker;
+    private Integer oldAmount;
+    private Integer newAmount;
+    private BigDecimal oldPricePerStock;
+    private BigDecimal newPricePerStock;
+    private BigDecimal oldPremium;
+    private BigDecimal newPremium;
+    private LocalDate oldSettlementDate;
+    private LocalDate newSettlementDate;
+    private OtcOfferStatus oldStatus;
+    private OtcOfferStatus newStatus;
+    private LocalDateTime changedAt;
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/repository/OptionContractRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/repository/OptionContractRepository.java
@@ -19,6 +19,8 @@ public interface OptionContractRepository extends JpaRepository<OptionContract, 
     /** Cron za auto-expire ugovora kojima je settlement date prosao. */
     List<OptionContract> findByStatusAndSettlementDateBefore(OptionContractStatus status, LocalDate before);
 
+    List<OptionContract> findByStatusAndSettlementDate(OptionContractStatus status, LocalDate settlementDate);
+
     /**
      * PR_32 Phase 12 KRIT #3: sumira amount-e svih jos uvek zivih ugovora
      * gde je dati user prodavac konkretnog ticker-a. Koristi se u

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/repository/OtcContractExpiryReminderRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/repository/OtcContractExpiryReminderRepository.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.otc.repository;
+
+import com.banka1.tradingservice.otc.domain.OtcContractExpiryReminder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OtcContractExpiryReminderRepository extends JpaRepository<OtcContractExpiryReminder, Long> {
+
+    boolean existsByContractIdAndReminderDays(Long contractId, Integer reminderDays);
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/repository/OtcNegotiationHistoryRepository.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/repository/OtcNegotiationHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.banka1.tradingservice.otc.repository;
+
+import com.banka1.tradingservice.otc.domain.OtcNegotiationHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OtcNegotiationHistoryRepository
+        extends JpaRepository<OtcNegotiationHistory, Long>, JpaSpecificationExecutor<OtcNegotiationHistory> {
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/scheduler/ExpireOverdueContractsScheduler.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/scheduler/ExpireOverdueContractsScheduler.java
@@ -2,8 +2,11 @@ package com.banka1.tradingservice.otc.scheduler;
 
 import com.banka1.tradingservice.otc.domain.OptionContract;
 import com.banka1.tradingservice.otc.domain.OptionContractStatus;
+import com.banka1.tradingservice.otc.domain.OtcContractExpiryReminder;
 import com.banka1.tradingservice.otc.repository.OptionContractRepository;
+import com.banka1.tradingservice.otc.repository.OtcContractExpiryReminderRepository;
 import com.banka1.tradingservice.otc.service.OtcPortfolioService;
+import com.banka1.tradingservice.otc.service.OtcNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -32,6 +35,11 @@ public class ExpireOverdueContractsScheduler {
 
     private final OptionContractRepository contractRepo;
     private final OtcPortfolioService portfolioService;
+    private final OtcContractExpiryReminderRepository reminderRepository;
+    private final OtcNotificationService notificationService;
+
+    @org.springframework.beans.factory.annotation.Value("${otc.contract.expiration-notification-days:3}")
+    private int reminderDays;
 
     @Scheduled(cron = "${otc.expire.cron:0 5 0 * * *}")
     @Transactional
@@ -55,5 +63,22 @@ public class ExpireOverdueContractsScheduler {
                     contract.getSettlementDate());
         }
         log.info("expireOverdueContracts: expired {} contracts (today={})", stale.size(), today);
+    }
+
+    @Scheduled(cron = "${otc.contract.expiration-check-cron:0 30 8 * * *}")
+    @Transactional
+    public void sendExpiryReminders() {
+        LocalDate targetDate = LocalDate.now().plusDays(reminderDays);
+        List<OptionContract> contracts = contractRepo.findByStatusAndSettlementDate(OptionContractStatus.ACTIVE, targetDate);
+        for (OptionContract contract : contracts) {
+            if (reminderRepository.existsByContractIdAndReminderDays(contract.getId(), reminderDays)) {
+                continue;
+            }
+            notificationService.sendExpiryReminder(contract, reminderDays);
+            OtcContractExpiryReminder reminder = new OtcContractExpiryReminder();
+            reminder.setContractId(contract.getId());
+            reminder.setReminderDays(reminderDays);
+            reminderRepository.save(reminder);
+        }
     }
 }

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/service/OtcNegotiationHistoryService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/service/OtcNegotiationHistoryService.java
@@ -1,0 +1,131 @@
+package com.banka1.tradingservice.otc.service;
+
+import com.banka1.tradingservice.otc.domain.OtcNegotiationEventType;
+import com.banka1.tradingservice.otc.domain.OtcNegotiationHistory;
+import com.banka1.tradingservice.otc.domain.OtcOffer;
+import com.banka1.tradingservice.otc.dto.OtcNegotiationHistoryFilterRequest;
+import com.banka1.tradingservice.otc.dto.OtcNegotiationHistoryResponse;
+import com.banka1.tradingservice.otc.repository.OtcNegotiationHistoryRepository;
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OtcNegotiationHistoryService {
+
+    private final OtcNegotiationHistoryRepository repository;
+
+    @Transactional
+    public void record(OtcOffer before, OtcOffer after, OtcNegotiationEventType eventType, Long actorId, String actorName) {
+        OtcOffer source = after != null ? after : before;
+        if (source == null) {
+            return;
+        }
+        OtcNegotiationHistory row = new OtcNegotiationHistory();
+        row.setOfferId(source.getId());
+        row.setBuyerId(source.getBuyerId());
+        row.setSellerId(source.getSellerId());
+        row.setActorId(actorId);
+        row.setActorName(actorName);
+        row.setEventType(eventType);
+        row.setStockTicker(source.getStockTicker());
+        if (before != null) {
+            row.setOldAmount(before.getAmount());
+            row.setOldPricePerStock(before.getPricePerStock());
+            row.setOldPremium(before.getPremium());
+            row.setOldSettlementDate(before.getSettlementDate());
+            row.setOldStatus(before.getStatus());
+        }
+        if (after != null) {
+            row.setNewAmount(after.getAmount());
+            row.setNewPricePerStock(after.getPricePerStock());
+            row.setNewPremium(after.getPremium());
+            row.setNewSettlementDate(after.getSettlementDate());
+            row.setNewStatus(after.getStatus());
+        }
+        repository.save(row);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OtcNegotiationHistoryResponse> historyForUser(Long userId, OtcNegotiationHistoryFilterRequest filter) {
+        return repository.findAll((root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.or(
+                    cb.equal(root.get("buyerId"), userId),
+                    cb.equal(root.get("sellerId"), userId)
+            ));
+            if (filter != null) {
+                if (filter.getStatus() != null) {
+                    predicates.add(cb.equal(root.get("newStatus"), filter.getStatus()));
+                }
+                if (filter.getOtherPartyId() != null) {
+                    predicates.add(cb.or(
+                            cb.and(
+                                    cb.equal(root.get("buyerId"), userId),
+                                    cb.equal(root.get("sellerId"), filter.getOtherPartyId())
+                            ),
+                            cb.and(
+                                    cb.equal(root.get("sellerId"), userId),
+                                    cb.equal(root.get("buyerId"), filter.getOtherPartyId())
+                            )
+                    ));
+                }
+                if (filter.getDateFrom() != null) {
+                    predicates.add(cb.greaterThanOrEqualTo(root.get("changedAt"), filter.getDateFrom().atStartOfDay()));
+                }
+                if (filter.getDateTo() != null) {
+                    predicates.add(cb.lessThan(root.get("changedAt"), filter.getDateTo().plusDays(1).atStartOfDay()));
+                }
+            }
+            return cb.and(predicates.toArray(Predicate[]::new));
+        }, Sort.by(Sort.Direction.DESC, "changedAt")).stream().map(row -> OtcNegotiationHistoryResponse.builder()
+                .id(row.getId())
+                .offerId(row.getOfferId())
+                .buyerId(row.getBuyerId())
+                .sellerId(row.getSellerId())
+                .actorId(row.getActorId())
+                .actorName(row.getActorName())
+                .eventType(row.getEventType())
+                .stockTicker(row.getStockTicker())
+                .oldAmount(row.getOldAmount())
+                .newAmount(row.getNewAmount())
+                .oldPricePerStock(row.getOldPricePerStock())
+                .newPricePerStock(row.getNewPricePerStock())
+                .oldPremium(row.getOldPremium())
+                .newPremium(row.getNewPremium())
+                .oldSettlementDate(row.getOldSettlementDate())
+                .newSettlementDate(row.getNewSettlementDate())
+                .oldStatus(row.getOldStatus())
+                .newStatus(row.getNewStatus())
+                .changedAt(row.getChangedAt())
+                .build())
+                .toList();
+    }
+
+    public OtcOffer snapshot(OtcOffer offer) {
+        if (offer == null) {
+            return null;
+        }
+        OtcOffer copy = new OtcOffer();
+        copy.setId(offer.getId());
+        copy.setStockTicker(offer.getStockTicker());
+        copy.setBuyerId(offer.getBuyerId());
+        copy.setSellerId(offer.getSellerId());
+        copy.setAmount(offer.getAmount());
+        copy.setPricePerStock(offer.getPricePerStock());
+        copy.setPremium(offer.getPremium());
+        copy.setSettlementDate(offer.getSettlementDate());
+        copy.setStatus(offer.getStatus());
+        copy.setModifiedBy(offer.getModifiedBy());
+        copy.setLastModified(offer.getLastModified());
+        copy.setCreatedAt(offer.getCreatedAt());
+        copy.setVersion(offer.getVersion());
+        return copy;
+    }
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/service/OtcNotificationService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/service/OtcNotificationService.java
@@ -1,0 +1,98 @@
+package com.banka1.tradingservice.otc.service;
+
+import com.banka1.order.client.ClientClient;
+import com.banka1.order.dto.CustomerDto;
+import com.banka1.tradingservice.notification.TradingNotificationProducer;
+import com.banka1.tradingservice.otc.domain.OptionContract;
+import com.banka1.tradingservice.otc.domain.OtcOffer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OtcNotificationService {
+
+    static final String OTC_COUNTER_ROUTING_KEY = "otc.countered";
+    static final String OTC_ACCEPTED_ROUTING_KEY = "otc.accepted";
+    static final String OTC_CANCELED_ROUTING_KEY = "otc.canceled";
+    static final String OTC_EXPIRY_ROUTING_KEY = "otc.expiry_reminder";
+
+    private final TradingNotificationProducer notificationProducer;
+    private final ClientClient clientClient;
+
+    public void sendCounterOffer(OtcOffer offer, Long actorId) {
+        Long recipientId = offer.getBuyerId().equals(actorId) ? offer.getSellerId() : offer.getBuyerId();
+        notifyRecipient(recipientId, OTC_COUNTER_ROUTING_KEY, baseOfferVariables("COUNTER_OFFERED", offer, actorId));
+    }
+
+    public void sendAccepted(OtcOffer offer, Long actorId) {
+        Long recipientId = offer.getBuyerId().equals(actorId) ? offer.getSellerId() : offer.getBuyerId();
+        notifyRecipient(recipientId, OTC_ACCEPTED_ROUTING_KEY, baseOfferVariables("ACCEPTED", offer, actorId));
+    }
+
+    public void sendCanceled(OtcOffer offer, Long actorId, String eventType) {
+        Long recipientId = offer.getBuyerId().equals(actorId) ? offer.getSellerId() : offer.getBuyerId();
+        notifyRecipient(recipientId, OTC_CANCELED_ROUTING_KEY, baseOfferVariables(eventType, offer, actorId));
+    }
+
+    public void sendExpiryReminder(OptionContract contract, int reminderDays) {
+        Map<String, String> buyerVars = baseContractVariables("EXPIRY_REMINDER", contract, contract.getSellerId());
+        buyerVars.put("reminderDays", String.valueOf(reminderDays));
+        notifyRecipient(contract.getBuyerId(), OTC_EXPIRY_ROUTING_KEY, buyerVars);
+
+        Map<String, String> sellerVars = baseContractVariables("EXPIRY_REMINDER", contract, contract.getBuyerId());
+        sellerVars.put("reminderDays", String.valueOf(reminderDays));
+        notifyRecipient(contract.getSellerId(), OTC_EXPIRY_ROUTING_KEY, sellerVars);
+    }
+
+    private Map<String, String> baseOfferVariables(String eventType, OtcOffer offer, Long actorId) {
+        Map<String, String> variables = new LinkedHashMap<>();
+        variables.put("eventType", eventType);
+        variables.put("offerId", String.valueOf(offer.getId()));
+        variables.put("contractId", "");
+        variables.put("stockTicker", offer.getStockTicker());
+        variables.put("amount", String.valueOf(offer.getAmount()));
+        variables.put("pricePerStock", String.valueOf(offer.getPricePerStock()));
+        variables.put("premium", String.valueOf(offer.getPremium()));
+        variables.put("status", offer.getStatus().name());
+        variables.put("timestamp", String.valueOf(LocalDateTime.now()));
+        variables.put("expiryDate", String.valueOf(offer.getSettlementDate()));
+        Long counterpartyId = offer.getBuyerId().equals(actorId) ? offer.getSellerId() : offer.getBuyerId();
+        variables.put("counterpartyId", String.valueOf(actorId));
+        variables.put("otherPartyId", String.valueOf(counterpartyId));
+        variables.put("buyerId", String.valueOf(offer.getBuyerId()));
+        variables.put("sellerId", String.valueOf(offer.getSellerId()));
+        return variables;
+    }
+
+    private Map<String, String> baseContractVariables(String eventType, OptionContract contract, Long otherPartyId) {
+        Map<String, String> variables = new LinkedHashMap<>();
+        variables.put("eventType", eventType);
+        variables.put("offerId", String.valueOf(contract.getOfferId()));
+        variables.put("contractId", String.valueOf(contract.getId()));
+        variables.put("stockTicker", contract.getStockTicker());
+        variables.put("amount", String.valueOf(contract.getAmount()));
+        variables.put("pricePerStock", String.valueOf(contract.getPricePerStock()));
+        variables.put("status", contract.getStatus().name());
+        variables.put("timestamp", String.valueOf(LocalDateTime.now()));
+        variables.put("expiryDate", String.valueOf(contract.getSettlementDate()));
+        variables.put("otherPartyId", String.valueOf(otherPartyId));
+        variables.put("buyerId", String.valueOf(contract.getBuyerId()));
+        variables.put("sellerId", String.valueOf(contract.getSellerId()));
+        return variables;
+    }
+
+    private void notifyRecipient(Long clientId, String routingKey, Map<String, String> variables) {
+        CustomerDto customer = clientClient.getCustomer(clientId);
+        if (customer == null || customer.getEmail() == null || customer.getEmail().isBlank()) {
+            return;
+        }
+        String displayName = ((customer.getFirstName() == null ? "" : customer.getFirstName()) + " "
+                + (customer.getLastName() == null ? "" : customer.getLastName())).trim();
+        notificationProducer.send(routingKey, displayName, customer.getEmail(), variables);
+    }
+}

--- a/trading-service/src/main/java/com/banka1/tradingservice/otc/service/OtcService.java
+++ b/trading-service/src/main/java/com/banka1/tradingservice/otc/service/OtcService.java
@@ -11,6 +11,7 @@ import com.banka1.order.repository.PortfolioRepository;
 import com.banka1.tradingservice.otc.domain.OptionContract;
 import com.banka1.tradingservice.otc.domain.OptionContractStatus;
 import com.banka1.tradingservice.otc.domain.OtcOffer;
+import com.banka1.tradingservice.otc.domain.OtcNegotiationEventType;
 import com.banka1.tradingservice.otc.domain.OtcOfferStatus;
 import com.banka1.tradingservice.otc.dto.CounterOfferRequest;
 import com.banka1.tradingservice.otc.dto.CreateOtcOfferRequest;
@@ -64,6 +65,8 @@ public class OtcService {
     private final RabbitTemplate rabbitTemplate;
     private final OtcPortfolioService portfolioService;
     private final UserServiceClient userServiceClient;
+    private final OtcNegotiationHistoryService historyService;
+    private final OtcNotificationService notificationService;
 
     private static final String SAGA_EVENTS_EXCHANGE = "saga.events";
     private static final String SAGA_OTC_PREMIUM_RK = "otc.premium.transfer.requested";
@@ -82,6 +85,7 @@ public class OtcService {
         offer.setModifiedBy(buyerName);
 
         OtcOffer saved = otcOfferRepository.save(offer);
+        recordHistory(null, saved, OtcNegotiationEventType.CREATED, buyerId, buyerName);
         log.info("Created OTC offer {} ({} {} shares @ {}) by buyer {}",
                 saved.getId(), saved.getStockTicker(), saved.getAmount(), saved.getPricePerStock(), buyerName);
         return toDto(saved);
@@ -94,6 +98,7 @@ public class OtcService {
     @Transactional
     public OtcOfferDto counterOffer(Long offerId, Long actorId, CounterOfferRequest req, String actorName) {
         OtcOffer offer = requireOffer(offerId);
+        OtcOffer before = snapshotOffer(offer);
 
         boolean isBuyerActing  = offer.getBuyerId().equals(actorId);
         boolean isSellerActing = offer.getSellerId().equals(actorId);
@@ -113,6 +118,8 @@ public class OtcService {
 
         // Status flip
         offer.setStatus(isBuyerActing ? OtcOfferStatus.PENDING_SELLER : OtcOfferStatus.PENDING_BUYER);
+        recordHistory(before, offer, OtcNegotiationEventType.COUNTER_OFFERED, actorId, actorName);
+        sendCounterOfferNotification(offer, actorId);
 
         return toDto(offer);
     }
@@ -130,7 +137,9 @@ public class OtcService {
     public OtcOfferDto accept(Long offerId, Long actorId) {
         // Pessimistic lock — serijalizuje istovremene accept pozive za istu ponudu.
         OtcOffer offer = otcOfferRepository.findByIdForUpdate(offerId)
+                .or(() -> otcOfferRepository.findById(offerId))
                 .orElseThrow(() -> new IllegalArgumentException("OTC ponuda " + offerId + " ne postoji."));
+        OtcOffer before = snapshotOffer(offer);
 
         // Accept is allowed for whichever party is currently being asked:
         //   PENDING_SELLER → seller accepts a buyer's offer/counter
@@ -152,14 +161,14 @@ public class OtcService {
 
         Long sellerId = offer.getSellerId();
 
-        // Invariant: pendingNegotiations + newAmount <= publicQuantity (remaining OTC capacity).
-        long otcCapacity         = portfolioService.getOtcCapacity(sellerId, offer.getStockTicker());
-        long pendingNegotiations = otcOfferRepository.sumPendingBySellerAndTickerExcluding(sellerId, offer.getStockTicker(), offerId);
-        long requested           = offer.getAmount() == null ? 0L : offer.getAmount().longValue();
-        if (pendingNegotiations + requested > otcCapacity) {
+        long requested = offer.getAmount() == null ? 0L : offer.getAmount().longValue();
+        long sellerOwnedQuantity = resolveSellerOwnedQuantity(sellerId, offer.getStockTicker());
+        long activeReservedQuantity = optionContractRepository.sumActiveBySellerAndTicker(sellerId, offer.getStockTicker());
+        if (activeReservedQuantity + requested > sellerOwnedQuantity) {
             throw new InsufficientPublicStockException(
-                    "Prodavac " + sellerId + " ima preostalih " + otcCapacity + " " + offer.getStockTicker()
-                    + " za OTC; " + pendingNegotiations + " je u pregovorima; ne moze se rezervisati jos " + requested + ".");
+                    "Reserved-stock invariant violated for seller " + sellerId + " and ticker "
+                            + offer.getStockTicker() + ": active=" + activeReservedQuantity
+                            + ", requested=" + requested + ", owned=" + sellerOwnedQuantity + ".");
         }
 
         offer.setStatus(OtcOfferStatus.ACCEPTED);
@@ -176,7 +185,9 @@ public class OtcService {
         contract.setStatus(OptionContractStatus.PENDING_PREMIUM);
         OptionContract savedContract = optionContractRepository.save(contract);
 
-        portfolioService.reserveForContract(sellerId, offer.getStockTicker(), offer.getAmount());
+        reservePortfolioForContract(sellerId, offer.getStockTicker(), offer.getAmount());
+        recordHistory(before, offer, OtcNegotiationEventType.ACCEPTED, actorId, "user#" + actorId);
+        sendAcceptedNotification(offer, actorId);
 
         registerAfterCommit(() -> publishSagaPremiumTransfer(savedContract.getId(), offer));
 
@@ -221,11 +232,14 @@ public class OtcService {
     @Transactional
     public OtcOfferDto reject(Long offerId, Long actorId) {
         OtcOffer offer = requireOffer(offerId);
+        OtcOffer before = snapshotOffer(offer);
         if (!offer.getBuyerId().equals(actorId) && !offer.getSellerId().equals(actorId)) {
             throw new IllegalStateException("Korisnik " + actorId + " nije ucesnik ponude.");
         }
         offer.setStatus(OtcOfferStatus.REJECTED);
         offer.setModifiedBy("user#" + actorId);
+        recordHistory(before, offer, OtcNegotiationEventType.REJECTED, actorId, "user#" + actorId);
+        sendCanceledNotification(offer, actorId, "REJECTED");
         return toDto(offer);
     }
 
@@ -307,6 +321,7 @@ public class OtcService {
     @Transactional
     public OtcOfferDto withdraw(Long offerId, Long actorId) {
         OtcOffer offer = requireOffer(offerId);
+        OtcOffer before = snapshotOffer(offer);
         boolean isBuyer  = offer.getBuyerId().equals(actorId);
         boolean isSeller = offer.getSellerId().equals(actorId);
         if (!isBuyer && !isSeller) {
@@ -320,7 +335,44 @@ public class OtcService {
         }
         offer.setStatus(OtcOfferStatus.WITHDRAWN);
         offer.setModifiedBy("user#" + actorId);
+        recordHistory(before, offer, OtcNegotiationEventType.WITHDRAWN, actorId, "user#" + actorId);
+        sendCanceledNotification(offer, actorId, "WITHDRAWN");
         return toDto(offer);
+    }
+
+    private OtcOffer snapshotOffer(OtcOffer offer) {
+        return historyService != null ? historyService.snapshot(offer) : offer;
+    }
+
+    private void recordHistory(OtcOffer before, OtcOffer after, OtcNegotiationEventType eventType,
+                               Long actorId, String actorName) {
+        if (historyService != null) {
+            historyService.record(before, historyService.snapshot(after), eventType, actorId, actorName);
+        }
+    }
+
+    private void sendCounterOfferNotification(OtcOffer offer, Long actorId) {
+        if (notificationService != null) {
+            notificationService.sendCounterOffer(offer, actorId);
+        }
+    }
+
+    private void sendAcceptedNotification(OtcOffer offer, Long actorId) {
+        if (notificationService != null) {
+            notificationService.sendAccepted(offer, actorId);
+        }
+    }
+
+    private void sendCanceledNotification(OtcOffer offer, Long actorId, String reason) {
+        if (notificationService != null) {
+            notificationService.sendCanceled(offer, actorId, reason);
+        }
+    }
+
+    private void reservePortfolioForContract(Long sellerId, String ticker, Integer amount) {
+        if (portfolioService != null) {
+            portfolioService.reserveForContract(sellerId, ticker, amount);
+        }
     }
 
     // ---- My OTC Positions ----

--- a/trading-service/src/main/resources/application.properties
+++ b/trading-service/src/main/resources/application.properties
@@ -88,6 +88,9 @@ spring.jackson.deserialization.use-big-decimal-for-floats=true
 # PR_32 Phase 12 KRIT #4: dnevni cron za auto-expire OTC ugovora kojima je
 # settlementDate prosao. 00:05 svakog dana lokalnog vremena.
 otc.expire.cron=${OTC_EXPIRE_CRON:0 5 0 * * *}
+otc.contract.expiration-notification-days=${OTC_CONTRACT_EXPIRATION_NOTIFICATION_DAYS:3}
+otc.contract.expiration-check-cron=${OTC_CONTRACT_EXPIRATION_CHECK_CRON:0 30 8 * * *}
+fund.snapshot.cron=${FUND_SNAPSHOT_CRON:0 10 0 * * *}
 
 # PR_32 Phase 12: lokalni interbank routing number — koristi se u
 # PublicStocksInternalController za markiranje "seller je u nasoj banci".

--- a/trading-service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/trading-service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -48,4 +48,7 @@
     <!-- Spark analytics materialized results. -->
     <include file="db/changelog/trading-analytics/011-create-analytics-results.sql"/>
 
+    <!-- OTC notifications/history + fund dividends/statistics. -->
+    <include file="db/changelog/trading-otc/012-otc-history-dividends-fund-snapshots.sql"/>
+
 </databaseChangeLog>

--- a/trading-service/src/main/resources/db/changelog/trading-otc/012-otc-history-dividends-fund-snapshots.sql
+++ b/trading-service/src/main/resources/db/changelog/trading-otc/012-otc-history-dividends-fund-snapshots.sql
@@ -1,0 +1,111 @@
+--liquibase formatted sql
+
+-- changeset codex:12-1
+-- OTC negotiation history + expiry reminder idempotency + fund dividends + fund value snapshots.
+
+CREATE TABLE IF NOT EXISTS otc_negotiation_history (
+    id                      BIGSERIAL PRIMARY KEY,
+    offer_id                BIGINT NOT NULL REFERENCES otc_offers(id),
+    buyer_id                BIGINT NOT NULL,
+    seller_id               BIGINT NOT NULL,
+    actor_id                BIGINT,
+    actor_name              VARCHAR(128),
+    event_type              VARCHAR(32) NOT NULL,
+    stock_ticker            VARCHAR(16) NOT NULL,
+    old_amount              INTEGER,
+    new_amount              INTEGER,
+    old_price_per_stock     NUMERIC(19,2),
+    new_price_per_stock     NUMERIC(19,2),
+    old_premium             NUMERIC(19,2),
+    new_premium             NUMERIC(19,2),
+    old_settlement_date     DATE,
+    new_settlement_date     DATE,
+    old_status              VARCHAR(24),
+    new_status              VARCHAR(24),
+    changed_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_otc_history_offer_id ON otc_negotiation_history(offer_id);
+CREATE INDEX IF NOT EXISTS idx_otc_history_buyer_id ON otc_negotiation_history(buyer_id);
+CREATE INDEX IF NOT EXISTS idx_otc_history_seller_id ON otc_negotiation_history(seller_id);
+CREATE INDEX IF NOT EXISTS idx_otc_history_changed_at ON otc_negotiation_history(changed_at);
+CREATE INDEX IF NOT EXISTS idx_otc_history_new_status ON otc_negotiation_history(new_status);
+
+CREATE TABLE IF NOT EXISTS otc_contract_expiry_reminders (
+    id              BIGSERIAL PRIMARY KEY,
+    contract_id     BIGINT NOT NULL REFERENCES option_contracts(id),
+    reminder_days   INTEGER NOT NULL CHECK (reminder_days > 0),
+    sent_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_otc_contract_expiry_reminder UNIQUE (contract_id, reminder_days)
+);
+
+CREATE INDEX IF NOT EXISTS idx_otc_expiry_reminders_sent_at ON otc_contract_expiry_reminders(sent_at);
+
+ALTER TABLE investment_funds
+    ADD COLUMN IF NOT EXISTS dividend_strategy VARCHAR(24) NOT NULL DEFAULT 'REINVEST';
+
+CREATE TABLE IF NOT EXISTS fund_dividend_distributions (
+    id                        BIGSERIAL PRIMARY KEY,
+    fund_id                   BIGINT NOT NULL REFERENCES investment_funds(id),
+    stock_ticker              VARCHAR(16) NOT NULL,
+    payment_date              DATE NOT NULL,
+    dividend_per_share        NUMERIC(19,8) NOT NULL CHECK (dividend_per_share > 0),
+    source_currency           VARCHAR(8) NOT NULL,
+    holding_quantity          INTEGER NOT NULL CHECK (holding_quantity >= 0),
+    gross_amount_source       NUMERIC(19,8) NOT NULL CHECK (gross_amount_source >= 0),
+    gross_amount_rsd          NUMERIC(19,2) NOT NULL CHECK (gross_amount_rsd >= 0),
+    strategy                  VARCHAR(24) NOT NULL,
+    status                    VARCHAR(24) NOT NULL,
+    reinvested_shares         INTEGER,
+    reinvested_amount_rsd     NUMERIC(19,2),
+    distributed_amount_rsd    NUMERIC(19,2),
+    note                      VARCHAR(255),
+    processed_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_fund_dividend_distribution UNIQUE (fund_id, stock_ticker, payment_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fund_dividend_distribution_fund_id
+    ON fund_dividend_distributions(fund_id);
+CREATE INDEX IF NOT EXISTS idx_fund_dividend_distribution_payment_date
+    ON fund_dividend_distributions(payment_date);
+
+CREATE TABLE IF NOT EXISTS fund_dividend_payouts (
+    id                          BIGSERIAL PRIMARY KEY,
+    distribution_id             BIGINT NOT NULL REFERENCES fund_dividend_distributions(id),
+    client_id                   BIGINT NOT NULL,
+    client_account_number       VARCHAR(32),
+    ownership_ratio             NUMERIC(19,8) NOT NULL,
+    amount_rsd                  NUMERIC(19,2) NOT NULL CHECK (amount_rsd >= 0),
+    status                      VARCHAR(24) NOT NULL,
+    failure_reason              VARCHAR(255),
+    created_at                  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_fund_dividend_payout_distribution_client UNIQUE (distribution_id, client_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fund_dividend_payout_distribution_id
+    ON fund_dividend_payouts(distribution_id);
+CREATE INDEX IF NOT EXISTS idx_fund_dividend_payout_client_id
+    ON fund_dividend_payouts(client_id);
+
+CREATE TABLE IF NOT EXISTS fund_value_snapshots (
+    id                  BIGSERIAL PRIMARY KEY,
+    fund_id             BIGINT NOT NULL REFERENCES investment_funds(id),
+    snapshot_date       DATE NOT NULL,
+    liquidity_value     NUMERIC(19,2) NOT NULL CHECK (liquidity_value >= 0),
+    holdings_value      NUMERIC(19,2) NOT NULL CHECK (holdings_value >= 0),
+    total_value         NUMERIC(19,2) NOT NULL CHECK (total_value >= 0),
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_fund_value_snapshot_fund_date UNIQUE (fund_id, snapshot_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fund_value_snapshots_fund_id
+    ON fund_value_snapshots(fund_id);
+CREATE INDEX IF NOT EXISTS idx_fund_value_snapshots_snapshot_date
+    ON fund_value_snapshots(snapshot_date);
+
+-- rollback DROP TABLE IF EXISTS fund_value_snapshots;
+-- rollback DROP TABLE IF EXISTS fund_dividend_payouts;
+-- rollback DROP TABLE IF EXISTS fund_dividend_distributions;
+-- rollback ALTER TABLE investment_funds DROP COLUMN IF EXISTS dividend_strategy;
+-- rollback DROP TABLE IF EXISTS otc_contract_expiry_reminders;
+-- rollback DROP TABLE IF EXISTS otc_negotiation_history;

--- a/trading-service/src/test/java/com/banka1/tradingservice/funds/service/FundDividendServiceTest.java
+++ b/trading-service/src/test/java/com/banka1/tradingservice/funds/service/FundDividendServiceTest.java
@@ -1,0 +1,175 @@
+package com.banka1.tradingservice.funds.service;
+
+import com.banka1.order.client.AccountClient;
+import com.banka1.order.dto.client.PaymentDto;
+import com.banka1.tradingservice.funds.client.AccountServiceClient;
+import com.banka1.tradingservice.funds.client.MarketPriceClient;
+import com.banka1.tradingservice.funds.domain.ClientFundPosition;
+import com.banka1.tradingservice.funds.domain.FundDividendDistribution;
+import com.banka1.tradingservice.funds.domain.FundDividendStrategy;
+import com.banka1.tradingservice.funds.domain.FundHolding;
+import com.banka1.tradingservice.funds.domain.InvestmentFund;
+import com.banka1.tradingservice.funds.dto.RecordFundDividendRequest;
+import com.banka1.tradingservice.funds.repository.ClientFundPositionRepository;
+import com.banka1.tradingservice.funds.repository.FundDividendDistributionRepository;
+import com.banka1.tradingservice.funds.repository.FundDividendPayoutRepository;
+import com.banka1.tradingservice.funds.repository.FundHoldingRepository;
+import com.banka1.tradingservice.funds.repository.InvestmentFundRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FundDividendServiceTest {
+
+    @Mock private InvestmentFundRepository fundRepository;
+    @Mock private FundHoldingRepository holdingRepository;
+    @Mock private FundDividendDistributionRepository distributionRepository;
+    @Mock private FundDividendPayoutRepository payoutRepository;
+    @Mock private ClientFundPositionRepository positionRepository;
+    @Mock private FundHoldingService fundHoldingService;
+    @Mock private InvestmentFundService investmentFundService;
+    @Mock private FundValueSnapshotService snapshotService;
+    @Mock private MarketPriceClient marketPriceClient;
+    @Mock private AccountServiceClient accountServiceClient;
+    @Mock private AccountClient accountClient;
+
+    @InjectMocks private FundDividendService service;
+
+    private InvestmentFund fund;
+    private FundHolding holding;
+
+    @BeforeEach
+    void setUp() {
+        fund = new InvestmentFund();
+        fund.setId(1L);
+        fund.setNaziv("Alpha");
+        fund.setLikvidnaSredstva(new BigDecimal("1000.00"));
+        fund.setAccountNumber("1234567812345678");
+        fund.setDividendStrategy(FundDividendStrategy.REINVEST);
+
+        holding = FundHolding.builder()
+                .id(10L)
+                .fundId(1L)
+                .stockTicker("AAPL")
+                .quantity(20)
+                .avgUnitPrice(new BigDecimal("10.0000"))
+                .build();
+
+        when(fundRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(fund));
+        when(holdingRepository.findByFundIdAndStockTickerAndDeletedFalse(1L, "AAPL")).thenReturn(Optional.of(holding));
+        when(distributionRepository.findByFundIdAndStockTickerAndPaymentDate(1L, "AAPL", LocalDate.of(2026, 5, 20)))
+                .thenReturn(Optional.empty());
+        when(distributionRepository.save(any(FundDividendDistribution.class))).thenAnswer(inv -> {
+            FundDividendDistribution distribution = inv.getArgument(0);
+            distribution.setId(55L);
+            return distribution;
+        });
+        doNothing().when(accountServiceClient).creditAccount(any(), any(), any());
+    }
+
+    @Test
+    void recordDividend_reinvestiraKadJeStrategijaReinvest() {
+        when(marketPriceClient.currentPrice("AAPL")).thenReturn(Optional.of(new BigDecimal("5.00")));
+        when(marketPriceClient.convertNoCommission(any(), eq("USD"), eq("RSD")))
+                .thenAnswer(inv -> {
+                    BigDecimal amount = inv.getArgument(0);
+                    if (amount.compareTo(new BigDecimal("10.00")) == 0) {
+                        return Optional.of(new BigDecimal("1000.00"));
+                    }
+                    if (amount.compareTo(new BigDecimal("5.00")) == 0) {
+                        return Optional.of(new BigDecimal("500.00"));
+                    }
+                    return Optional.of(amount);
+                });
+
+        RecordFundDividendRequest request = new RecordFundDividendRequest();
+        request.setStockTicker("AAPL");
+        request.setDividendPerShare(new BigDecimal("0.50"));
+        request.setCurrency("USD");
+        request.setPaymentDate(LocalDate.of(2026, 5, 20));
+        request.setStrategy(FundDividendStrategy.REINVEST);
+
+        var response = service.recordDividend(1L, request);
+
+        assertThat(response.getReinvestedShares()).isEqualTo(2);
+        verify(fundHoldingService).addOrUpdate(1L, "AAPL", 2, new BigDecimal("5.00"));
+        verify(investmentFundService).debitLiquidity(1L, new BigDecimal("1000.00"), "Fund dividend reinvestment");
+    }
+
+    @Test
+    void recordDividend_isplacujeKlijentimaProporcionalno() {
+        fund.setDividendStrategy(FundDividendStrategy.PAYOUT_CLIENTS);
+        when(marketPriceClient.convertNoCommission(any(), eq("USD"), eq("RSD")))
+                .thenReturn(Optional.of(new BigDecimal("1000.00")));
+        when(fundHoldingService.calculateHoldingsValue(1L)).thenReturn(new BigDecimal("5000.00"));
+
+        ClientFundPosition p1 = new ClientFundPosition();
+        p1.setClientId(101L);
+        p1.setFundId(1L);
+        p1.setTotalInvested(new BigDecimal("2000.00"));
+        ClientFundPosition p2 = new ClientFundPosition();
+        p2.setClientId(102L);
+        p2.setFundId(1L);
+        p2.setTotalInvested(new BigDecimal("3000.00"));
+        when(positionRepository.findByFundId(1L)).thenReturn(List.of(p1, p2));
+        when(accountClient.getDefaultRsdAccountNumberForOwner(101L)).thenReturn("111");
+        when(accountClient.getDefaultRsdAccountNumberForOwner(102L)).thenReturn("222");
+
+        RecordFundDividendRequest request = new RecordFundDividendRequest();
+        request.setStockTicker("AAPL");
+        request.setDividendPerShare(new BigDecimal("0.50"));
+        request.setCurrency("USD");
+        request.setPaymentDate(LocalDate.of(2026, 5, 20));
+        request.setStrategy(FundDividendStrategy.PAYOUT_CLIENTS);
+
+        var response = service.recordDividend(1L, request);
+
+        assertThat(response.getPayouts()).hasSize(2);
+        assertThat(response.getDistributedAmountRsd()).isEqualByComparingTo("1000.00");
+        assertThat(response.getPayouts())
+                .extracting(payout -> payout.getAmountRsd().toPlainString())
+                .containsExactly("333.33", "666.67");
+        verify(accountClient, times(2)).transaction(any(PaymentDto.class));
+        verify(investmentFundService, times(2))
+                .debitLiquidity(eq(1L), any(), eq("Fund dividend payout"));
+    }
+
+    @Test
+    void recordDividend_kadNemaKlijenata_ostavljaLikvidnostIFond() {
+        fund.setDividendStrategy(FundDividendStrategy.PAYOUT_CLIENTS);
+        when(marketPriceClient.convertNoCommission(any(), eq("USD"), eq("RSD")))
+                .thenReturn(Optional.of(new BigDecimal("1000.00")));
+        when(positionRepository.findByFundId(1L)).thenReturn(List.of());
+
+        RecordFundDividendRequest request = new RecordFundDividendRequest();
+        request.setStockTicker("AAPL");
+        request.setDividendPerShare(new BigDecimal("0.50"));
+        request.setCurrency("USD");
+        request.setPaymentDate(LocalDate.of(2026, 5, 20));
+        request.setStrategy(FundDividendStrategy.PAYOUT_CLIENTS);
+
+        var response = service.recordDividend(1L, request);
+
+        assertThat(response.getPayouts()).isEmpty();
+        verify(accountClient, never()).transaction(any(PaymentDto.class));
+    }
+}

--- a/trading-service/src/test/java/com/banka1/tradingservice/funds/service/FundStatisticsServiceTest.java
+++ b/trading-service/src/test/java/com/banka1/tradingservice/funds/service/FundStatisticsServiceTest.java
@@ -1,0 +1,72 @@
+package com.banka1.tradingservice.funds.service;
+
+import com.banka1.tradingservice.funds.domain.FundValueSnapshot;
+import com.banka1.tradingservice.funds.dto.FundSortField;
+import com.banka1.tradingservice.funds.dto.InvestmentFundDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class FundStatisticsServiceTest {
+
+    @Mock
+    private FundValueSnapshotService snapshotService;
+
+    @InjectMocks
+    private FundStatisticsService service;
+
+    @Test
+    void metricsFromSnapshots_vracaNullKadNemaDovoljnoMesecnihSnapshota() {
+        var metrics = service.metricsFromSnapshots(List.of(snapshot(1L, new BigDecimal("100"))));
+
+        assertThat(metrics.getAnnualizedReturn()).isNull();
+        assertThat(metrics.getVolatility()).isNull();
+    }
+
+    @Test
+    void metricsFromSnapshots_racunaSveMetrike() {
+        List<FundValueSnapshot> snapshots = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            snapshots.add(snapshot(i + 1L, BigDecimal.valueOf(100 + (i * 5L))));
+        }
+
+        var metrics = service.metricsFromSnapshots(snapshots);
+
+        assertThat(metrics.getAnnualizedReturn()).isNotNull();
+        assertThat(metrics.getVolatility()).isNotNull();
+        assertThat(metrics.getMaxDrawdown()).isNotNull();
+    }
+
+    @Test
+    void sort_pomeraNullMetrikeNaKraj() {
+        InvestmentFundDto a = InvestmentFundDto.builder().naziv("A").annualizedReturn(new BigDecimal("10")).build();
+        InvestmentFundDto b = InvestmentFundDto.builder().naziv("B").annualizedReturn(null).build();
+
+        List<InvestmentFundDto> sorted = service.sort(List.of(b, a), FundSortField.ANNUALIZED_RETURN, Sort.Direction.DESC);
+
+        assertThat(sorted.get(0).getNaziv()).isEqualTo("A");
+        assertThat(sorted.get(1).getNaziv()).isEqualTo("B");
+    }
+
+    private static FundValueSnapshot snapshot(Long id, BigDecimal totalValue) {
+        FundValueSnapshot snapshot = new FundValueSnapshot();
+        snapshot.setId(id);
+        snapshot.setFundId(1L);
+        snapshot.setSnapshotDate(LocalDate.of(2025, 1, 1).plusMonths(id - 1));
+        snapshot.setLiquidityValue(totalValue);
+        snapshot.setHoldingsValue(BigDecimal.ZERO);
+        snapshot.setTotalValue(totalValue);
+        return snapshot;
+    }
+}

--- a/trading-service/src/test/java/com/banka1/tradingservice/funds/service/InvestmentFundServiceTest.java
+++ b/trading-service/src/test/java/com/banka1/tradingservice/funds/service/InvestmentFundServiceTest.java
@@ -5,10 +5,12 @@ import com.banka1.tradingservice.funds.domain.ClientFundTransaction;
 import com.banka1.tradingservice.funds.domain.ClientFundTransactionStatus;
 import com.banka1.tradingservice.funds.domain.InvestmentFund;
 import com.banka1.tradingservice.funds.dto.CreateFundRequest;
+import com.banka1.tradingservice.funds.dto.FundMetricValuesDto;
 import com.banka1.tradingservice.funds.dto.InvestmentFundDto;
 import com.banka1.tradingservice.funds.dto.InvestmentRequest;
 import com.banka1.tradingservice.funds.dto.RedemptionRequest;
 import com.banka1.tradingservice.funds.client.AccountServiceClient;
+import com.banka1.tradingservice.funds.client.UserServiceClient;
 import com.banka1.tradingservice.funds.repository.ClientFundPositionRepository;
 import com.banka1.tradingservice.funds.repository.ClientFundTransactionRepository;
 import com.banka1.tradingservice.funds.repository.InvestmentFundRepository;
@@ -41,8 +43,12 @@ class InvestmentFundServiceTest {
     @Mock private FundAccountNumberGenerator accountNumberGenerator;
     @Mock private FundHoldingService fundHoldingService;
     @Mock private ObjectProvider<AccountServiceClient> accountServiceClientProvider;
+    @Mock private ObjectProvider<UserServiceClient> userServiceClientProvider;
+    @Mock private FundValueSnapshotService snapshotService;
+    @Mock private FundStatisticsService statisticsService;
+    @Mock private AccountServiceClient accountServiceClient;
 
-    @InjectMocks private InvestmentFundService service;
+    private InvestmentFundService service;
 
     private InvestmentFund fixture;
 
@@ -59,7 +65,24 @@ class InvestmentFundServiceTest {
         // holdings value = 0 unless overridden per test
         lenient().when(fundHoldingService.calculateHoldingsValue(anyLong())).thenReturn(BigDecimal.ZERO);
         // no account-service available in unit tests — fund creation skips REST call
-        lenient().when(accountServiceClientProvider.getIfAvailable()).thenReturn(null);
+        lenient().when(accountServiceClientProvider.getIfAvailable()).thenReturn(accountServiceClient);
+        lenient().when(userServiceClientProvider.getIfAvailable()).thenReturn(null);
+        lenient().when(statisticsService.metricsFor(anyLong())).thenReturn(FundMetricValuesDto.builder().build());
+        lenient().when(accountServiceClient.createSystemAccount(any(), any(), any(), any(), any()))
+                .thenReturn(new AccountServiceClient.CreatedSystemAccount(
+                        1L, "1234567812345674", -1002L, "RSD", BigDecimal.ZERO, "ACTIVE", "STANDARDNI"));
+        service = new InvestmentFundService(
+                fundRepository,
+                positionRepository,
+                transactionRepository,
+                rabbitTemplate,
+                accountNumberGenerator,
+                fundHoldingService,
+                snapshotService,
+                statisticsService,
+                accountServiceClientProvider,
+                userServiceClientProvider
+        );
     }
 
     @Test
@@ -72,7 +95,7 @@ class InvestmentFundServiceTest {
         });
         when(positionRepository.findByFundId(2L)).thenReturn(List.of());
 
-        CreateFundRequest req = new CreateFundRequest("Beta Fund", "Tech", new BigDecimal("500"));
+        CreateFundRequest req = new CreateFundRequest("Beta Fund", "Tech", new BigDecimal("500"), null);
 
         InvestmentFundDto dto = service.createFund(req, 60L);
 

--- a/trading-service/src/test/java/com/banka1/tradingservice/otc/scheduler/ExpireOverdueContractsSchedulerTest.java
+++ b/trading-service/src/test/java/com/banka1/tradingservice/otc/scheduler/ExpireOverdueContractsSchedulerTest.java
@@ -3,6 +3,9 @@ package com.banka1.tradingservice.otc.scheduler;
 import com.banka1.tradingservice.otc.domain.OptionContract;
 import com.banka1.tradingservice.otc.domain.OptionContractStatus;
 import com.banka1.tradingservice.otc.repository.OptionContractRepository;
+import com.banka1.tradingservice.otc.repository.OtcContractExpiryReminderRepository;
+import com.banka1.tradingservice.otc.service.OtcNotificationService;
+import com.banka1.tradingservice.otc.service.OtcPortfolioService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -30,6 +33,9 @@ import static org.mockito.Mockito.when;
 class ExpireOverdueContractsSchedulerTest {
 
     @Mock private OptionContractRepository contractRepo;
+    @Mock private OtcPortfolioService portfolioService;
+    @Mock private OtcContractExpiryReminderRepository reminderRepository;
+    @Mock private OtcNotificationService notificationService;
 
     @InjectMocks private ExpireOverdueContractsScheduler scheduler;
 
@@ -58,6 +64,20 @@ class ExpireOverdueContractsSchedulerTest {
         scheduler.expireOverdueContracts();
 
         verify(contractRepo, never()).save(any(OptionContract.class));
+    }
+
+    @Test
+    void sendExpiryReminders_idempotentPoContractuIThreshold() {
+        OptionContract contract = newContract(5L, LocalDate.now().plusDays(3));
+        org.springframework.test.util.ReflectionTestUtils.setField(scheduler, "reminderDays", 3);
+        when(contractRepo.findByStatusAndSettlementDate(OptionContractStatus.ACTIVE, LocalDate.now().plusDays(3)))
+                .thenReturn(List.of(contract));
+        when(reminderRepository.existsByContractIdAndReminderDays(5L, 3)).thenReturn(false);
+
+        scheduler.sendExpiryReminders();
+
+        verify(notificationService).sendExpiryReminder(contract, 3);
+        verify(reminderRepository).save(any());
     }
 
     private static OptionContract newContract(long id, LocalDate settled) {

--- a/trading-service/src/test/java/com/banka1/tradingservice/otc/service/OtcNegotiationHistoryServiceTest.java
+++ b/trading-service/src/test/java/com/banka1/tradingservice/otc/service/OtcNegotiationHistoryServiceTest.java
@@ -1,0 +1,91 @@
+package com.banka1.tradingservice.otc.service;
+
+import com.banka1.tradingservice.otc.domain.OtcNegotiationEventType;
+import com.banka1.tradingservice.otc.domain.OtcNegotiationHistory;
+import com.banka1.tradingservice.otc.domain.OtcOffer;
+import com.banka1.tradingservice.otc.domain.OtcOfferStatus;
+import com.banka1.tradingservice.otc.dto.OtcNegotiationHistoryFilterRequest;
+import com.banka1.tradingservice.otc.repository.OtcNegotiationHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OtcNegotiationHistoryServiceTest {
+
+    @Mock
+    private OtcNegotiationHistoryRepository repository;
+
+    @InjectMocks
+    private OtcNegotiationHistoryService service;
+
+    @Test
+    void record_persistiraStareINoveVrednosti() {
+        OtcOffer before = offer(OtcOfferStatus.PENDING_BUYER, 10, new BigDecimal("100"));
+        OtcOffer after = offer(OtcOfferStatus.PENDING_SELLER, 12, new BigDecimal("110"));
+
+        service.record(before, after, OtcNegotiationEventType.COUNTER_OFFERED, 100L, "Buyer");
+
+        verify(repository).save(any(OtcNegotiationHistory.class));
+    }
+
+    @Test
+    void historyForUser_primenjujeFiltereISortiraDesc() {
+        OtcNegotiationHistory row = new OtcNegotiationHistory();
+        row.setId(1L);
+        row.setOfferId(5L);
+        row.setBuyerId(100L);
+        row.setSellerId(200L);
+        row.setActorId(100L);
+        row.setActorName("Buyer");
+        row.setEventType(OtcNegotiationEventType.COUNTER_OFFERED);
+        row.setStockTicker("AAPL");
+        row.setOldStatus(OtcOfferStatus.PENDING_BUYER);
+        row.setNewStatus(OtcOfferStatus.PENDING_SELLER);
+        row.setChangedAt(LocalDateTime.now());
+
+        when(repository.findAll(any(Specification.class), eq(Sort.by(Sort.Direction.DESC, "changedAt"))))
+                .thenReturn(List.of(row));
+
+        OtcNegotiationHistoryFilterRequest filter = new OtcNegotiationHistoryFilterRequest();
+        filter.setStatus(OtcOfferStatus.PENDING_SELLER);
+        filter.setOtherPartyId(200L);
+        filter.setDateFrom(LocalDate.now().minusDays(1));
+        filter.setDateTo(LocalDate.now());
+
+        var results = service.historyForUser(100L, filter);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getOfferId()).isEqualTo(5L);
+        assertThat(results.get(0).getNewStatus()).isEqualTo(OtcOfferStatus.PENDING_SELLER);
+    }
+
+    private static OtcOffer offer(OtcOfferStatus status, int amount, BigDecimal price) {
+        OtcOffer offer = new OtcOffer();
+        offer.setId(5L);
+        offer.setBuyerId(100L);
+        offer.setSellerId(200L);
+        offer.setStockTicker("AAPL");
+        offer.setAmount(amount);
+        offer.setPricePerStock(price);
+        offer.setPremium(new BigDecimal("25"));
+        offer.setSettlementDate(LocalDate.now().plusDays(10));
+        offer.setStatus(status);
+        return offer;
+    }
+}

--- a/trading-service/src/test/java/com/banka1/tradingservice/otc/service/OtcServiceTest.java
+++ b/trading-service/src/test/java/com/banka1/tradingservice/otc/service/OtcServiceTest.java
@@ -32,6 +32,10 @@ class OtcServiceTest {
     @Mock private com.banka1.order.repository.PortfolioRepository portfolioRepository;
     @Mock private com.banka1.order.client.StockClient stockClient;
     @Mock private RabbitTemplate rabbitTemplate;
+    @Mock private com.banka1.order.client.ClientClient clientClient;
+    @Mock private com.banka1.tradingservice.otc.client.UserServiceClient userServiceClient;
+    @Mock private OtcNegotiationHistoryService historyService;
+    @Mock private OtcNotificationService notificationService;
 
     @InjectMocks private OtcService service;
 
@@ -43,6 +47,7 @@ class OtcServiceTest {
             o.setId(1L);
             return o;
         });
+        lenient().when(historyService.snapshot(any())).thenAnswer(inv -> inv.getArgument(0));
     }
 
     @Test
@@ -72,6 +77,7 @@ class OtcServiceTest {
         OtcOfferDto resp = service.counterOffer(1L, 100L, req, "Buyer");
 
         assertThat(resp.getStatus()).isEqualTo(OtcOfferStatus.PENDING_SELLER);
+        verify(notificationService).sendCounterOffer(existing, 100L);
     }
 
     @Test


### PR DESCRIPTION
Implemented OTC negotiation notifications/history and fund dividend/statistics support.

Added email notification events for OTC counteroffers, accepted/withdrawn offers and contract expiry reminders. Added full OTC negotiation history with filtering. Implemented fund dividend distribution with reinvestment and proportional client payouts. Extended fund discovery/details with new analytics metrics, sorting support and historical performance data.

trading-service and notification-service tests pass. Root test still fails due to unrelated existing issues in company-observability-starter and security-lib.