### PR TITLE
feat(order/notification): order lifecycle push notifications + enrich…

### DIFF
--- a/api-gateway/default.conf.template
+++ b/api-gateway/default.conf.template
@@ -424,6 +424,142 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # === Swagger / OpenAPI per service =====================================
+    # Each consolidated service serves springdoc at /swagger-ui/* and
+    # /v3/api-docs internally. We expose it under a per-service prefix and
+    # strip that prefix toward the upstream (trailing slash on proxy_pass).
+    # springdoc.swagger-ui.{config-url,url} in each service point at the same
+    # prefix so the UI fetches the spec back through the gateway.
+    # Entry point: http://localhost/<prefix>/swagger-ui/index.html
+
+    # user-service -> /users
+    location /users/swagger-ui/ {
+        proxy_pass http://user_service/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /users/v3/api-docs {
+        proxy_pass http://user_service/v3/api-docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # banking-core-service -> /banking
+    location /banking/swagger-ui/ {
+        proxy_pass http://banking_core_service/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /banking/v3/api-docs {
+        proxy_pass http://banking_core_service/v3/api-docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # market-service -> /market
+    location /market/swagger-ui/ {
+        proxy_pass http://market_service/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /market/v3/api-docs {
+        proxy_pass http://market_service/v3/api-docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # trading-service -> /trading
+    location /trading/swagger-ui/ {
+        proxy_pass http://trading_service/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /trading/v3/api-docs {
+        proxy_pass http://trading_service/v3/api-docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # credit-service -> /credit
+    location /credit/swagger-ui/ {
+        proxy_pass http://credit_service/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /credit/v3/api-docs {
+        proxy_pass http://credit_service/v3/api-docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # interbank-service -> /interbank
+    location /interbank/swagger-ui/ {
+        proxy_pass http://interbank_service/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /interbank/v3/api-docs {
+        proxy_pass http://interbank_service/v3/api-docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # notification-service -> /notifications
+    location /notifications/swagger-ui/ {
+        proxy_pass http://notification_service/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /notifications/v3/api-docs {
+        proxy_pass http://notification_service/v3/api-docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # saga-orchestrator-service -> /saga
+    location /saga/swagger-ui/ {
+        proxy_pass http://saga_orchestrator_service/swagger-ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /saga/v3/api-docs {
+        proxy_pass http://saga_orchestrator_service/v3/api-docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Health check
     location /gateway-health {
         access_log off;

--- a/credit-service/src/main/resources/application.properties
+++ b/credit-service/src/main/resources/application.properties
@@ -15,6 +15,9 @@ banka.security.permissions-claim=permissions
 banka.security.permit-all=/auth/*,/v3/api-docs/**,/v3/api-docs.yaml,/swagger-ui/**,/swagger-ui.html,/actuator/health/liveness,/actuator/health/readiness,/actuator/info
 springdoc.api-docs.enabled=${SWAGGER_ENABLED:true}
 springdoc.swagger-ui.enabled=${SWAGGER_ENABLED:true}
+# Behind api-gateway: swagger-ui fetches the spec via the /credit prefix (nginx strips it)
+springdoc.swagger-ui.config-url=/credit/v3/api-docs/swagger-config
+springdoc.swagger-ui.url=/credit/v3/api-docs
 server.forward-headers-strategy=FRAMEWORK
 url.reset-password="http://localhost:4200/auth/reset-password?token="
 url.activate-account="http://localhost:4200/auth/activate-account?token="

--- a/interbank-service/src/main/resources/application.properties
+++ b/interbank-service/src/main/resources/application.properties
@@ -70,6 +70,9 @@ spring.rabbitmq.password=${RABBITMQ_PASSWORD:guest}
 # --- Swagger -----------------------------------------------------------------
 springdoc.swagger-ui.enabled=${SWAGGER_ENABLED:true}
 springdoc.api-docs.enabled=${SWAGGER_ENABLED:true}
+# Behind api-gateway: swagger-ui fetches the spec via the /interbank prefix (nginx strips it)
+springdoc.swagger-ui.config-url=/interbank/v3/api-docs/swagger-config
+springdoc.swagger-ui.url=/interbank/v3/api-docs
 server.forward-headers-strategy=FRAMEWORK
 
 # --- Actuator ----------------------------------------------------------------

--- a/notification-service/src/main/java/app/entities/RoutingKeys.java
+++ b/notification-service/src/main/java/app/entities/RoutingKeys.java
@@ -74,6 +74,22 @@ public final class RoutingKeys {
      */
     public static final String ORDER_DECLINED = "order.declined";
     /**
+     * Routing key za kreiran order.
+     */
+    public static final String ORDER_CREATED = "order.created";
+    /**
+     * Routing key za u potpunosti izvrsen order.
+     */
+    public static final String ORDER_DONE = "order.done";
+    /**
+     * Routing key za delimicno izvrsen order.
+     */
+    public static final String ORDER_PARTIAL_FILL = "order.partial_fill";
+    /**
+     * Routing key za automatski otkazan (istekao) order.
+     */
+    public static final String ORDER_AUTO_CANCELLED = "order.auto_cancelled";
+    /**
      * Routing key za uspesno naplaceni porez.
      */
     public static final String TAX_COLLECTED = "tax.collected";

--- a/notification-service/src/main/java/app/service/FcmPushService.java
+++ b/notification-service/src/main/java/app/service/FcmPushService.java
@@ -8,6 +8,8 @@ import com.google.firebase.messaging.AndroidConfig.Priority;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 /**
  * Sends verification OTP pushes to the mobile client via Firebase Cloud Messaging.
  *
@@ -96,6 +98,52 @@ public class FcmPushService {
             log.info("FCM push sent: messageId={}, operationType={}", messageId, operationType);
         } catch (Exception e) {
             log.warn("FCM push failed (email delivery is authoritative): {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Sends a high-priority data-only FCM message describing an order lifecycle event.
+     *
+     * <p>The payload carries {@code type=ORDER_<EVENT>} (e.g. {@code ORDER_DONE}) plus a
+     * human-readable {@code title}/{@code body} and the key order fields ({@code orderId},
+     * {@code ticker}, {@code status}) so the mobile app can persist an inbox row and render a
+     * system notification consistently regardless of app lifecycle state.
+     *
+     * <p>Failures never propagate: any exception thrown by the FCM SDK is logged at warn level
+     * and swallowed so that email delivery (the authoritative channel) is not disturbed.
+     *
+     * @param fcmToken device token to deliver to
+     * @param notificationType order event type, e.g. {@code ORDER_CREATED} / {@code ORDER_DONE}
+     * @param title user-visible notification title (rendered email subject)
+     * @param body user-visible notification body (rendered email body)
+     * @param variables order template variables (orderId, ticker, status, ...)
+     */
+    public void sendOrderPush(String fcmToken, String notificationType,
+                              String title, String body, Map<String, String> variables) {
+        if (!firebaseAvailable) {
+            log.debug("Firebase not available, skipping order FCM push");
+            return;
+        }
+
+        Map<String, String> data = variables == null ? Map.of() : variables;
+        Message message = Message.builder()
+                .setToken(fcmToken)
+                .putData("type", notificationType)
+                .putData("title", title != null ? title : "")
+                .putData("body", body != null ? body : "")
+                .putData("orderId", data.getOrDefault("orderId", ""))
+                .putData("ticker", data.getOrDefault("ticker", ""))
+                .putData("status", data.getOrDefault("status", ""))
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(Priority.HIGH)
+                        .build())
+                .build();
+
+        try {
+            String messageId = FirebaseMessaging.getInstance().send(message);
+            log.info("FCM order push sent: messageId={}, type={}", messageId, notificationType);
+        } catch (Exception e) {
+            log.warn("FCM order push failed (email delivery is authoritative): {}", e.getMessage());
         }
     }
 }

--- a/notification-service/src/main/java/app/service/NotificationDeliveryService.java
+++ b/notification-service/src/main/java/app/service/NotificationDeliveryService.java
@@ -199,6 +199,18 @@ public class NotificationDeliveryService {
             String sessId = req.getSessionId();
             runAfterCommit(() -> attemptFcmPush(clientId, rawCode, opType, sessId));
         }
+
+        // FCM push for order lifecycle events (fire-and-forget, email is authoritative)
+        if (notificationType.startsWith("ORDER_") && req.getClientId() != null) {
+            Long clientId = req.getClientId();
+            String type = notificationType;
+            String title = resolvedEmail.subject();
+            String body = resolvedEmail.body();
+            Map<String, String> vars = req.getTemplateVariables() == null
+                    ? Map.of()
+                    : Map.copyOf(req.getTemplateVariables());
+            runAfterCommit(() -> attemptOrderFcmPush(clientId, type, title, body, vars));
+        }
     }
 
     /**
@@ -475,6 +487,25 @@ public class NotificationDeliveryService {
             fcmPushService.sendVerificationPush(token.get(), code, operationType, sessionId);
         } catch (Exception e) {
             log.warn("FCM push failed for clientId={}: {}", clientId, e.getMessage());
+        }
+    }
+
+    /**
+     * Attempts to send an FCM push notification for an order lifecycle event.
+     * Fire-and-forget: if no token is registered or sending fails, email delivery
+     * remains the authoritative channel.
+     */
+    private void attemptOrderFcmPush(Long clientId, String notificationType,
+                                     String title, String body, Map<String, String> variables) {
+        try {
+            Optional<String> token = fcmTokenService.findToken(clientId);
+            if (token.isEmpty()) {
+                log.debug("No FCM token for clientId={}, skipping order push", clientId);
+                return;
+            }
+            fcmPushService.sendOrderPush(token.get(), notificationType, title, body, variables);
+        } catch (Exception e) {
+            log.warn("FCM order push failed for clientId={}: {}", clientId, e.getMessage());
         }
     }
 

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -30,6 +30,13 @@ spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.open-in-view=false
 
+# --- Swagger -----------------------------------------------------------------
+springdoc.api-docs.enabled=${SWAGGER_ENABLED:true}
+springdoc.swagger-ui.enabled=${SWAGGER_ENABLED:true}
+# Behind api-gateway: swagger-ui fetches the spec via the /notifications prefix (nginx strips it)
+springdoc.swagger-ui.config-url=/notifications/v3/api-docs/swagger-config
+springdoc.swagger-ui.url=/notifications/v3/api-docs
+
 spring.mail.host=${MAIL_HOST:smtp.gmail.com}
 spring.mail.port=${MAIL_PORT:587}
 spring.mail.username=${MAIL_USERNAME:}
@@ -89,6 +96,14 @@ notification.templates.ORDER_APPROVED.subject=Order Approved
 notification.templates.ORDER_APPROVED.body-template=Zdravo {{name}}, order {{orderId}} za listing {{listingId}} je odobren. Tip: {{orderType}}, smer: {{direction}}, supervisor: {{supervisorId}}.
 notification.templates.ORDER_DECLINED.subject=Order Declined
 notification.templates.ORDER_DECLINED.body-template=Zdravo {{name}}, order {{orderId}} za listing {{listingId}} je odbijen. Tip: {{orderType}}, smer: {{direction}}, supervisor: {{supervisorId}}.
+notification.templates.ORDER_CREATED.subject=Nalog kreiran
+notification.templates.ORDER_CREATED.body-template=Zdravo {{name}}, vas nalog {{orderId}} ({{ticker}}) je kreiran. Smer: {{direction}}, kolicina: {{quantity}}, cena: {{price}}. Status: {{status}}.
+notification.templates.ORDER_DONE.subject=Nalog izvrsen
+notification.templates.ORDER_DONE.body-template=Zdravo {{name}}, vas nalog {{orderId}} ({{ticker}}) je u potpunosti izvrsen. Kolicina: {{quantity}}, cena izvrsenja: {{price}}.
+notification.templates.ORDER_PARTIAL_FILL.subject=Delimicno izvrsenje naloga
+notification.templates.ORDER_PARTIAL_FILL.body-template=Zdravo {{name}}, nalog {{orderId}} ({{ticker}}) je delimicno izvrsen. Preostala kolicina: {{remainingPortions}}, cena: {{price}}.
+notification.templates.ORDER_AUTO_CANCELLED.subject=Nalog otkazan
+notification.templates.ORDER_AUTO_CANCELLED.body-template=Zdravo {{name}}, vas nalog {{orderId}} ({{ticker}}) je automatski otkazan jer je istekao rok poravnanja.
 notification.templates.TAX_COLLECTED.subject=Tax Collected
 notification.templates.TAX_COLLECTED.body-template=Zdravo {{name}}, naplacen je porez za listing {{listingId}}. Transakcija: {{transactionId}}, porez: {{tax}}, porez u RSD: {{taxRsd}}.
 notification.templates.OTC_COUNTER_OFFERED.subject=OTC Counter Offer
@@ -125,6 +140,10 @@ notification.routing-keys.credit.declined=CREDIT_DECLINED
 notification.routing-keys.credit.installment_failed=CREDIT_INSTALLMENT_FAILED
 notification.routing-keys.order.approved=ORDER_APPROVED
 notification.routing-keys.order.declined=ORDER_DECLINED
+notification.routing-keys.order.created=ORDER_CREATED
+notification.routing-keys.order.done=ORDER_DONE
+notification.routing-keys.order.partial_fill=ORDER_PARTIAL_FILL
+notification.routing-keys.order.auto_cancelled=ORDER_AUTO_CANCELLED
 notification.routing-keys.tax.collected=TAX_COLLECTED
 notification.routing-keys.otc.countered=OTC_COUNTER_OFFERED
 notification.routing-keys.otc.accepted=OTC_ACCEPTED

--- a/order-service/src/main/java/com/banka1/order/controller/OrderController.java
+++ b/order-service/src/main/java/com/banka1/order/controller/OrderController.java
@@ -6,6 +6,7 @@ import com.banka1.order.dto.CreateSellOrderRequest;
 import com.banka1.order.dto.OrderOverviewResponse;
 import com.banka1.order.dto.OrderResponse;
 import com.banka1.order.dto.PartialCancelOrderRequest;
+import com.banka1.order.entity.enums.ListingType;
 import com.banka1.order.entity.enums.OrderOverviewStatusFilter;
 import com.banka1.order.service.OrderCreationService;
 import jakarta.validation.Valid;
@@ -14,12 +15,14 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -79,6 +82,26 @@ public class OrderController {
     @PreAuthorize("hasAnyRole('CLIENT_BASIC','CLIENT_TRADING','CLIENT')")
     public ResponseEntity<List<OrderResponse>> getMyOrders(@AuthenticationPrincipal Jwt jwt) {
         return ResponseEntity.ok(orderCreationService.getMyOrders(toAuthenticatedUser(jwt)));
+    }
+
+    /**
+     * Filtered, paginated view of the authenticated client's own orders. Backs the mobile
+     * My Orders screen. The flat {@link #getMyOrders(Jwt)} endpoint is left untouched for the
+     * existing web frontend.
+     */
+    @GetMapping("/my-orders/paged")
+    @PreAuthorize("hasAnyRole('CLIENT_BASIC','CLIENT_TRADING','CLIENT')")
+    public ResponseEntity<Page<OrderResponse>> getMyOrdersPaged(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestParam(defaultValue = "ALL") OrderOverviewStatusFilter status,
+            @RequestParam(required = false) ListingType listingType,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateTo,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        return ResponseEntity.ok(orderCreationService.getMyOrdersPaged(
+                toAuthenticatedUser(jwt), status, listingType, dateFrom, dateTo, PageRequest.of(page, size)));
     }
 
     @PostMapping("/{id}/confirm")

--- a/order-service/src/main/java/com/banka1/order/dto/OrderNotificationPayload.java
+++ b/order-service/src/main/java/com/banka1/order/dto/OrderNotificationPayload.java
@@ -19,6 +19,11 @@ public class OrderNotificationPayload {
     private Long orderId;
     private OrderStatus status;
     private Long userId;
+    /**
+     * Client id used by notification-service for FCM token lookup. For client-placed orders this
+     * equals {@link #userId}; agent/actuary orders set it too but simply have no registered device.
+     */
+    private Long clientId;
     private Long supervisorId;
     private Long listingId;
     private OrderType orderType;

--- a/order-service/src/main/java/com/banka1/order/dto/OrderResponse.java
+++ b/order-service/src/main/java/com/banka1/order/dto/OrderResponse.java
@@ -1,12 +1,13 @@
 package com.banka1.order.dto;
 
+import com.banka1.order.entity.enums.ListingType;
 import com.banka1.order.entity.enums.OrderDirection;
 import com.banka1.order.entity.enums.OrderStatus;
 import com.banka1.order.entity.enums.OrderType;
 import lombok.Data;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * Response DTO for order creation and details.
@@ -56,8 +57,8 @@ public class OrderResponse {
     /** True when all portions of the order have been executed. */
     private Boolean isDone;
 
-    /** Timestamp of the last status change. */
-    private LocalDateTime lastModification;
+    /** Timestamp of the last status change, in UTC (serialized as ISO-8601 with a trailing {@code Z}). */
+    private Instant lastModification;
 
     /** Number of units still awaiting execution. */
     private Integer remainingPortions;
@@ -82,4 +83,22 @@ public class OrderResponse {
 
     /** Calculated trading fee for this order. */
     private BigDecimal fee;
+
+    /** Ticker symbol of the traded security (enriched from stock-service). */
+    private String ticker;
+
+    /** Full name of the traded security (enriched from stock-service). */
+    private String securityName;
+
+    /** Category of the traded security (STOCK, FUTURES, FOREX, OPTION); enriched from stock-service. */
+    private ListingType listingType;
+
+    /** Weighted-average execution price per unit across all filled portions; null if not executed. */
+    private BigDecimal executionPrice;
+
+    /** Timestamp when the order was created, in UTC (serialized as ISO-8601 with a trailing {@code Z}). */
+    private Instant createdAt;
+
+    /** Timestamp when the order was fully executed (reached DONE), in UTC; null otherwise. */
+    private Instant executedAt;
 }

--- a/order-service/src/main/java/com/banka1/order/entity/Order.java
+++ b/order-service/src/main/java/com/banka1/order/entity/Order.java
@@ -82,6 +82,14 @@ public class Order {
     @Column(nullable = false)
     private LocalDateTime lastModification;
 
+    /** Timestamp when the order was first created. Set once on initial persist. */
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    /** Timestamp when the order reached DONE (all portions executed). Null until fully executed. */
+    @Column(name = "executed_at")
+    private LocalDateTime executedAt;
+
     /** Number of units still to be executed. Decreases as partial fills occur. */
     @Column(nullable = false)
     private Integer remainingPortions;
@@ -125,10 +133,13 @@ public class Order {
     @Column(name = "fund_id")
     private Long fundId;
 
-    /** Updates the lastModification timestamp on every persist and update. */
+    /** Updates the lastModification timestamp on every persist and update, and stamps createdAt once. */
     @PrePersist
     @PreUpdate
     public void updateLastModification() {
         this.lastModification = LocalDateTime.now();
+        if (this.createdAt == null) {
+            this.createdAt = this.lastModification;
+        }
     }
 }

--- a/order-service/src/main/java/com/banka1/order/rabbitmq/OrderEventNotifier.java
+++ b/order-service/src/main/java/com/banka1/order/rabbitmq/OrderEventNotifier.java
@@ -1,0 +1,157 @@
+package com.banka1.order.rabbitmq;
+
+import com.banka1.order.client.ClientClient;
+import com.banka1.order.client.EmployeeClient;
+import com.banka1.order.dto.CustomerDto;
+import com.banka1.order.dto.EmployeeDto;
+import com.banka1.order.dto.OrderNotificationPayload;
+import com.banka1.order.entity.Order;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Publishes order lifecycle notifications (created, fully executed, partial fill, auto-cancelled)
+ * to RabbitMQ for notification-service to deliver via email + FCM push.
+ *
+ * <p>Recipient resolution: client orders are resolved through {@link ClientClient} (so the email
+ * renders and the FCM push — keyed on {@code clientId == order.userId} — reaches the mobile device);
+ * agent/actuary orders fall back to {@link EmployeeClient}. {@code clientId} is always set to the
+ * order owner; agent orders simply have no registered device, so the push is skipped downstream.
+ *
+ * <p>All publishing is best-effort: any failure resolving the recipient or sending is logged and
+ * swallowed so it never blocks order creation/execution.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventNotifier {
+
+    private final OrderNotificationProducer orderNotificationProducer;
+    private final ClientClient clientClient;
+    private final EmployeeClient employeeClient;
+
+    /** Order lifecycle events that produce a client-facing notification. */
+    public enum OrderEventType { CREATED, DONE, PARTIAL_FILL, AUTO_CANCELLED }
+
+    /**
+     * Builds and publishes a lifecycle notification for the given order.
+     *
+     * @param order the order the event concerns
+     * @param eventType the lifecycle event
+     * @param ticker the security ticker if known (may be null)
+     * @param price the relevant price per unit (execution price or reference price; may be null)
+     */
+    public void notifyOrderEvent(Order order, OrderEventType eventType, String ticker, BigDecimal price) {
+        Runnable publish = () -> doPublish(order, eventType, ticker, price);
+
+        // The publish must happen strictly after the surrounding DB transaction commits. The
+        // RabbitTemplate is not channel-transacted, so publishing inline would send the message
+        // immediately — and if the commit later fails, the execution attempt is retried and the
+        // same notification is republished, producing duplicate FCM pushes on the mobile client.
+        // Deferring to afterCommit guarantees exactly one publish per durably-persisted event.
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    publish.run();
+                }
+            });
+        } else {
+            // No active transaction (e.g. invoked outside a @Transactional context) — publish directly.
+            publish.run();
+        }
+    }
+
+    private void doPublish(Order order, OrderEventType eventType, String ticker, BigDecimal price) {
+        try {
+            Recipient recipient = resolveRecipient(order.getUserId());
+            OrderNotificationPayload payload = buildPayload(order, eventType, ticker, price, recipient);
+            switch (eventType) {
+                case CREATED -> orderNotificationProducer.sendOrderCreated(payload);
+                case DONE -> orderNotificationProducer.sendOrderDone(payload);
+                case PARTIAL_FILL -> orderNotificationProducer.sendOrderPartialFill(payload);
+                case AUTO_CANCELLED -> orderNotificationProducer.sendOrderAutoCancelled(payload);
+                default -> { }
+            }
+        } catch (Exception ex) {
+            log.warn("Failed to publish order {} notification for event {}: {}",
+                    order.getId(), eventType, ex.toString());
+        }
+    }
+
+    private OrderNotificationPayload buildPayload(Order order, OrderEventType eventType, String ticker,
+                                                  BigDecimal price, Recipient recipient) {
+        OrderNotificationPayload payload = new OrderNotificationPayload();
+        payload.setOrderId(order.getId());
+        payload.setStatus(order.getStatus());
+        payload.setUserId(order.getUserId());
+        payload.setClientId(order.getUserId());
+        payload.setListingId(order.getListingId());
+        payload.setOrderType(order.getOrderType());
+        payload.setDirection(order.getDirection());
+        payload.setUsername(recipient.name());
+        payload.setUserEmail(recipient.email());
+
+        Map<String, String> variables = new LinkedHashMap<>();
+        if (recipient.name() != null) {
+            variables.put("name", recipient.name());
+        }
+        variables.put("orderId", String.valueOf(order.getId()));
+        variables.put("status", order.getStatus() == null ? "" : order.getStatus().name());
+        variables.put("ticker", ticker == null ? "" : ticker);
+        variables.put("listingId", String.valueOf(order.getListingId()));
+        variables.put("quantity", String.valueOf(order.getQuantity()));
+        variables.put("remainingPortions", String.valueOf(order.getRemainingPortions()));
+        variables.put("price", price == null ? "" : price.toPlainString());
+        variables.put("orderType", order.getOrderType() == null ? "" : order.getOrderType().name());
+        variables.put("direction", order.getDirection() == null ? "" : order.getDirection().name());
+        variables.put("event", eventType.name());
+        payload.setTemplateVariables(variables);
+        return payload;
+    }
+
+    private Recipient resolveRecipient(Long userId) {
+        // Clients are the push audience — resolve them first so email renders and FCM reaches the device.
+        try {
+            CustomerDto customer = clientClient.getCustomer(userId);
+            if (customer != null && customer.getEmail() != null && !customer.getEmail().isBlank()) {
+                return new Recipient(formatCustomerName(customer), customer.getEmail());
+            }
+        } catch (RuntimeException ex) {
+            log.debug("Order owner {} is not a client (or lookup failed): {}", userId, ex.toString());
+        }
+        try {
+            EmployeeDto employee = employeeClient.getEmployee(userId);
+            if (employee != null) {
+                return new Recipient(formatEmployeeName(employee), employee.getEmail());
+            }
+        } catch (RuntimeException ex) {
+            log.debug("Order owner {} is not an employee (or lookup failed): {}", userId, ex.toString());
+        }
+        return new Recipient(null, null);
+    }
+
+    private String formatCustomerName(CustomerDto customer) {
+        String first = customer.getFirstName() == null ? "" : customer.getFirstName().trim();
+        String last = customer.getLastName() == null ? "" : customer.getLastName().trim();
+        String full = (first + " " + last).trim();
+        return full.isEmpty() ? null : full;
+    }
+
+    private String formatEmployeeName(EmployeeDto employee) {
+        String first = employee.getIme() == null ? "" : employee.getIme().trim();
+        String last = employee.getPrezime() == null ? "" : employee.getPrezime().trim();
+        String full = (first + " " + last).trim();
+        return full.isEmpty() ? employee.getUsername() : full;
+    }
+
+    private record Recipient(String name, String email) {
+    }
+}

--- a/order-service/src/main/java/com/banka1/order/rabbitmq/OrderNotificationProducer.java
+++ b/order-service/src/main/java/com/banka1/order/rabbitmq/OrderNotificationProducer.java
@@ -38,6 +38,42 @@ public class OrderNotificationProducer {
     }
 
     /**
+     * Publishes a notification that an order has been created/placed and is awaiting execution.
+     *
+     * @param payload the notification payload (serialized to JSON by Jackson)
+     */
+    public void sendOrderCreated(Object payload) {
+        rabbitTemplate.convertAndSend(exchange, "order.created", payload);
+    }
+
+    /**
+     * Publishes a notification that an order has been fully executed (status DONE).
+     *
+     * @param payload the notification payload (serialized to JSON by Jackson)
+     */
+    public void sendOrderDone(Object payload) {
+        rabbitTemplate.convertAndSend(exchange, "order.done", payload);
+    }
+
+    /**
+     * Publishes a notification that a portion of an order has been filled (partial fill).
+     *
+     * @param payload the notification payload (serialized to JSON by Jackson)
+     */
+    public void sendOrderPartialFill(Object payload) {
+        rabbitTemplate.convertAndSend(exchange, "order.partial_fill", payload);
+    }
+
+    /**
+     * Publishes a notification that a pending order was automatically cancelled on expiry.
+     *
+     * @param payload the notification payload (serialized to JSON by Jackson)
+     */
+    public void sendOrderAutoCancelled(Object payload) {
+        rabbitTemplate.convertAndSend(exchange, "order.auto_cancelled", payload);
+    }
+
+    /**
      * Publishes a notification that tax has been collected from a portfolio transaction.
      *
      * @param payload the notification payload (serialized to JSON by Jackson)

--- a/order-service/src/main/java/com/banka1/order/service/OrderCreationService.java
+++ b/order-service/src/main/java/com/banka1/order/service/OrderCreationService.java
@@ -5,10 +5,12 @@ import com.banka1.order.dto.CreateBuyOrderRequest;
 import com.banka1.order.dto.CreateSellOrderRequest;
 import com.banka1.order.dto.OrderOverviewResponse;
 import com.banka1.order.dto.OrderResponse;
+import com.banka1.order.entity.enums.ListingType;
 import com.banka1.order.entity.enums.OrderOverviewStatusFilter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -49,6 +51,22 @@ public interface OrderCreationService {
      * @return orders created by the client
      */
     List<OrderResponse> getMyOrders(AuthenticatedUser user);
+
+    /**
+     * Returns a filtered, paginated page of orders owned by the authenticated client.
+     * Backs the mobile My Orders screen; the existing {@link #getMyOrders(AuthenticatedUser)}
+     * stays unchanged for the web frontend.
+     *
+     * @param user the authenticated client
+     * @param statusFilter optional status filter (ALL or null for any status)
+     * @param listingType optional security-type filter (null for any)
+     * @param dateFrom optional inclusive lower bound on the order creation date (null for unbounded)
+     * @param dateTo optional inclusive upper bound on the order creation date (null for unbounded)
+     * @param pageable paging request
+     * @return enriched order responses owned by the client, newest first
+     */
+    Page<OrderResponse> getMyOrdersPaged(AuthenticatedUser user, OrderOverviewStatusFilter statusFilter,
+                                         ListingType listingType, LocalDate dateFrom, LocalDate dateTo, Pageable pageable);
 
     /**
      * Confirms a draft order and finalizes validation, approval state, and fee transfer.

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderCreationServiceImpl.java
@@ -21,6 +21,7 @@ import com.banka1.order.dto.client.PaymentDto;
 import com.banka1.order.entity.ActuaryInfo;
 import com.banka1.order.entity.Order;
 import com.banka1.order.entity.Portfolio;
+import com.banka1.order.entity.Transaction;
 import com.banka1.order.entity.enums.ListingType;
 import com.banka1.order.entity.enums.OrderDirection;
 import com.banka1.order.entity.enums.OrderOverviewStatusFilter;
@@ -34,10 +35,13 @@ import com.banka1.order.exception.ResourceNotFoundException;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import com.banka1.order.rabbitmq.OrderEventNotifier;
+import com.banka1.order.rabbitmq.OrderEventNotifier.OrderEventType;
 import com.banka1.order.rabbitmq.OrderNotificationProducer;
 import com.banka1.order.repository.ActuaryInfoRepository;
 import com.banka1.order.repository.OrderRepository;
 import com.banka1.order.repository.PortfolioRepository;
+import com.banka1.order.repository.TransactionRepository;
 import com.banka1.order.service.OrderCreationService;
 import com.banka1.order.service.OrderExecutionService;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +55,11 @@ import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -92,6 +100,7 @@ public class OrderCreationServiceImpl implements OrderCreationService {
 
 
     private final OrderRepository orderRepository;
+    private final TransactionRepository transactionRepository;
     private final ActuaryInfoRepository actuaryInfoRepository;
     private final PortfolioRepository portfolioRepository;
     private final StockClient stockClient;
@@ -101,6 +110,7 @@ public class OrderCreationServiceImpl implements OrderCreationService {
     private final OrderExecutionService orderExecutionService;
     private final TradingServiceClient tradingServiceClient;
     private final OrderNotificationProducer orderNotificationProducer;
+    private final OrderEventNotifier orderEventNotifier;
 
     @Override
     @Transactional
@@ -257,6 +267,67 @@ public class OrderCreationServiceImpl implements OrderCreationService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public Page<OrderResponse> getMyOrdersPaged(AuthenticatedUser user, OrderOverviewStatusFilter statusFilter,
+                                                ListingType listingType, LocalDate dateFrom, LocalDate dateTo, Pageable pageable) {
+        if (!user.isClient()) {
+            throw new ForbiddenOperationException("Only clients can view their orders");
+        }
+
+        List<Order> orders = orderRepository.findByUserId(user.userId());
+
+        Map<Long, StockListingDto> listingCache = new HashMap<>();
+        for (Order order : orders) {
+            if (order.getListingId() != null && !listingCache.containsKey(order.getListingId())) {
+                listingCache.put(order.getListingId(), stockClient.getListing(order.getListingId()));
+            }
+        }
+
+        List<OrderResponse> filtered = orders.stream()
+                .filter(order -> matchesStatusFilter(order, statusFilter))
+                .filter(order -> matchesListingTypeFilter(order, listingType, listingCache))
+                .filter(order -> matchesDateRange(order, dateFrom, dateTo))
+                .sorted(Comparator.comparing(Order::getCreatedAt,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .map(order -> enrichStoredOrderResponse(order, listingCache.get(order.getListingId())))
+                .toList();
+
+        if (pageable.isUnpaged()) {
+            return new PageImpl<>(filtered, pageable, filtered.size());
+        }
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        List<OrderResponse> slice = start >= filtered.size() ? List.of() : filtered.subList(start, end);
+        return new PageImpl<>(slice, pageable, filtered.size());
+    }
+
+    private boolean matchesStatusFilter(Order order, OrderOverviewStatusFilter statusFilter) {
+        if (statusFilter == null || statusFilter == OrderOverviewStatusFilter.ALL) {
+            return true;
+        }
+        return order.getStatus() == OrderStatus.valueOf(statusFilter.name());
+    }
+
+    private boolean matchesListingTypeFilter(Order order, ListingType listingType, Map<Long, StockListingDto> listingCache) {
+        if (listingType == null) {
+            return true;
+        }
+        StockListingDto listing = listingCache.get(order.getListingId());
+        return listing != null && listing.getListingType() == listingType;
+    }
+
+    private boolean matchesDateRange(Order order, LocalDate dateFrom, LocalDate dateTo) {
+        LocalDate created = order.getCreatedAt() == null ? null : order.getCreatedAt().toLocalDate();
+        if (created == null) {
+            return dateFrom == null && dateTo == null;
+        }
+        if (dateFrom != null && created.isBefore(dateFrom)) {
+            return false;
+        }
+        return dateTo == null || !created.isAfter(dateTo);
+    }
+
+    @Override
     @Transactional
     public OrderResponse confirmOrder(AuthenticatedUser user, Long orderId) {
         Order order = getOwnedOrder(user.userId(), orderId);
@@ -323,6 +394,8 @@ public class OrderCreationServiceImpl implements OrderCreationService {
         order.setApprovedBy(decision.status() == OrderStatus.APPROVED ? NO_APPROVAL_REQUIRED : null);
         order.setReservedLimitExposure(decision.reservedExposure());
         order = orderRepository.save(order);
+
+        orderEventNotifier.notifyOrderEvent(order, OrderEventType.CREATED, listing.getTicker(), order.getPricePerUnit());
 
         if (decision.status() == OrderStatus.APPROVED) {
             final Long approvedOrderId = order.getId();
@@ -437,7 +510,9 @@ public class OrderCreationServiceImpl implements OrderCreationService {
                 continue;
             }
 
-            declinePendingOrder(lockedOrder, SYSTEM_APPROVAL, true);
+            Order cancelled = declinePendingOrder(lockedOrder, SYSTEM_APPROVAL, false);
+            orderEventNotifier.notifyOrderEvent(cancelled, OrderEventType.AUTO_CANCELLED,
+                    listing.getTicker(), cancelled.getPricePerUnit());
         }
     }
 
@@ -850,6 +925,46 @@ public class OrderCreationServiceImpl implements OrderCreationService {
         return mapToResponse(order, approximatePrice, fee, order.getExchangeClosed());
     }
 
+    /**
+     * Builds an enriched response for the mobile My Orders screen: base order fields plus
+     * ticker / security name / listing type from the (cached) listing and the realized
+     * execution price computed from recorded transactions.
+     */
+    private OrderResponse enrichStoredOrderResponse(Order order, StockListingDto listing) {
+        BigDecimal approximatePrice = order.getPricePerUnit()
+                .multiply(BigDecimal.valueOf(order.getContractSize()))
+                .multiply(BigDecimal.valueOf(order.getQuantity()));
+        String currency = listing == null ? null : listing.getCurrency();
+        BigDecimal fee = calculateFee(orderPricingFamily(order.getOrderType()), approximatePrice, currency);
+        OrderResponse response = mapToResponse(order, approximatePrice, fee, order.getExchangeClosed());
+        if (listing != null) {
+            response.setTicker(listing.getTicker());
+            response.setSecurityName(listing.getName());
+            response.setListingType(listing.getListingType());
+        }
+        response.setExecutionPrice(calculateExecutionPrice(order.getId()));
+        return response;
+    }
+
+    /** Weighted-average execution price per unit across all recorded fills, or null if none. */
+    private BigDecimal calculateExecutionPrice(Long orderId) {
+        List<Transaction> transactions = transactionRepository.findByOrderId(orderId);
+        BigDecimal weightedSum = BigDecimal.ZERO;
+        long totalQuantity = 0;
+        for (Transaction transaction : transactions) {
+            if (transaction.getPricePerUnit() == null || transaction.getQuantity() == null) {
+                continue;
+            }
+            weightedSum = weightedSum.add(transaction.getPricePerUnit()
+                    .multiply(BigDecimal.valueOf(transaction.getQuantity())));
+            totalQuantity += transaction.getQuantity();
+        }
+        if (totalQuantity == 0) {
+            return null;
+        }
+        return weightedSum.divide(BigDecimal.valueOf(totalQuantity), 4, RoundingMode.HALF_UP);
+    }
+
     private OrderResponse mapToResponse(Order order, BigDecimal approximatePrice, BigDecimal fee, Boolean exchangeClosed) {
         OrderResponse response = new OrderResponse();
         response.setId(order.getId());
@@ -865,7 +980,7 @@ public class OrderCreationServiceImpl implements OrderCreationService {
         response.setStatus(order.getStatus());
         response.setApprovedBy(order.getApprovedBy());
         response.setIsDone(order.getIsDone());
-        response.setLastModification(order.getLastModification());
+        response.setLastModification(toUtcInstant(order.getLastModification()));
         response.setRemainingPortions(order.getRemainingPortions());
         response.setAfterHours(order.getAfterHours());
         response.setExchangeClosed(exchangeClosed);
@@ -874,7 +989,19 @@ public class OrderCreationServiceImpl implements OrderCreationService {
         response.setAccountId(order.getAccountId());
         response.setApproximatePrice(approximatePrice);
         response.setFee(fee);
+        response.setCreatedAt(toUtcInstant(order.getCreatedAt()));
+        response.setExecutedAt(toUtcInstant(order.getExecutedAt()));
         return response;
+    }
+
+    /**
+     * Converts a stored naive {@link LocalDateTime} (persisted in UTC by the service) into an
+     * {@link Instant} so the API serializes it as ISO-8601 with a trailing {@code Z}. Without this,
+     * clients received a zone-less timestamp and rendered it as if local, drifting from the UTC
+     * timestamps shown elsewhere (e.g. push notifications) by the host's offset.
+     */
+    private static Instant toUtcInstant(LocalDateTime timestamp) {
+        return timestamp == null ? null : timestamp.toInstant(ZoneOffset.UTC);
     }
 
     private void validateTradingAccess(AuthenticatedUser user, StockListingDto listing) {

--- a/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
+++ b/order-service/src/main/java/com/banka1/order/service/impl/OrderExecutionServiceImpl.java
@@ -23,6 +23,8 @@ import com.banka1.order.entity.enums.PurchaseFor;
 import com.banka1.order.repository.ActuaryInfoRepository;
 import com.banka1.order.repository.OrderRepository;
 import com.banka1.order.repository.PortfolioRepository;
+import com.banka1.order.rabbitmq.OrderEventNotifier;
+import com.banka1.order.rabbitmq.OrderEventNotifier.OrderEventType;
 import com.banka1.order.repository.TransactionRepository;
 import com.banka1.order.service.OrderExecutionService;
 import org.springframework.beans.factory.ObjectProvider;
@@ -90,6 +92,19 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
     private static final String USD = "USD";
     private static final long MISSING_QUOTE_RETRY_DELAY_MILLIS = 1000L;
 
+    /**
+     * Nominal window (in seconds) over which an order whose remaining size equals the listing's
+     * traded volume would spread its fills. Larger volume relative to the order shortens the gap;
+     * the result is clamped by the MIN/MAX gap constants below so it can neither bunch nor stall.
+     */
+    private static final double EXECUTION_SPREAD_WINDOW_SECONDS = 24d * 60d * 60d;
+    /** Floor between two consecutive fills so partial-fill/done pushes never arrive in one burst. */
+    private static final long MIN_EXECUTION_GAP_MILLIS = 15_000L;
+    /** Ceiling for a single inter-fill gap so the simulated order still completes in an observable window. */
+    private static final long MAX_EXECUTION_GAP_MILLIS = 300_000L;
+    /** Extra delay applied to after-hours orders, which only execute once the next session opens. */
+    private static final long AFTER_HOURS_DELAY_MILLIS = 30L * 60L * 1000L;
+
     private final OrderRepository orderRepository;
     private final PortfolioRepository portfolioRepository;
     private final TransactionRepository transactionRepository;
@@ -101,6 +116,7 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
     private final ObjectProvider<OrderExecutionService> selfProvider;
     private final TaskScheduler orderExecutionTaskScheduler;
     private final TradingServiceClient tradingServiceClient;
+    private final OrderEventNotifier orderEventNotifier;
 
     private static final long INITIAL_EXECUTION_DELAY_MILLIS = 60_000L;
 
@@ -196,8 +212,14 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
         if (managedOrder.getRemainingPortions() == 0) {
             managedOrder.setIsDone(true);
             managedOrder.setStatus(OrderStatus.DONE);
+            managedOrder.setExecutedAt(LocalDateTime.now());
         }
         orderRepository.save(managedOrder);
+
+        OrderEventType event = managedOrder.getRemainingPortions() == 0
+                ? OrderEventType.DONE
+                : OrderEventType.PARTIAL_FILL;
+        orderEventNotifier.notifyOrderEvent(managedOrder, event, listing.getTicker(), executionPricePerUnit);
     }
 
     private boolean activateIfEligible(Order order, StockListingDto listing) {
@@ -462,12 +484,22 @@ public class OrderExecutionServiceImpl implements OrderExecutionService {
             return MISSING_QUOTE_RETRY_DELAY_MILLIS;
         }
         long volume = listing.getVolume() == null || listing.getVolume() <= 0 ? 1L : listing.getVolume();
-        double maxSeconds = (24d * 60d) / (volume / (double) Math.max(1, order.getRemainingPortions()));
-        double delaySeconds = ThreadLocalRandom.current().nextDouble() * maxSeconds;
+        // Liquidity-driven spacing: a small order against deep volume fills quickly, a large order
+        // against thin volume fills slowly. The previous formula used (24*60) as the window, which
+        // for any liquid listing collapsed the gap to a few milliseconds — so every remaining
+        // portion (and its partial-fill/done notification) fired in a single instantaneous burst.
+        // We now spread over a full-day window and clamp the gap to [MIN, MAX] so consecutive fills
+        // are never closer than MIN_EXECUTION_GAP (no notification bunching) nor farther apart than
+        // MAX_EXECUTION_GAP (the order still completes within an observable window).
+        double liquidityRatio = volume / (double) Math.max(1, order.getRemainingPortions());
+        double spreadSeconds = EXECUTION_SPREAD_WINDOW_SECONDS / liquidityRatio;
+        double randomizedSeconds = ThreadLocalRandom.current().nextDouble() * spreadSeconds;
+        long delayMillis = Math.max(MIN_EXECUTION_GAP_MILLIS,
+                Math.min(MAX_EXECUTION_GAP_MILLIS, (long) (randomizedSeconds * 1000)));
         if (Boolean.TRUE.equals(order.getAfterHours())) {
-            delaySeconds += 30d * 60d;
+            delayMillis += AFTER_HOURS_DELAY_MILLIS;
         }
-        return (long) (delaySeconds * 1000);
+        return delayMillis;
     }
 
     private BigDecimal calculateCommission(OrderType orderType, BigDecimal baseAmount, String currency) {

--- a/order-service/src/main/resources/db/changelog/db-changelog-order.xml
+++ b/order-service/src/main/resources/db/changelog/db-changelog-order.xml
@@ -16,4 +16,5 @@
     <include file="db/changelog/order/009-otc-tax-charge-contract-id.sql"/>
     <include file="db/changelog/order/010-tax-charge-drop-fk.sql"/>
     <include file="db/changelog/order/011-fund-order-columns.sql"/>
+    <include file="db/changelog/order/012-order-timestamps.sql"/>
 </databaseChangeLog>

--- a/order-service/src/main/resources/db/changelog/order/012-order-timestamps.sql
+++ b/order-service/src/main/resources/db/changelog/order/012-order-timestamps.sql
@@ -1,0 +1,8 @@
+-- liquibase formatted sql
+
+-- changeset order:12
+ALTER TABLE orders ADD COLUMN created_at TIMESTAMP;
+ALTER TABLE orders ADD COLUMN executed_at TIMESTAMP;
+UPDATE orders SET created_at = last_modification WHERE created_at IS NULL;
+UPDATE orders SET executed_at = last_modification WHERE executed_at IS NULL AND status = 'DONE';
+ALTER TABLE orders ALTER COLUMN created_at SET NOT NULL;

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderCreationServiceTest.java
@@ -86,6 +86,10 @@ class OrderCreationServiceTest {
     private OrderExecutionService orderExecutionService;
     @Mock
     private OrderNotificationProducer orderNotificationProducer;
+    @Mock
+    private com.banka1.order.repository.TransactionRepository transactionRepository;
+    @Mock
+    private com.banka1.order.rabbitmq.OrderEventNotifier orderEventNotifier;
 
     @InjectMocks
     private OrderCreationServiceImpl service;
@@ -1175,18 +1179,11 @@ class OrderCreationServiceTest {
         activeListing.setId(43L);
         activeListing.setSettlementDate(LocalDate.now().plusDays(1));
 
-        EmployeeDto employee = new EmployeeDto();
-        employee.setId(2L);
-        employee.setIme("Ana");
-        employee.setPrezime("Agent");
-        employee.setEmail("ana.agent@example.com");
-
         when(orderRepository.findByStatus(OrderStatus.PENDING)).thenReturn(List.of(expiredPending, activePending));
         when(orderRepository.findByIdForUpdate(201L)).thenReturn(Optional.of(expiredPending));
         when(orderRepository.findByIdForUpdate(202L)).thenReturn(Optional.of(activePending));
         when(stockClient.getListing(42L)).thenReturn(expiredListing);
         when(stockClient.getListing(43L)).thenReturn(activeListing);
-        when(employeeClient.getEmployee(2L)).thenReturn(employee);
 
         service.autoDeclineExpiredPendingOrders();
 
@@ -1197,7 +1194,12 @@ class OrderCreationServiceTest {
         assertThat(activePending.getStatus()).isEqualTo(OrderStatus.PENDING);
         verify(orderRepository).save(expiredPending);
         verify(orderRepository, never()).save(activePending);
-        verify(orderNotificationProducer).sendOrderDeclined(any(OrderNotificationPayload.class));
+        // Expired pending orders are now reported as a distinct auto-cancelled event (not a decline).
+        verify(orderEventNotifier).notifyOrderEvent(
+                org.mockito.ArgumentMatchers.eq(expiredPending),
+                org.mockito.ArgumentMatchers.eq(com.banka1.order.rabbitmq.OrderEventNotifier.OrderEventType.AUTO_CANCELLED),
+                any(), any());
+        verify(orderNotificationProducer, never()).sendOrderDeclined(any(OrderNotificationPayload.class));
     }
 
     private Order orderForUser(Long orderId, Long userId) {

--- a/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
+++ b/order-service/src/test/java/com/banka1/order/service/impl/OrderExecutionServiceTest.java
@@ -74,6 +74,8 @@ class OrderExecutionServiceTest {
     private OrderExecutionService self;
     @Mock
     private TaskScheduler orderExecutionTaskScheduler;
+    @Mock
+    private com.banka1.order.rabbitmq.OrderEventNotifier orderEventNotifier;
 
     @InjectMocks
     private OrderExecutionServiceImpl service;

--- a/saga-orchestrator-service/src/main/resources/application.properties
+++ b/saga-orchestrator-service/src/main/resources/application.properties
@@ -33,6 +33,13 @@ spring.jpa.open-in-view=false
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 
+# --- Swagger -----------------------------------------------------------------
+springdoc.api-docs.enabled=${SWAGGER_ENABLED:true}
+springdoc.swagger-ui.enabled=${SWAGGER_ENABLED:true}
+# Behind api-gateway: swagger-ui fetches the spec via the /saga prefix (nginx strips it)
+springdoc.swagger-ui.config-url=/saga/v3/api-docs/swagger-config
+springdoc.swagger-ui.url=/saga/v3/api-docs
+
 spring.rabbitmq.listener.simple.default-requeue-rejected=false
 spring.rabbitmq.listener.simple.auto-startup=${RABBITMQ_LISTENER_ENABLED:true}
 spring.rabbitmq.listener.simple.prefetch=10


### PR DESCRIPTION
…ed mobile orders view

Adds end-to-end order lifecycle notifications (created, done, partial fill, auto-cancelled) delivered via RabbitMQ to notification-service, which fans out to email (authoritative) and FCM push (best-effort) for the mobile app.

order-service:
- OrderEventNotifier publishes lifecycle events after transaction commit to avoid duplicate pushes on retry; resolves recipient via client/employee client.
- OrderNotificationProducer gains created/done/partial_fill/auto_cancelled keys.
- Expired pending orders now reported as a distinct AUTO_CANCELLED event.
- New GET /my-orders/paged: filtered, paginated, enriched (ticker, security name, listing type, weighted-avg execution price) view for the mobile screen.
- Order gains createdAt/executedAt; OrderResponse timestamps serialized as UTC Instant (ISO-8601 Z) to fix client timezone drift. Liquibase 012 migration.
- Execution delay reworked to spread fills over a clamped [15s,300s] window so partial-fill/done notifications no longer fire in one burst.

notification-service:
- ORDER_CREATED/DONE/PARTIAL_FILL/AUTO_CANCELLED routing keys + email templates.
- FcmPushService.sendOrderPush: high-priority data-only order push.
- NotificationDeliveryService schedules order FCM push after commit.

api-gateway + service configs:
- Expose per-service Swagger UI/api-docs behind the gateway prefixes.

Verified: order-service and notification-service tests for the changed code pass; the change introduces no new test failures.