### PR TITLE
prekucane ilijanove promene iz jave u go

### DIFF
--- a/banking-core-service-go/internal/http/authz_test.go
+++ b/banking-core-service-go/internal/http/authz_test.go
@@ -42,6 +42,7 @@ func TestRouteAuth(t *testing.T) {
 	}{
 		{"GET", "/actuator/health/liveness", authOpen, nil},
 		{"GET", "/accounts/internal/default/5", authOpen, nil},
+		{"GET", "/accounts/internal/by-owner/5/currency/USD", authOpen, nil},
 		{"POST", "/verification/generate", authAuthenticated, nil},
 		{"POST", "/transactions/payment", authRoles, rolesClientBasic},
 		{"GET", "/transactions/by-client", authRoles, rolesBasic},

--- a/banking-core-service-go/internal/http/handler.go
+++ b/banking-core-service-go/internal/http/handler.go
@@ -191,6 +191,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getMarginUser(w, r, strings.TrimPrefix(path, "/accounts/getMarginUser/"))
 	case r.Method == http.MethodGet && strings.HasPrefix(path, "/accounts/company/getMarginCompany/"):
 		h.getMarginCompany(w, r, strings.TrimPrefix(path, "/accounts/company/getMarginCompany/"))
+	case r.Method == http.MethodGet && strings.HasPrefix(path, "/accounts/internal/by-owner/"):
+		h.accountByOwnerAndCurrency(w, r, strings.TrimPrefix(path, "/accounts/internal/by-owner/"))
 	case r.Method == http.MethodGet && strings.HasPrefix(path, "/accounts/internal/default/"):
 		h.defaultAccount(w, r, strings.TrimPrefix(path, "/accounts/internal/default/"))
 
@@ -336,6 +338,29 @@ func (h *Handler) defaultAccount(w http.ResponseWriter, r *http.Request, rawID s
 		"ownerId":       strconv.FormatInt(id, 10),
 		"accountNumber": resp.AccountNumber,
 	})
+}
+
+func (h *Handler) accountByOwnerAndCurrency(w http.ResponseWriter, r *http.Request, raw string) {
+	parts := strings.Split(strings.Trim(raw, "/"), "/")
+	if len(parts) != 3 || parts[1] != "currency" || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[2]) == "" {
+		writeError(w, http.StatusBadRequest, "ERR_VALIDATION", "Neispravni podaci", "putanja mora biti /accounts/internal/by-owner/{ownerId}/currency/{currencyCode}")
+		return
+	}
+	id, ok := parseIntPath(w, parts[0])
+	if !ok {
+		return
+	}
+	resp, err := h.services.Accounts.FindByOwnerAndCurrency(r.Context(), id, parts[2])
+	if err != nil {
+		var serviceErr *service.Error
+		if errors.As(err, &serviceErr) && serviceErr.Status == http.StatusNotFound {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		handleError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *Handler) buyOnMargin(w http.ResponseWriter, r *http.Request) {
@@ -681,6 +706,7 @@ func isKnownPath(path string) bool {
 		"/accounts/client/accounts/",
 		"/accounts/getMarginUser/",
 		"/accounts/company/getMarginCompany/",
+		"/accounts/internal/by-owner/",
 		"/accounts/internal/default/",
 		"/api/cards/client/",
 		"/api/cards/id/",

--- a/banking-core-service-go/internal/http/handler_test.go
+++ b/banking-core-service-go/internal/http/handler_test.go
@@ -147,6 +147,16 @@ func TestActuatorEndpointsOpenWithoutAuth(t *testing.T) {
 	}
 }
 
+func TestInternalAccountByOwnerCurrencyRejectsInvalidPathWithoutAuth(t *testing.T) {
+	h := testHandler()
+	req := httptest.NewRequest(http.MethodGet, "/accounts/internal/by-owner/5/currency", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400\nbody: %s", rec.Code, rec.Body.String())
+	}
+}
+
 // ── 404 on completely unknown paths ─────────────────────────────────────────
 
 func TestServeHTTPNotFoundForUnknownPaths(t *testing.T) {
@@ -194,6 +204,7 @@ func TestIsKnownPathMatchesPrefixRoutes(t *testing.T) {
 		"/transactions/addToMargin/7",
 		"/transfers/ORDER-001",
 		"/internal/accounts/ACC123/details",
+		"/accounts/internal/by-owner/5/currency/USD",
 	}
 	for _, p := range known {
 		if !isKnownPath(p) {

--- a/banking-core-service-go/internal/http/internal_account_controller_test.go
+++ b/banking-core-service-go/internal/http/internal_account_controller_test.go
@@ -1,0 +1,246 @@
+package http
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"banka1/banking-core-service-go/internal/config"
+	"banka1/banking-core-service-go/internal/service"
+)
+
+func TestInternalDefaultAccountReturnsRSDAccountNumber(t *testing.T) {
+	h, cleanup := internalAccountTestHandler(t, []internalAccountFixture{
+		{id: 701, ownerID: 7, currency: "RSD", accountNumber: "111000110000000701"},
+	})
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/accounts/internal/default/7", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200\nbody: %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		OwnerID       string `json:"ownerId"`
+		AccountNumber string `json:"accountNumber"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.OwnerID != "7" || got.AccountNumber != "111000110000000701" {
+		t.Fatalf("response = %+v, want ownerId=7 accountNumber=111000110000000701", got)
+	}
+}
+
+func TestInternalAccountByOwnerAndCurrencyReturnsAccountWhenPresent(t *testing.T) {
+	h, cleanup := internalAccountTestHandler(t, []internalAccountFixture{
+		{id: 801, ownerID: 7, currency: "USD", accountNumber: "111000110000000801"},
+	})
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/accounts/internal/by-owner/7/currency/USD", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200\nbody: %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		ID            int64  `json:"id"`
+		AccountNumber string `json:"accountNumber"`
+		Currency      string `json:"currency"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != 801 || got.AccountNumber != "111000110000000801" || got.Currency != "USD" {
+		t.Fatalf("response = %+v, want USD account payload", got)
+	}
+}
+
+func TestInternalAccountByOwnerAndCurrencyReturns404WhenMissing(t *testing.T) {
+	h, cleanup := internalAccountTestHandler(t, nil)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/accounts/internal/by-owner/7/currency/USD", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404\nbody: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("body length = %d, want empty 404 body: %q", rec.Body.Len(), rec.Body.String())
+	}
+}
+
+type internalAccountFixture struct {
+	id            int64
+	ownerID       int64
+	currency      string
+	accountNumber string
+}
+
+func internalAccountTestHandler(t *testing.T, fixtures []internalAccountFixture) (*Handler, func()) {
+	t.Helper()
+	db, dsn := openInternalAccountFixtureDB(t, fixtures)
+	accounts := service.NewAccountService(db, config.Config{}, nil)
+	return &Handler{
+			cfg: testAuthConfig(),
+			services: &service.Container{
+				Accounts: accounts,
+			},
+		}, func() {
+			deleteInternalAccountFixtures(dsn)
+			_ = db.Close()
+		}
+}
+
+const internalAccountFixtureDriverName = "internal-account-fixture"
+
+var (
+	internalAccountFixtureDriverOnce sync.Once
+	internalAccountFixtureDBSeq      atomic.Int64
+	internalAccountFixtureMu         sync.Mutex
+	internalAccountFixturesByDSN     = map[string]map[string]internalAccountFixture{}
+)
+
+func openInternalAccountFixtureDB(t *testing.T, fixtures []internalAccountFixture) (*sql.DB, string) {
+	t.Helper()
+	internalAccountFixtureDriverOnce.Do(func() {
+		sql.Register(internalAccountFixtureDriverName, internalAccountFixtureDriver{})
+	})
+
+	dsn := "internal-account-fixture-" + strconv.FormatInt(internalAccountFixtureDBSeq.Add(1), 10)
+	byKey := map[string]internalAccountFixture{}
+	for _, fixture := range fixtures {
+		byKey[internalAccountFixtureKey(fixture.ownerID, fixture.currency)] = fixture
+	}
+	internalAccountFixtureMu.Lock()
+	internalAccountFixturesByDSN[dsn] = byKey
+	internalAccountFixtureMu.Unlock()
+
+	db, err := sql.Open(internalAccountFixtureDriverName, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db, dsn
+}
+
+func deleteInternalAccountFixtures(dsn string) {
+	internalAccountFixtureMu.Lock()
+	delete(internalAccountFixturesByDSN, dsn)
+	internalAccountFixtureMu.Unlock()
+}
+
+func internalAccountFixtureKey(ownerID int64, currency string) string {
+	return strconv.FormatInt(ownerID, 10) + ":" + currency
+}
+
+type internalAccountFixtureDriver struct{}
+
+func (internalAccountFixtureDriver) Open(name string) (driver.Conn, error) {
+	return internalAccountFixtureConn{dsn: name}, nil
+}
+
+type internalAccountFixtureConn struct {
+	dsn string
+}
+
+func (c internalAccountFixtureConn) Prepare(string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (c internalAccountFixtureConn) Close() error {
+	internalAccountFixtureMu.Lock()
+	delete(internalAccountFixturesByDSN, c.dsn)
+	internalAccountFixtureMu.Unlock()
+	return nil
+}
+
+func (c internalAccountFixtureConn) Begin() (driver.Tx, error) {
+	return nil, driver.ErrSkip
+}
+
+func (c internalAccountFixtureConn) QueryContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
+	var ownerID int64
+	var currency string
+	if len(args) >= 2 {
+		if v, ok := args[0].Value.(int64); ok {
+			ownerID = v
+		}
+		if v, ok := args[1].Value.(string); ok {
+			currency = v
+		}
+	}
+
+	internalAccountFixtureMu.Lock()
+	fixture, ok := internalAccountFixturesByDSN[c.dsn][internalAccountFixtureKey(ownerID, currency)]
+	internalAccountFixtureMu.Unlock()
+	if !ok {
+		return &internalAccountFixtureRows{}, nil
+	}
+	return &internalAccountFixtureRows{row: fixture, hasRow: true}, nil
+}
+
+type internalAccountFixtureRows struct {
+	row     internalAccountFixture
+	hasRow  bool
+	scanned bool
+}
+
+func (r *internalAccountFixtureRows) Columns() []string {
+	return []string{
+		"id", "broj_racuna", "vlasnik", "oznaka", "raspolozivo_stanje",
+		"stanje", "status", "account_type", "email", "username",
+		"dnevni_limit", "mesecni_limit", "dnevna_potrosnja", "mesecna_potrosnja",
+		"has_daily_limit", "has_monthly_limit", "datum_isteka",
+		"daily_limit_remaining", "has_daily_limit_remaining",
+	}
+}
+
+func (r *internalAccountFixtureRows) Close() error {
+	return nil
+}
+
+func (r *internalAccountFixtureRows) Next(dest []driver.Value) error {
+	if !r.hasRow || r.scanned {
+		return io.EOF
+	}
+	r.scanned = true
+	values := []driver.Value{
+		r.row.id,
+		r.row.accountNumber,
+		r.row.ownerID,
+		r.row.currency,
+		"0",
+		"0",
+		"ACTIVE",
+		"CHECKING",
+		"",
+		"",
+		"0",
+		"0",
+		"0",
+		"0",
+		false,
+		false,
+		nil,
+		"0",
+		false,
+	}
+	copy(dest, values)
+	return nil
+}
+
+var _ driver.QueryerContext = internalAccountFixtureConn{}

--- a/banking-core-service-go/internal/service/accounts.go
+++ b/banking-core-service-go/internal/service/accounts.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math/rand"
 	"net/http"
+	"strings"
 	"time"
 
 	"banka1/banking-core-service-go/internal/config"
@@ -42,6 +43,12 @@ type AccountDetails struct {
 	AccountType      string          `json:"accountType,omitempty"`
 	Email            string          `json:"email,omitempty"`
 	Username         string          `json:"username,omitempty"`
+}
+
+type InternalAccountByOwnerCurrencyResponse struct {
+	ID            int64  `json:"id"`
+	AccountNumber string `json:"accountNumber"`
+	Currency      string `json:"currency"`
 }
 
 type accountBalanceRow struct {
@@ -126,6 +133,22 @@ func (s *AccountService) FindDefaultRSDByOwner(ctx context.Context, ownerID int6
 		return AccountDetails{}, err
 	}
 	return row.details(), nil
+}
+
+func (s *AccountService) FindByOwnerAndCurrency(ctx context.Context, ownerID int64, currency string) (InternalAccountByOwnerCurrencyResponse, error) {
+	currency = strings.ToUpper(strings.TrimSpace(currency))
+	if currency == "" {
+		return InternalAccountByOwnerCurrencyResponse{}, BadRequest("currencyCode je obavezan")
+	}
+	row, err := s.getByOwnerAndCurrency(ctx, s.db, ownerID, currency, false)
+	if err != nil {
+		return InternalAccountByOwnerCurrencyResponse{}, err
+	}
+	return InternalAccountByOwnerCurrencyResponse{
+		ID:            row.ID,
+		AccountNumber: row.AccountNumber,
+		Currency:      row.Currency,
+	}, nil
 }
 
 func (s *AccountService) FindClientAccounts(ctx context.Context, ownerID int64) ([]AccountDetails, error) {


### PR DESCRIPTION
## Summary

Portovan je novi Java `InternalAccountController` endpoint iz dividend commita u `banking-core-service-go`.

Dodato:
- `GET /accounts/internal/by-owner/{ownerId}/currency/{currencyCode}`
- response `{ id, accountNumber, currency }` kada račun postoji
- prazan `404` kada vlasnik nema račun u traženoj valuti, za dividend FX fallback tok
- Go test ekvivalent novog Java controller testa

Postojeći endpoint `GET /accounts/internal/default/{ownerId}` je ostavljen kompatibilan i dodatno pokriven testom.
