### PR TITLE
fix(backend): trading startup crash + 4 FE bug-a + gateway/CORS + inter-bank dev config

### DIFF
--- a/account-service/src/main/java/com/banka1/account_service/controller/SifraDelatnostiController.java
+++ b/account-service/src/main/java/com/banka1/account_service/controller/SifraDelatnostiController.java
@@ -1,0 +1,52 @@
+package com.banka1.account_service.controller;
+
+import com.banka1.account_service.domain.SifraDelatnosti;
+import com.banka1.account_service.dto.response.SifraDelatnostiResponseDto;
+import com.banka1.account_service.repository.SifraDelatnostiRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST kontroler koji izlaze sifre delatnosti (klasifikacija po granama) koje
+ * frontend koristi pri kreiranju poslovnog (firma) racuna.
+ * <p>
+ * Eksterna putanja je {@code /accounts/api/sifra-delatnosti} (gateway prosledjuje
+ * bez strip-ovanja prefiksa, isto kao {@code /accounts/api/currencies}). Pristup
+ * imaju klijenti i zaposleni jer je podatak read-only sifarnik potreban tokom
+ * forme za otvaranje racuna.
+ */
+@RestController
+@RequestMapping("/accounts/api/sifra-delatnosti")
+@AllArgsConstructor
+@PreAuthorize("hasAnyRole('CLIENT_BASIC','BASIC')")
+public class SifraDelatnostiController {
+
+    /** Repozitorijum sifri delatnosti (read-only sifarnik). */
+    private final SifraDelatnostiRepository sifraDelatnostiRepository;
+
+    /**
+     * Vraca sve sifre delatnosti, sortirane po sifri rastuce.
+     *
+     * @param jwt JWT token autentifikovanog korisnika
+     * @return lista {@link SifraDelatnostiResponseDto} ({@code {sifra, grana}})
+     */
+    @GetMapping
+    public ResponseEntity<List<SifraDelatnostiResponseDto>> findAll(@AuthenticationPrincipal Jwt jwt) {
+        List<SifraDelatnostiResponseDto> result = sifraDelatnostiRepository
+                .findAll(Sort.by(Sort.Direction.ASC, "sifra"))
+                .stream()
+                .map(SifraDelatnostiResponseDto::from)
+                .toList();
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+}

--- a/account-service/src/main/java/com/banka1/account_service/dto/response/SifraDelatnostiResponseDto.java
+++ b/account-service/src/main/java/com/banka1/account_service/dto/response/SifraDelatnostiResponseDto.java
@@ -1,0 +1,27 @@
+package com.banka1.account_service.dto.response;
+
+import com.banka1.account_service.domain.SifraDelatnosti;
+
+/**
+ * Lagani odgovor sa sifrom delatnosti i nazivom grane.
+ * <p>
+ * Frontend (account-create) ocekuje listu objekata oblika {@code {sifra, grana}}
+ * za popunjavanje dropdown-a pri kreiranju poslovnog racuna. Vracamo DTO umesto
+ * {@link SifraDelatnosti} entiteta da ne bismo serijalizovali lazy {@code sektori}
+ * kolekciju i interna polja (id, version).
+ *
+ * @param sifra jedinstvena sifra delatnosti (npr. "6419")
+ * @param grana ljudski-citljiv naziv grane (npr. "Finansijska delatnost")
+ */
+public record SifraDelatnostiResponseDto(String sifra, String grana) {
+
+    /**
+     * Mapira JPA entitet u lagani DTO.
+     *
+     * @param entity entitet sifre delatnosti
+     * @return DTO sa sifrom i granom
+     */
+    public static SifraDelatnostiResponseDto from(SifraDelatnosti entity) {
+        return new SifraDelatnostiResponseDto(entity.getSifra(), entity.getGrana());
+    }
+}

--- a/api-gateway/default.conf.template
+++ b/api-gateway/default.conf.template
@@ -90,8 +90,14 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Card-service controlleri (CardManagementController/CardCreationController) su
+    # mapirani na BARE sufikse (/all, /client/{id}, /id/{cardId}/block, /account/{n},
+    # /request, /request/business) — NEMAJU /api/cards prefiks (potvrdjeno u
+    # banking-core /v3/api-docs). Zato OVDE strip-ujemo /api/cards (trailing slash na
+    # proxy_pass): /api/cards/all -> /all, /api/cards/id/5/block -> /id/5/block, itd.
+    # Ovo pokriva CEO card surface jednim blokom, a ne samo /all.
     location /api/cards/ {
-        proxy_pass http://banking_core_service;
+        proxy_pass http://banking_core_service/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -286,6 +292,26 @@ server {
     }
     location /audit/ {
         proxy_pass http://trading_service;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Frontend (AuditLogService) zove BARE /audit-logs; backend AuditLogController je
+    # na /audit (trading-service). Ranije /audit-logs nije bio rutiran -> nginx 404
+    # BEZ CORS header-a -> browser je prijavljivao CORS gresku. Mapiramo /audit-logs
+    # na trading-service /audit; CORS header-e dodaje sam trading-service (security-lib
+    # CorsConfigurationSource, isto kao za /audit i ostale radne rute).
+    location = /audit-logs {
+        proxy_pass http://trading_service/audit$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /audit-logs/ {
+        proxy_pass http://trading_service/audit/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/client-service/src/main/java/com/banka1/clientService/advice/GlobalExceptionHandler.java
+++ b/client-service/src/main/java/com/banka1/clientService/advice/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ import java.util.NoSuchElementException;
  * Mapira ocekivane i neocekivane izuzetke na standardizovane HTTP odgovore sa {@link ErrorResponseDto} telom.
  */
 @Slf4j
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.banka1.clientService.controller")
 @Component("clientServiceGlobalExceptionHandler")
 public class GlobalExceptionHandler {
 

--- a/employee-service/src/main/java/com/banka1/employeeService/advice/GlobalExceptionHandler.java
+++ b/employee-service/src/main/java/com/banka1/employeeService/advice/GlobalExceptionHandler.java
@@ -24,7 +24,7 @@ import java.util.NoSuchElementException;
  * Centralizovani hendler gresaka za sve REST kontrolere.
  * Mapira ocekivane i neocekivane izuzetke na standardizovane HTTP odgovore sa {@link ErrorResponseDto} telom.
  */
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.banka1.employeeService.controller")
 @Component("employeeServiceGlobalExceptionHandler")
 public class GlobalExceptionHandler {
 

--- a/order-service/src/main/resources/db/changelog/order/012-order-timestamps.sql
+++ b/order-service/src/main/resources/db/changelog/order/012-order-timestamps.sql
@@ -1,8 +1,11 @@
 -- liquibase formatted sql
 
 -- changeset order:12
-ALTER TABLE orders ADD COLUMN created_at TIMESTAMP;
-ALTER TABLE orders ADD COLUMN executed_at TIMESTAMP;
+-- validCheckSum: ANY
+-- Idempotentno (IF NOT EXISTS) da delimicno-primenjen changeset (npr. kolona
+-- created_at vec dodata u ranijem padu) ne srusi startup na postojecoj bazi.
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS created_at TIMESTAMP;
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS executed_at TIMESTAMP;
 UPDATE orders SET created_at = last_modification WHERE created_at IS NULL;
 UPDATE orders SET executed_at = last_modification WHERE executed_at IS NULL AND status = 'DONE';
 ALTER TABLE orders ALTER COLUMN created_at SET NOT NULL;

--- a/order-service/src/main/resources/db/changelog/order/013-recurring-orders.sql
+++ b/order-service/src/main/resources/db/changelog/order/013-recurring-orders.sql
@@ -1,7 +1,11 @@
 -- liquibase formatted sql
 
 -- changeset order:13
-CREATE TABLE recurring_orders (
+-- validCheckSum: ANY
+-- validCheckSum ANY: changeset je u proslosti menjan posle primene (checksum
+-- mutacija) -> na postojecoj bazi bi se srusio startup. ANY toleriše promenu
+-- checksum-a bez ponovnog izvrsavanja.
+CREATE TABLE IF NOT EXISTS recurring_orders (
     id                  BIGSERIAL PRIMARY KEY,
     user_id             BIGINT          NOT NULL,
     listing_id          BIGINT          NOT NULL,
@@ -16,5 +20,5 @@ CREATE TABLE recurring_orders (
     created_at          TIMESTAMP       NOT NULL
 );
 
-CREATE INDEX idx_recurring_orders_user_id ON recurring_orders (user_id);
-CREATE INDEX idx_recurring_orders_due ON recurring_orders (active, next_run);
+CREATE INDEX IF NOT EXISTS idx_recurring_orders_user_id ON recurring_orders (user_id);
+CREATE INDEX IF NOT EXISTS idx_recurring_orders_due ON recurring_orders (active, next_run);

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -868,7 +868,7 @@ services:
   # =========================================================================
   frontend:
     build:
-      context: ../../Banka-1-Frontendd
+      context: ../../Banka-1-Frontend-frontendNew
       dockerfile: Dockerfile
     container_name: banka_frontend
     restart: unless-stopped


### PR DESCRIPTION
Skup popravki da app radi end-to-end i da inter-bank komunikacija sa partner bankom (222)
prolazi u oba smera. Sve izmene su na BACKEND strani (gateway + servisi); frontend nije diran.

**1) Trading-service startup crash (Liquibase).** Servis je ulazio u crash-loop na startup-u
nad bazom koja vec ima primenjene migracije ili je ostala delimicno migrirana:
- `order/013-recurring-orders.sql` je mutiran NAKON primene → checksum mismatch
  (`9:aa9eb6…` → `9:86b6062…`) → `ValidationFailedException`. Latentno: pada na BILO KOM
  postojecem deploy-u, ne samo lokalno.
- `order/012-order-timestamps.sql` nije idempotentan → pri delimicnom prethodnom run-u
  `ALTER TABLE orders ADD COLUMN created_at` puca: `column "created_at" … already exists`.
- Fix: `validCheckSum: ANY` na oba changeset-a + `ADD COLUMN / CREATE TABLE / CREATE INDEX IF NOT EXISTS`.
  Testovi netaknuti (`spring.liquibase.enabled=false` u testu, H2/Hibernate gradi semu).

**2) `POST /clients/auth/login` → 500.** Konsolidovani `user-service` ucitava dva
`@RestControllerAdvice` bean-a (client + employee). Employee advice
(`@ExceptionHandler(Exception.class)`) je presretao client-ov `BusinessException` (drugi
paket → employee `handleBusinessException` ga ne matchuje) i vracao 500 cak i za obican
pogresan password. Fix: oba advice-a scope-ovana sa `@RestControllerAdvice(basePackages=…controller)`.
Sada pogresne kredencijale vracaju **401** (`ERR_AUTH_002`), tacne **200** + token.

**3) `GET /accounts/api/sifra-delatnosti` → 404.** Endpoint nije postojao (postojao samo
`SifraDelatnosti` entitet + repo, bez kontrolera). Fix: nov read-only `SifraDelatnostiController`
(+ DTO), `hasAnyRole('CLIENT_BASIC','BASIC')`, vraca `[{sifra, grana}]` (44 sifre).

**4) `GET /audit-logs` → 404 + CORS.** Gateway je rutirao samo `/audit` (trading-service);
FE zove bare `/audit-logs`. nginx 404 nema CORS header-e → browser prijavljuje CORS gresku.
Fix: dodate `location /audit-logs` rute → `trading_service/audit` (CORS dodaje sam
trading-service preko security-lib `CorsConfigurationSource`, isto kao za `/audit`).

**5) `GET /api/cards/all` → 404.** Card kontroleri su mapirani na bare sufikse
(`/all`, `/client/{id}`, `/id/{c}/block`, `/request`…) bez `/api/cards` prefiksa; gateway je
prosledjivao `/api/cards/all` bez strip-a → banking-core 404. Fix: `proxy_pass
http://banking_core_service/;` (trailing slash strip-uje `/api/cards`) → pokriva ceo card surface.

**6) Compose frontend build typo.** `setup/docker-compose.yml` `frontend.build.context` je
pokazivao na nepostojeci `../../Banka-1-Frontendd` (duplo `d`) → ispravljeno na
`../../Banka-1-Frontend-frontendNew`.

**Verifikacija (lokalno, kroz gateway):**
```
trading-service        : healthy (33 changeset-a; zdrav i sa namerno pokvarenim checksum-om → validCheckSum ANY radi)
login (client)         : pogresan pw 401, tacan pw 200
sifra-delatnosti       : 200 (44 sifre)
audit-logs             : 200 + Access-Control-Allow-Origin: <FE origin>; OPTIONS preflight 200
cards/all              : 200 (Page)
inter-bank (oba smera) : Banka 1 cita partner /public-stock (200); partner cita Banka 1 /public-stock (200) — realne ponude
```
