### PR TITLE
fix(interbank): puna wire-kompatibilnost sa Bankom 2 (partner 222) — decimal/2PC/idempotency hardening

### DIFF
--- a/.github/workflows/cd-go.yml
+++ b/.github/workflows/cd-go.yml
@@ -1,0 +1,72 @@
+name: cd-go
+# Build + push GHCR images for every consolidated Go service.
+#
+# WHY THIS EXISTS: ci-go.yml only vets/builds/tests and does a throwaway local
+# `docker build -t ...:ci` for interbank-service — it NEVER pushes to GHCR, and
+# never builds the other 7 Go services. So the images the k8s manifests reference
+# (ghcr.io/raf-si-2025/banka-1-<service>:latest) did not exist. This workflow
+# creates them. imagePullPolicy: Always + :latest + `kubectl rollout restart`
+# then pulls the newest image — the exact model Banka 2 uses.
+#
+# All Go services share the go.work workspace, so the Docker build CONTEXT is the
+# repo root (.) and the Dockerfile is <service-dir>/Dockerfile.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'go.work'
+      - 'proto/**'
+      - '**/Dockerfile'
+      - '.github/workflows/cd-go.yml'
+  workflow_dispatch: {}   # manual "Run workflow" button
+
+permissions:
+  contents: read
+  packages: write          # required to push to GHCR
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { image: banka-1-user-service,                dockerfile: user-service-go/Dockerfile }
+          - { image: banka-1-banking-core-service,        dockerfile: banking-core-service-go/Dockerfile }
+          - { image: banka-1-market-service,              dockerfile: market-service-go/Dockerfile }
+          - { image: banka-1-trading-service,             dockerfile: trading-service-go/Dockerfile }
+          - { image: banka-1-credit-service,              dockerfile: credit-service-go/Dockerfile }
+          - { image: banka-1-notification-service,        dockerfile: notification-service-go/Dockerfile }
+          - { image: banka-1-saga-orchestrator-service,   dockerfile: saga-orchestrator-service/Dockerfile }
+          - { image: banka-1-interbank-service,           dockerfile: interbank-service/Dockerfile }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lowercase GHCR owner
+        id: owner
+        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .                              # go.work workspace root
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ghcr.io/${{ steps.owner.outputs.owner }}/${{ matrix.image }}:latest
+            ghcr.io/${{ steps.owner.outputs.owner }}/${{ matrix.image }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/interbank-service/internal/api/inbound.go
+++ b/interbank-service/internal/api/inbound.go
@@ -75,6 +75,15 @@ func (h *InboundHandler) PostMessage(w http.ResponseWriter, r *http.Request) {
 		return // do NOT cache routing-mismatch failures
 	}
 
+	// Spec §2.2: locallyGeneratedKey is at most 64 bytes. Reject over-length keys
+	// with 400 and WITHOUT caching — an over-length key must never become a cached
+	// 200/204. Mirrors Banka 2 InterbankInboundController MAX_KEY_LENGTH=64.
+	if len(msg.IdempotenceKey.LocallyGeneratedKey) > 64 {
+		writeError(w, http.StatusBadRequest,
+			"idempotenceKey.locallyGeneratedKey exceeds maximum length of 64 bytes")
+		return // do NOT cache malformed-key failures
+	}
+
 	// Idempotency cache lookup.
 	cached, err := h.messages.Lookup(r.Context(), store.DirectionInbound, senderRouting, msg.IdempotenceKey.LocallyGeneratedKey)
 	if err != nil {
@@ -83,6 +92,22 @@ func (h *InboundHandler) PostMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if cached != nil {
+		// Type-aware idempotency (Banka 2 §2.2): the (senderRouting, key) pair is
+		// unique PER MESSAGE. If the same key was already used for a DIFFERENT
+		// messageType (e.g. a COMMIT_TX arriving under a key that cached a NEW_TX
+		// vote), replaying the cached vote would skip the commit and strand money.
+		// Reject the mismatch as a protocol violation (400) instead of replaying.
+		if cached.MessageType != "" && cached.MessageType != string(msg.MessageType) {
+			h.log.WarnContext(r.Context(), "inbound: idempotency key reused for a different messageType",
+				"senderRouting", senderRouting,
+				"key", msg.IdempotenceKey.LocallyGeneratedKey,
+				"cachedType", cached.MessageType,
+				"newType", string(msg.MessageType))
+			writeError(w, http.StatusBadRequest,
+				"idempotenceKey already used for a "+cached.MessageType+
+					" message; cannot reuse it for "+string(msg.MessageType))
+			return
+		}
 		h.log.InfoContext(r.Context(), "inbound: idempotency cache hit",
 			"senderRouting", senderRouting,
 			"key", msg.IdempotenceKey.LocallyGeneratedKey,

--- a/interbank-service/internal/api/inbound_test.go
+++ b/interbank-service/internal/api/inbound_test.go
@@ -291,3 +291,50 @@ func TestInbound_RollbackTx_Happy(t *testing.T) {
 		t.Fatalf("expected 204, got %d body: %s", rr.Code, rr.Body.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tests: protocol-compatibility guards (Banka 2 interop)
+// ---------------------------------------------------------------------------
+
+// A locallyGeneratedKey longer than 64 bytes must be rejected with 400 and NOT
+// cached (Banka 2 §2.2). Regression guard for the missing length check.
+func TestInbound_KeyTooLong_400(t *testing.T) {
+	exec := &fakeInboundExecutor{prepareVote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	msgs := newFakeInboundMessageStore()
+	r := buildTestRouter(exec, msgs)
+
+	longKey := ""
+	for i := 0; i < 65; i++ {
+		longKey += "x"
+	}
+	rr := doPost(r, "/interbank", newTxBody(longKey, testTheirRouting), testApiKey)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for >64-byte key, got %d body: %s", rr.Code, rr.Body.String())
+	}
+	// Must NOT have been cached.
+	if cached, _ := msgs.Lookup(context.Background(), store.DirectionInbound, testTheirRouting, longKey); cached != nil {
+		t.Errorf("over-length key must not be cached")
+	}
+}
+
+// Reusing one idempotency key across two DIFFERENT messageTypes (e.g. NEW_TX
+// then COMMIT_TX under the same key) must return 400, not replay the cached
+// vote — otherwise a COMMIT_TX would replay a NEW_TX vote and strand money
+// (Banka 2 §2.2 type-aware idempotency).
+func TestInbound_KeyReusedDifferentType_400(t *testing.T) {
+	exec := &fakeInboundExecutor{prepareVote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	msgs := newFakeInboundMessageStore()
+	r := buildTestRouter(exec, msgs)
+
+	const key = "shared-key-1"
+	// 1) NEW_TX caches a vote under `key`.
+	rr1 := doPost(r, "/interbank", newTxBody(key, testTheirRouting), testApiKey)
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("NEW_TX expected 200, got %d", rr1.Code)
+	}
+	// 2) COMMIT_TX reusing the SAME key — must be 400 (type mismatch), not 204.
+	rr2 := doPost(r, "/interbank", commitBody(key, testTheirRouting, "tx-abc"), testApiKey)
+	if rr2.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on key reuse across messageType, got %d body: %s", rr2.Code, rr2.Body.String())
+	}
+}

--- a/interbank-service/internal/api/otc.go
+++ b/interbank-service/internal/api/otc.go
@@ -140,8 +140,12 @@ func (h *OtcHandler) handleOtcError(w http.ResponseWriter, ctx context.Context, 
 	case errors.Is(err, service.ErrSenderNotParty):
 		writeError(w, http.StatusForbidden, err.Error())
 	case errors.Is(err, service.ErrInterbankProtocol):
+		// 2PC/communication failure to a downstream bank during /accept. Banka 2
+		// §6.3 expects 502 Bad Gateway here (downstream interbank communication
+		// error), not 500. Our client aborts on any non-2xx either way; 502 just
+		// aligns the wire status with the spec.
 		h.log.WarnContext(ctx, "otc: 2PC protocol failure", "err", err)
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeError(w, http.StatusBadGateway, err.Error())
 	default:
 		h.log.ErrorContext(ctx, "otc: unexpected error", "err", err)
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/interbank-service/internal/api/otc_outbound_test.go
+++ b/interbank-service/internal/api/otc_outbound_test.go
@@ -125,7 +125,7 @@ func (f *fakeOutboundClientAPI) OutboundDelete(_ context.Context, _ int, _ proto
 }
 func (f *fakeOutboundClientAPI) OutboundFetchPublicStock(_ context.Context, _ int) ([]protocol.PublicStockEntry, error) {
 	return []protocol.PublicStockEntry{
-		{Stock: protocol.StockDescription{Ticker: "AAPL"}, Sellers: []protocol.PublicStockSellerRef{{SellerID: protocol.ForeignBankId{RoutingNumber: 222, Id: "C-2"}, Quantity: 50}}},
+		{Stock: protocol.StockDescription{Ticker: "AAPL"}, Sellers: []protocol.PublicStockSellerRef{{SellerID: protocol.ForeignBankId{RoutingNumber: 222, Id: "C-2"}, Quantity: decimal.NewFromInt(50)}}},
 	}, nil
 }
 

--- a/interbank-service/internal/api/otc_test.go
+++ b/interbank-service/internal/api/otc_test.go
@@ -285,7 +285,10 @@ func TestOtc_Accept_ProtocolFailure_5xx(t *testing.T) {
 	svc := &fakeOtcService{acceptErr: service.ErrInterbankProtocol}
 	r := buildOtcRouter(svc)
 	rr := doMethod(r, http.MethodGet, "/negotiations/111/neg-abc/accept", nil, testApiKey)
-	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500 on 2PC failure, got %d", rr.Code)
+	// A 2PC/communication failure to a downstream bank maps to 502 Bad Gateway
+	// (Banka 2 §6.3). Previously this returned 500; the client aborts on any
+	// non-2xx so the change is wire-compatible, it just aligns the status.
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 on 2PC failure, got %d", rr.Code)
 	}
 }

--- a/interbank-service/internal/grpc/mapper.go
+++ b/interbank-service/internal/grpc/mapper.go
@@ -175,7 +175,7 @@ func mapProtoOtcOfferFromCreate(req *interbankv1.CreateNegotiationRequest) (serv
 		Premium:        premium,
 		BuyerID:        mapProtoForeignBankId(req.GetBuyerId()),
 		SellerID:       mapProtoForeignBankId(req.GetSellerId()),
-		Amount:         int(req.GetAmount()),
+		Amount:         service.IntAmount(req.GetAmount()),
 		LastModifiedBy: mapProtoForeignBankId(req.GetLastModifiedBy()),
 	}, nil
 }
@@ -204,7 +204,7 @@ func mapProtoOtcOfferFromPut(req *interbankv1.PutCounterRequest) (service.OtcOff
 		Premium:        premium,
 		BuyerID:        mapProtoForeignBankId(req.GetBuyerId()),
 		SellerID:       mapProtoForeignBankId(req.GetSellerId()),
-		Amount:         int(req.GetAmount()),
+		Amount:         service.IntAmount(req.GetAmount()),
 		LastModifiedBy: mapProtoForeignBankId(req.GetLastModifiedBy()),
 	}, nil
 }

--- a/interbank-service/internal/grpc/server_test.go
+++ b/interbank-service/internal/grpc/server_test.go
@@ -708,7 +708,7 @@ func mapProtoOtcOfferFromCreateForTest(req *interbankv1.CreateNegotiationRequest
 		Premium:        premium,
 		BuyerID:        mapProtoForeignBankIdForTest(req.GetBuyerId()),
 		SellerID:       mapProtoForeignBankIdForTest(req.GetSellerId()),
-		Amount:         int(req.GetAmount()),
+		Amount:         service.IntAmount(req.GetAmount()),
 		LastModifiedBy: mapProtoForeignBankIdForTest(req.GetLastModifiedBy()),
 	}, nil
 }
@@ -720,7 +720,7 @@ func mapProtoOtcOfferFromPutForTest(req *interbankv1.PutCounterRequest) (service
 	}
 	return service.OtcOfferDto{
 		SettlementDate: settleDate,
-		Amount:         int(req.GetAmount()),
+		Amount:         service.IntAmount(req.GetAmount()),
 		LastModifiedBy: mapProtoForeignBankIdForTest(req.GetLastModifiedBy()),
 	}, nil
 }

--- a/interbank-service/internal/mock/banka2.go
+++ b/interbank-service/internal/mock/banka2.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
 
 	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
 )
@@ -137,7 +138,7 @@ func mockPublicStock(w http.ResponseWriter, r *http.Request) {
 			Sellers: []protocol.PublicStockSellerRef{
 				{
 					SellerID: protocol.ForeignBankId{RoutingNumber: banka2Routing, Id: "C-99"},
-					Quantity: 25,
+					Quantity: decimal.NewFromInt(25),
 				},
 			},
 		},
@@ -146,7 +147,7 @@ func mockPublicStock(w http.ResponseWriter, r *http.Request) {
 			Sellers: []protocol.PublicStockSellerRef{
 				{
 					SellerID: protocol.ForeignBankId{RoutingNumber: banka2Routing, Id: "C-100"},
-					Quantity: 50,
+					Quantity: decimal.NewFromInt(50),
 				},
 			},
 		},

--- a/interbank-service/internal/protocol/public_stock.go
+++ b/interbank-service/internal/protocol/public_stock.go
@@ -1,15 +1,29 @@
 package protocol
 
+import "github.com/shopspring/decimal"
+
 // PublicStockEntry represents one row from GET /public-stock (§3.1).
 // Mirrors Java PublicStockEntryDto.
 type PublicStockEntry struct {
-	Stock   StockDescription        `json:"stock"`
-	Sellers []PublicStockSellerRef  `json:"sellers"`
+	Stock   StockDescription       `json:"stock"`
+	Sellers []PublicStockSellerRef `json:"sellers"`
 }
 
 // PublicStockSellerRef identifies one seller of a public stock.
-// Mirrors Java PublicStockSellerDto.
+//
+// Wire keys are "seller" + "amount" — matching Banka 2's PublicStock.Seller
+// record (ForeignBankId seller, BigDecimal amount) AND Banka 1's own live
+// /public-stock handler (api.SellerRow Seller/Amount). The previous tags
+// "sellerId"/"quantity" disagreed with both, so decoding a partner's real
+// /public-stock response (OutboundFetchPublicStock) silently produced
+// zero-value sellers.
+//
+// Quantity is decimal.Decimal (was int): Banka 2 serializes the available
+// amount as a BigDecimal and its live response contains scaled values like
+// 1.0000, which a Go int CANNOT decode ("cannot unmarshal number 1.0000 into
+// Go value of type int") — that would fail the whole /public-stock decode and
+// drop every seller. decimal.Decimal accepts 1.0000, 3, "5" etc. gracefully.
 type PublicStockSellerRef struct {
-	SellerID ForeignBankId `json:"sellerId"`
-	Quantity int           `json:"quantity"`
+	SellerID ForeignBankId   `json:"seller"`
+	Quantity decimal.Decimal `json:"amount"`
 }

--- a/interbank-service/internal/protocol/public_stock_wire_test.go
+++ b/interbank-service/internal/protocol/public_stock_wire_test.go
@@ -1,0 +1,43 @@
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// The /public-stock seller entry must serialize with wire keys "seller" and
+// "amount" — matching Banka 2's PublicStock.Seller(seller, amount) record AND
+// Banka 1's own live api.SellerRow handler. The legacy keys "sellerId" /
+// "quantity" silently produced zero-value sellers when decoding a partner's
+// real /public-stock response (OutboundFetchPublicStock). This guards the fix.
+func TestPublicStockSellerRef_WireKeys(t *testing.T) {
+	ref := PublicStockSellerRef{
+		SellerID: ForeignBankId{RoutingNumber: 222, Id: "C-2"},
+		Quantity: decimal.NewFromInt(50),
+	}
+	b, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"seller"`) || !strings.Contains(s, `"amount"`) {
+		t.Errorf("expected wire keys seller+amount, got %s", s)
+	}
+	if strings.Contains(s, `"sellerId"`) || strings.Contains(s, `"quantity"`) {
+		t.Errorf("must not emit legacy keys sellerId/quantity, got %s", s)
+	}
+
+	// CRITICAL: decode a SCALED Banka-2-shaped amount (1.0000). Banka 2's live
+	// /public-stock emits scaled decimals; a Go int could not decode 1.0000 and
+	// would fail the whole response. decimal.Decimal must accept it.
+	var back PublicStockSellerRef
+	if err := json.Unmarshal([]byte(`{"seller":{"routingNumber":222,"id":"C-2"},"amount":1.0000}`), &back); err != nil {
+		t.Fatalf("unmarshal scaled amount 1.0000: %v", err)
+	}
+	if back.SellerID.RoutingNumber != 222 || back.SellerID.Id != "C-2" || !back.Quantity.Equal(decimal.NewFromInt(1)) {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}

--- a/interbank-service/internal/service/intamount_test.go
+++ b/interbank-service/internal/service/intamount_test.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// IntAmount must tolerate the scaled / quoted forms Banka 2 may emit for an OTC
+// amount (BigDecimal serialized as 10.00, 10, "10", 10.0000) — all decode to 10
+// — while rejecting a genuinely fractional value, and always marshalling back as
+// a bare integer so Banka 1's own outbound offers stay int-shaped.
+func TestIntAmount_DecodeScaledRejectFractional(t *testing.T) {
+	for _, in := range []string{`10`, `10.00`, `"10"`, `10.0000`} {
+		var a IntAmount
+		if err := json.Unmarshal([]byte(in), &a); err != nil {
+			t.Errorf("unmarshal %s: %v", in, err)
+			continue
+		}
+		if a != 10 {
+			t.Errorf("unmarshal %s = %d, want 10", in, int(a))
+		}
+	}
+
+	var a IntAmount
+	if err := json.Unmarshal([]byte(`10.5`), &a); err == nil {
+		t.Errorf("expected error decoding fractional 10.5, got %d", int(a))
+	}
+
+	b, err := json.Marshal(IntAmount(7))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != "7" {
+		t.Errorf("marshal IntAmount(7) = %s, want bare 7", b)
+	}
+}

--- a/interbank-service/internal/service/joinurl_test.go
+++ b/interbank-service/internal/service/joinurl_test.go
@@ -1,0 +1,23 @@
+package service
+
+import "testing"
+
+// joinURL must produce exactly one slash between a partner BaseURL and the
+// protocol path segment regardless of trailing/leading slashes, so the same
+// code works for "https://banka-2.radenkovic.rs/api" and ".../api/".
+// Regression guard for the BaseURL+segment concatenation footgun that produced
+// ".../apiinterbank" (404) when BaseURL had no trailing slash.
+func TestJoinURL(t *testing.T) {
+	cases := []struct{ base, path, want string }{
+		{"https://banka-2.radenkovic.rs/api", "interbank", "https://banka-2.radenkovic.rs/api/interbank"},
+		{"https://banka-2.radenkovic.rs/api/", "interbank", "https://banka-2.radenkovic.rs/api/interbank"},
+		{"https://banka-2.radenkovic.rs/api", "/interbank", "https://banka-2.radenkovic.rs/api/interbank"},
+		{"https://banka-2.radenkovic.rs/api/", "negotiations/222/neg-1", "https://banka-2.radenkovic.rs/api/negotiations/222/neg-1"},
+		{"http://localhost:9999", "public-stock", "http://localhost:9999/public-stock"},
+	}
+	for _, c := range cases {
+		if got := joinURL(c.base, c.path); got != c.want {
+			t.Errorf("joinURL(%q, %q) = %q, want %q", c.base, c.path, got, c.want)
+		}
+	}
+}

--- a/interbank-service/internal/service/otc_negotiation.go
+++ b/interbank-service/internal/service/otc_negotiation.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -13,6 +15,36 @@ import (
 	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
 	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
 )
+
+// IntAmount is a whole-share-count OTC amount that tolerates a JSON value
+// written with trailing-zero scale (e.g. 10.00) or as a quoted string ("10").
+// Banka 2 serializes OTC amounts from BigDecimal and may emit a scaled form; a
+// plain Go int cannot decode 10.00 ("cannot unmarshal number 10.00 into Go
+// value of type int") and would 400 the offer. IntAmount decodes any integral
+// decimal (rejecting a genuinely fractional value) and always marshals back as
+// a bare integer (10), so Banka 1's own outbound offers stay int-shaped.
+type IntAmount int
+
+func (a *IntAmount) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if s == "" || s == "null" {
+		*a = 0
+		return nil
+	}
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return fmt.Errorf("amount %q is not a number: %w", s, err)
+	}
+	if !d.Equal(d.Truncate(0)) {
+		return fmt.Errorf("amount %s must be a whole number of shares", s)
+	}
+	*a = IntAmount(d.IntPart())
+	return nil
+}
+
+func (a IntAmount) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Itoa(int(a))), nil
+}
 
 // ---------------------------------------------------------------------------
 // Store interface consumed by OtcNegotiationService
@@ -40,7 +72,7 @@ type OtcOfferDto struct {
 	Premium        protocol.MonetaryValue    `json:"premium"`
 	BuyerID        protocol.ForeignBankId    `json:"buyerId"`
 	SellerID       protocol.ForeignBankId    `json:"sellerId"`
-	Amount         int                       `json:"amount"`
+	Amount         IntAmount                 `json:"amount"`
 	LastModifiedBy protocol.ForeignBankId    `json:"lastModifiedBy"`
 }
 
@@ -53,7 +85,7 @@ type OtcNegotiationDto struct {
 	Premium        protocol.MonetaryValue    `json:"premium"`
 	BuyerID        protocol.ForeignBankId    `json:"buyerId"`
 	SellerID       protocol.ForeignBankId    `json:"sellerId"`
-	Amount         int                       `json:"amount"`
+	Amount         IntAmount                 `json:"amount"`
 	LastModifiedBy protocol.ForeignBankId    `json:"lastModifiedBy"`
 	IsOngoing      bool                      `json:"isOngoing"`
 }
@@ -135,7 +167,7 @@ func (s *OtcNegotiationService) CreateNegotiation(ctx context.Context, offer Otc
 		SellerRouting:         offer.SellerID.RoutingNumber,
 		SellerID:              offer.SellerID.Id,
 		StockTicker:           offer.Stock.Ticker,
-		Amount:                offer.Amount,
+		Amount:                int(offer.Amount),
 		PriceCurrency:         offer.PricePerUnit.Currency,
 		PriceAmount:           offer.PricePerUnit.Amount,
 		PremiumCurrency:       offer.Premium.Currency,
@@ -209,7 +241,7 @@ func (s *OtcNegotiationService) UpdateCounter(ctx context.Context, rn int, id st
 		return fmt.Errorf("%w: premium.amount must be non-negative", ErrNegotiationInvalid)
 	}
 
-	neg.Amount = offer.Amount
+	neg.Amount = int(offer.Amount)
 	neg.PriceAmount = offer.PricePerUnit.Amount
 	neg.PriceCurrency = offer.PricePerUnit.Currency
 	neg.PremiumAmount = offer.Premium.Amount
@@ -297,7 +329,7 @@ func toDto(n *store.Negotiation) OtcNegotiationDto {
 		},
 		BuyerID:  protocol.ForeignBankId{RoutingNumber: n.BuyerRouting, Id: n.BuyerID},
 		SellerID: protocol.ForeignBankId{RoutingNumber: n.SellerRouting, Id: n.SellerID},
-		Amount:   n.Amount,
+		Amount:   IntAmount(n.Amount),
 		LastModifiedBy: protocol.ForeignBankId{
 			RoutingNumber: n.LastModifiedByRouting,
 			Id:            n.LastModifiedByID,

--- a/interbank-service/internal/service/otc_outbound.go
+++ b/interbank-service/internal/service/otc_outbound.go
@@ -203,7 +203,7 @@ func (s *OtcOutboundService) CreateOutbound(
 		Premium:        protocol.MonetaryValue{Currency: req.PremiumCurrency, Amount: req.Premium},
 		BuyerID:        buyer,
 		SellerID:       seller,
-		Amount:         req.Amount,
+		Amount:         IntAmount(req.Amount),
 		LastModifiedBy: buyer, // we initiated, so we are last modifier
 	}
 
@@ -353,7 +353,7 @@ func (s *OtcOutboundService) CounterOutbound(
 		Premium:        protocol.MonetaryValue{Currency: req.PremiumCurrency, Amount: req.Premium},
 		BuyerID:        buyer,
 		SellerID:       seller,
-		Amount:         req.Amount,
+		Amount:         IntAmount(req.Amount),
 		LastModifiedBy: modifier,
 	}
 

--- a/interbank-service/internal/service/otc_outbound_test.go
+++ b/interbank-service/internal/service/otc_outbound_test.go
@@ -509,7 +509,7 @@ func TestFetchPartnerPublicStock_Passthrough(t *testing.T) {
 		{
 			Stock: protocol.StockDescription{Ticker: "TSLA"},
 			Sellers: []protocol.PublicStockSellerRef{
-				{SellerID: protocol.ForeignBankId{RoutingNumber: 222, Id: "C-2"}, Quantity: 50},
+				{SellerID: protocol.ForeignBankId{RoutingNumber: 222, Id: "C-2"}, Quantity: decimal.NewFromInt(50)},
 			},
 		},
 	}

--- a/interbank-service/internal/service/outbound.go
+++ b/interbank-service/internal/service/outbound.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
@@ -258,7 +259,7 @@ func (c *InterbankClient) OutboundCreateNegotiation(ctx context.Context, partner
 		return nil, fmt.Errorf("outbound: marshal offer: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, partner.BaseURL+"negotiations", partner.OutboundToken, bodyBytes)
+	resp, err := c.doRequest(ctx, http.MethodPost, joinURL(partner.BaseURL, "negotiations"), partner.OutboundToken, bodyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +286,7 @@ func (c *InterbankClient) OutboundPutCounter(ctx context.Context, partnerRouting
 		return 0, fmt.Errorf("outbound: marshal offer: %w", err)
 	}
 
-	u := fmt.Sprintf("%snegotiations/%d/%s", partner.BaseURL, negID.RoutingNumber, negID.Id)
+	u := joinURL(partner.BaseURL, fmt.Sprintf("negotiations/%d/%s", negID.RoutingNumber, negID.Id))
 	status, _, doErr := c.doRequestFull(ctx, http.MethodPut, u, partner.OutboundToken, bodyBytes)
 	if doErr != nil {
 		// Unwrap typed errors to let caller decide.
@@ -302,7 +303,7 @@ func (c *InterbankClient) OutboundAccept(ctx context.Context, partnerRouting int
 		return 0, err
 	}
 
-	u := fmt.Sprintf("%snegotiations/%d/%s/accept", partner.BaseURL, negID.RoutingNumber, negID.Id)
+	u := joinURL(partner.BaseURL, fmt.Sprintf("negotiations/%d/%s/accept", negID.RoutingNumber, negID.Id))
 	status, _, doErr := c.doRequestFull(ctx, http.MethodGet, u, partner.OutboundToken, nil)
 	if doErr != nil {
 		return status, doErr
@@ -318,7 +319,7 @@ func (c *InterbankClient) OutboundDelete(ctx context.Context, partnerRouting int
 		return err
 	}
 
-	u := fmt.Sprintf("%snegotiations/%d/%s", partner.BaseURL, negID.RoutingNumber, negID.Id)
+	u := joinURL(partner.BaseURL, fmt.Sprintf("negotiations/%d/%s", negID.RoutingNumber, negID.Id))
 	status, _, doErr := c.doRequestFull(ctx, http.MethodDelete, u, partner.OutboundToken, nil)
 	if doErr != nil {
 		// 404 → idempotent no-op per Tim 2 MINOR-3.
@@ -342,7 +343,7 @@ func (c *InterbankClient) OutboundFetchPublicStock(ctx context.Context, partnerR
 		return nil, err
 	}
 
-	u := partner.BaseURL + "public-stock"
+	u := joinURL(partner.BaseURL, "public-stock")
 	status, body, doErr := c.doRequestFull(ctx, http.MethodGet, u, partner.OutboundToken, nil)
 	if doErr != nil {
 		if errors.Is(doErr, ErrOutboundAuth) {
@@ -463,7 +464,7 @@ func (c *InterbankClient) postInterbank(ctx context.Context, partner *auth.Partn
 	if err != nil {
 		return nil, 0, fmt.Errorf("outbound: marshal envelope: %w", err)
 	}
-	u := partner.BaseURL + "interbank"
+	u := joinURL(partner.BaseURL, "interbank")
 	status, body, doErr := c.doRequestFull(ctx, http.MethodPost, u, partner.OutboundToken, bodyBytes)
 	return body, status, doErr
 }
@@ -516,6 +517,19 @@ func (c *InterbankClient) doRequestFull(ctx context.Context, method, rawURL, api
 		return resp.StatusCode, respBody, fmt.Errorf("%w: status=%d body=%s", ErrOutboundUpstream, resp.StatusCode, respBody)
 	}
 	return resp.StatusCode, respBody, nil
+}
+
+// joinURL concatenates a partner base URL with a protocol path segment,
+// guaranteeing EXACTLY ONE slash between them regardless of whether BaseURL has
+// a trailing slash. This makes outbound calls correct for both
+// "https://banka-2.radenkovic.rs/api" and ".../api/" partner BaseURL forms.
+//
+// Banka 2's Envoy gateway requires the /api prefix in BaseURL (it strips /api
+// then hits backend /interbank, /negotiations, ...). The previous code did a
+// bare BaseURL+segment concatenation, so a BaseURL WITHOUT a trailing slash
+// produced ".../apiinterbank" (404). Normalizing here removes that footgun.
+func joinURL(base, path string) string {
+	return strings.TrimRight(base, "/") + "/" + strings.TrimLeft(path, "/")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION

Audit + **živi cross-bank test** `interbank-service`-a (Go) protiv partnera **Banka 2 (routing 222)**.
Implementacija je **~95% već kompatibilna** — envelope `Message{idempotenceKey, messageType, message}`,
oba discriminated union-a (`Asset` MONAS/STOCK/OPTION `{"type","asset"}`, `TxAccount`
PERSON/ACCOUNT/OPTION), svi enumi, `X-Api-Key` auth, idempotencija po `(senderRouting, key)`, user
endpoint na obe putanje (`/user/{rn}/{id}` i `/interbank/user/{rn}/{id}`). Ova izmena zatvara
preostale rupe za **100% interop**.

### Izmene

**1) Inbound `>64`-byte key check (BLOCKER) — `internal/api/inbound.go`.**
`locallyGeneratedKey` > 64 bajta → **400**, NE kesira se (spec §2.2). Ranije nije bilo provere.

**2) Type-aware idempotency cache (MONEY-SAFETY) — `internal/api/inbound.go`.**
Reuse ključa za **drugi** `messageType` → **400** (inače bi `COMMIT_TX` replay-ovao kеširan `NEW_TX`
vote i **zaglavio novac**).

**3) `/public-stock` seller wire-keys + DECIMAL (BLOCKER) — `internal/protocol/public_stock.go`.**
Dva problema, oba potvrđena živim testom protiv Banke 2:
- json tagovi `"sellerId"`/`"quantity"` → `"seller"`/`"amount"` (consumer je dekodirao realni Banka 2
  `/public-stock` i dobijao **zero-value** sellere).
- `Quantity: int` → **`decimal.Decimal`**. Živi `GET /public-stock` Banke 2 vraća **skaliran** iznos
  (npr. `"amount":1.0000`) koji Go `int` **ne može** da dekodira → obara ceo decode i gubi sve sellere.
  `decimal.Decimal` prima `1.0000`, `3`, `"5"`.

**4) OTC amount tolerantno dekodiranje (BLOCKER) — `internal/service/otc_negotiation.go` (+ `otc_outbound.go`, `grpc/mapper.go`).**
Novi tip **`IntAmount`** za `OtcOfferDto.Amount` / `OtcNegotiationDto.Amount`: dekodira skaliran/quoted
celobrojan iznos (`10.00`, `"10"`, `10.0000` → `10`), odbija pravi razlomak, a **serijalizuje nazad kao
bare `10`** (pa Banka 1 outbound ostaje int-oblika). Banka 2 serijalizuje OTC `amount` iz BigDecimal-a;
raniji `int` je **400**-ovao `POST/PUT /negotiations` na `"10.00"`. `store.Negotiation.Amount` ostaje
`int` (share count) — bez DB promene.

**5) Outbound BaseURL normalizacija (BLOCKER) — `internal/service/outbound.go`.**
`joinURL(base, path)` garantuje **tačno jedan** `/`. Banka 2 zahteva `/api` u BaseURL (gateway skida
`/api`); ranija bare konkatenacija je davala `.../apiinterbank` (404) bez trailing slash-a.

**6) `/accept` 2PC failure → 502 — `internal/api/otc.go`.** (bilo 500; Banka 2 §6.3).

### Testovi
Dodati: `TestInbound_KeyTooLong_400`, `TestInbound_KeyReusedDifferentType_400`, `TestJoinURL`,
`TestPublicStockSellerRef_WireKeys` (sa **skaliranim `1.0000`**), `TestIntAmount_DecodeScaledRejectFractional`.
Ažuriran `TestOtc_Accept_ProtocolFailure_5xx` → 502. **`go build ./...` + `go test ./...` zeleni.**

### Živa verifikacija (oba smera)
**Banka 1 wire → živa Banka 2** (`https://banka-2.radenkovic.rs/api`, token usklađen):
`GET /public-stock` → 200 (otkriven skalirani `1.0000`); `POST /interbank` NEW_TX → 200 `{vote:NO,…}`;
`GET /user/222/C-1` → 200; bez ključa → 401.

**Banka 2 wire → lokalni Banka 1** (Docker, nov kod):
`>64` key → **400**; bez ključa → **401**; `POST /negotiations` sa `amount:"10.00"` → **200** (IntAmount
fix radi — pre fixa 400); `/public-stock` ispravan oblik. (NEW_TX 500 i prazan public-stock = lokalni
seed bez podataka, ne protokol.)

### Napomena za go-live
NEW_TX na nepostojeći račun lokalno vraća 500 (`/internal/interbank/account-resolve` 404 u praznoj
bazi). Proveriti sa **seed podacima** da executor vraća **NO-vote `NO_SUCH_ACCOUNT` (200)**, ne 500, za
genuino-nepostojeći račun (kao Banka 2). Verovatno radi sa seed-om; nije menjano jer nije reproducibilno
bez podataka.

### CI
Uključen i `.github/workflows/cd-go.yml` — GHCR build+push svih 8 Go servisa
(`ghcr.io/raf-si-2025/banka-1-<servis>:latest`), tako da k8s manifesti imaju image-e da povuku.
