### PR TITLE
fix(interbank): map nested public-stock wire shape (partner saw empty ticker/amount)

### DIFF
--- a/interbank-service/cmd/interbank-service/main.go
+++ b/interbank-service/cmd/interbank-service/main.go
@@ -509,12 +509,12 @@ func (a *pubStockAdapter) GetPublicStocks(ctx context.Context) ([]api.PublicStoc
 		sellers := make([]api.SellerRow, len(e.Sellers))
 		for i, s := range e.Sellers {
 			sellers[i] = api.SellerRow{
-				Seller: api.SellerID{RoutingNumber: s.RoutingNumber, ID: s.ID},
-				Amount: e.Quantity,
+				Seller: api.SellerID{RoutingNumber: s.Seller.RoutingNumber, ID: s.Seller.ID},
+				Amount: s.Amount,
 			}
 		}
 		out = append(out, api.PublicStockEntry{
-			Stock:   api.StockRef{Ticker: e.Ticker},
+			Stock:   api.StockRef{Ticker: e.Stock.Ticker},
 			Sellers: sellers,
 		})
 	}

--- a/interbank-service/internal/client/client_test.go
+++ b/interbank-service/internal/client/client_test.go
@@ -223,7 +223,8 @@ func TestTradingClient_GetPublicStocks_OK(t *testing.T) {
 		}
 		hasBearer(t, r)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[{"ticker":"AAPL","sellers":[{"routingNumber":111,"id":"C-1"}],"quantity":100}]`))
+		// Nested protocol shape that trading-service actually emits.
+		_, _ = w.Write([]byte(`[{"stock":{"ticker":"AAPL"},"sellers":[{"seller":{"routingNumber":111,"id":"C-1"},"amount":100}]}]`))
 	}))
 	defer srv.Close()
 
@@ -235,14 +236,17 @@ func TestTradingClient_GetPublicStocks_OK(t *testing.T) {
 	if len(stocks) != 1 {
 		t.Fatalf("expected 1 stock, got %d", len(stocks))
 	}
-	if stocks[0].Ticker != "AAPL" {
-		t.Errorf("ticker want AAPL, got %s", stocks[0].Ticker)
+	if stocks[0].Stock.Ticker != "AAPL" {
+		t.Errorf("ticker want AAPL, got %s", stocks[0].Stock.Ticker)
 	}
-	if stocks[0].Quantity != 100 {
-		t.Errorf("quantity want 100, got %d", stocks[0].Quantity)
+	if len(stocks[0].Sellers) != 1 {
+		t.Fatalf("expected 1 seller, got %d", len(stocks[0].Sellers))
 	}
-	if len(stocks[0].Sellers) != 1 || stocks[0].Sellers[0].ID != "C-1" {
-		t.Errorf("sellers unexpected: %+v", stocks[0].Sellers)
+	if stocks[0].Sellers[0].Amount != 100 {
+		t.Errorf("amount want 100, got %d", stocks[0].Sellers[0].Amount)
+	}
+	if stocks[0].Sellers[0].Seller.ID != "C-1" || stocks[0].Sellers[0].Seller.RoutingNumber != 111 {
+		t.Errorf("seller unexpected: %+v", stocks[0].Sellers[0].Seller)
 	}
 }
 

--- a/interbank-service/internal/client/trading.go
+++ b/interbank-service/internal/client/trading.go
@@ -12,14 +12,29 @@ import (
 )
 
 // PublicStockEntry represents one row from GET /internal/interbank/public-stocks.
+// trading-service (Go) emits the NESTED protocol shape:
+//   {"stock":{"ticker":"AAPL"},"sellers":[{"seller":{"routingNumber":N,"id":"C-1"},"amount":N}]}
+// The previous FLAT tags (top-level `ticker`/`quantity`, flat seller) did not match this
+// shape, so the decode silently produced zero values — the partner bank saw empty ticker
+// and amount 0. Tags now mirror the wire shape so values actually decode.
 type PublicStockEntry struct {
-	Ticker   string      `json:"ticker"`
-	Sellers  []SellerRef `json:"sellers"`
-	Quantity int         `json:"quantity"`
+	Stock   StockDesc   `json:"stock"`
+	Sellers []SellerRef `json:"sellers"`
 }
 
-// SellerRef identifies one seller of a public stock.
+// StockDesc carries the ticker (trading-service StockDescription).
+type StockDesc struct {
+	Ticker string `json:"ticker"`
+}
+
+// SellerRef is one seller row: nested ForeignBankId + per-seller amount.
 type SellerRef struct {
+	Seller ForeignID `json:"seller"`
+	Amount int       `json:"amount"`
+}
+
+// ForeignID is the {routingNumber, id} foreign-bank tag of a seller.
+type ForeignID struct {
 	RoutingNumber int    `json:"routingNumber"`
 	ID            string `json:"id"`
 }

--- a/interbank-service/internal/grpc/handlers.go
+++ b/interbank-service/internal/grpc/handlers.go
@@ -252,13 +252,13 @@ func (s *Server) GetPublicStock(ctx context.Context, _ *interbankv1.GetPublicSto
 	resp := &interbankv1.GetPublicStockResponse{}
 	for _, e := range entries {
 		entry := &interbankv1.PublicStockEntry{
-			Ticker:   e.Ticker,
-			Quantity: int32(e.Quantity),
+			Ticker: e.Stock.Ticker,
 		}
 		for _, sel := range e.Sellers {
+			entry.Quantity += int32(sel.Amount)
 			entry.Sellers = append(entry.Sellers, &commonv1.ForeignBankId{
-				RoutingNumber: int32(sel.RoutingNumber),
-				Id:            sel.ID,
+				RoutingNumber: int32(sel.Seller.RoutingNumber),
+				Id:            sel.Seller.ID,
 			})
 		}
 		resp.Entries = append(resp.Entries, entry)

--- a/interbank-service/internal/grpc/handlers_real_test.go
+++ b/interbank-service/internal/grpc/handlers_real_test.go
@@ -619,7 +619,7 @@ func TestReal_GetPublicStock_Success(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]client.PublicStockEntry{
-			{Ticker: "AAPL", Quantity: 50, Sellers: []client.SellerRef{{RoutingNumber: 111, ID: "C-15"}}},
+			{Stock: client.StockDesc{Ticker: "AAPL"}, Sellers: []client.SellerRef{{Seller: client.ForeignID{RoutingNumber: 111, ID: "C-15"}, Amount: 50}}},
 		})
 	}))
 	defer ts.Close()


### PR DESCRIPTION
## Problem
Partner banka (222) ne vidi ticker ni dostupnu kolicinu nasih public-stock akcija — sve dolazi prazno (`ticker:""`, `amount:0`, `seller:{0,""}`).

## Uzrok
`interbank-service` `client.PublicStockEntry`/`SellerRef` koriste **FLAT** json tagove:
```go
Ticker string `json:"ticker"`; Sellers []SellerRef `json:"sellers"`; Quantity int `json:"quantity"`
SellerRef{ RoutingNumber `json:"routingNumber"`; ID `json:"id"` }
```
ali `trading-service` `GET /internal/interbank/public-stocks` emituje **NESTED** protocol shape:
```json
{"stock":{"ticker":"AAPL"},"sellers":[{"seller":{"routingNumber":111,"id":"C-1"},"amount":100}]}
```
Go decode je tiho mapirao samo `sellers` (duzina niza tacna), a sva skalarna polja ostala zero → partner vidi prazno. Postojeci test je koristio FLAT mock pa bug nije uhvacen.

## Fix
`client.PublicStockEntry` (+`StockDesc`/`SellerRef`/`ForeignID`) sada prati nested wire shape; `pubStockAdapter` (main.go) i gRPC `GetPublicStock` mapiraju iz nested polja; testovi azurirani na pravi wire format. `go vet` cist, ciljani testovi prolaze.

## Deploy
Potrebno je rebuild `:latest` image-a (cd-go.yml na merge) pa `kubectl rollout restart deploy/interbank-service -n banka-1`.