### PR TITLE
feat(mobile gap): push fixes + FX rate-history + dev seed data

### DIFF
--- a/banking-core-service-go/internal/db/seed_dev.go
+++ b/banking-core-service-go/internal/db/seed_dev.go
@@ -201,4 +201,58 @@ SELECT 0, 'FX', '1110001800000000321', 'Aleksandar', 'Aleksic',
     5000.00, 20000.00, 0.00, 0.00, NULL, NULL, NULL, 'PERSONAL'
 FROM currency_table c WHERE c.oznaka = 'USD'
 ON CONFLICT (broj_racuna) DO NOTHING;
+
+-- Marko — EUR FX account (mobile devizni racun screen)
+INSERT INTO account_table (
+    version, account_type, broj_racuna, ime_vlasnika_racuna, prezime_vlasnika_racuna,
+    email, username, naziv_racuna, vlasnik, zaposlen, stanje, raspolozivo_stanje,
+    datum_i_vreme_kreiranja, datum_isteka, currency_id, status,
+    dnevni_limit, mesecni_limit, dnevna_potrosnja, mesecna_potrosnja,
+    company_id, account_concrete, odrzavanje_racuna, account_ownership_type
+)
+SELECT 0, 'FX', '1110001100000000221', 'Marko', 'Markovic',
+    NULL, NULL, 'Devizni racun EUR', 1, 1,
+    5000.00, 5000.00, NOW(), '2031-03-25', c.id, 'ACTIVE',
+    10000.00, 50000.00, 0.00, 0.00, NULL, NULL, NULL, 'PERSONAL'
+FROM currency_table c WHERE c.oznaka = 'EUR'
+ON CONFLICT (broj_racuna) DO NOTHING;
+
+-- Marko — VISA DEBIT card (ACTIVE) on his RSD account
+INSERT INTO cards (
+    card_number, card_type, card_name, creation_date, expiration_date,
+    account_number, client_id, authorized_person_id, cvv, card_limit, status
+) VALUES (
+    '4532015112830366', 'DEBIT', 'Visa Debit',
+    CURRENT_DATE, CURRENT_DATE + INTERVAL '5 years',
+    '1110001100000000111', 1, NULL,
+    '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy',
+    50000.00, 'ACTIVE'
+) ON CONFLICT (card_number) DO NOTHING;
+
+-- Marko — Mastercard DEBIT (BLOCKED) on his RSD account — tests block/unblock toggle
+INSERT INTO cards (
+    card_number, card_type, card_name, creation_date, expiration_date,
+    account_number, client_id, authorized_person_id, cvv, card_limit, status
+) VALUES (
+    '5425233430109903', 'DEBIT', 'Mastercard Debit',
+    CURRENT_DATE, CURRENT_DATE + INTERVAL '5 years',
+    '1110001100000000111', 1, NULL,
+    '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy',
+    30000.00, 'BLOCKED'
+) ON CONFLICT (card_number) DO NOTHING;
+
+-- Marko — payment history (5 transactions with Ana Anic)
+INSERT INTO payment_table (
+    from_account_number, to_account_number,
+    initial_amount, final_amount, commission,
+    sender_client_id, recipient_client_id,
+    recipient_name, payment_code, reference_number,
+    payment_purpose, status, from_currency, to_currency, exchange_rate, created_at
+) VALUES
+  ('1110001100000000111','1110001200000000111', 5000,  5000,  0, 1, 2, 'Ana Anic',      '289','REF-001','Kirija',       'COMPLETED',   'RSD','RSD',NULL, NOW()-INTERVAL '28 days'),
+  ('1110001100000000111','1110001200000000111', 12000, 12000, 0, 1, 2, 'Ana Anic',      '221','REF-002','Racun za gas', 'COMPLETED',   'RSD','RSD',NULL, NOW()-INTERVAL '21 days'),
+  ('1110001100000000111','1110001200000000111', 3500,  3500,  0, 1, 2, 'Ana Anic',      '289','REF-003','Rata kredita', 'COMPLETED',   'RSD','RSD',NULL, NOW()-INTERVAL '14 days'),
+  ('1110001200000000111','1110001100000000111', 8000,  8000,  0, 2, 1, 'Marko Markovic','289','REF-004','Povrat',       'COMPLETED',   'RSD','RSD',NULL, NOW()-INTERVAL '7 days'),
+  ('1110001100000000111','1110001200000000111', 2000,  2000,  0, 1, 2, 'Ana Anic',      '289','REF-005','Hrana',        'IN_PROGRESS', 'RSD','RSD',NULL, NOW()-INTERVAL '1 day')
+ON CONFLICT DO NOTHING;
 `

--- a/credit-service-go/internal/dto/page.go
+++ b/credit-service-go/internal/dto/page.go
@@ -3,6 +3,8 @@ package dto
 type PageResponse[T any] struct {
 	Content       []T `json:"content"`
 	Page          int `json:"page"`
+	Number        int `json:"number"`
 	Size          int `json:"size"`
 	TotalElements int `json:"totalElements"`
+	TotalPages    int `json:"totalPages"`
 }

--- a/credit-service-go/internal/service/loan_service.go
+++ b/credit-service-go/internal/service/loan_service.go
@@ -118,11 +118,17 @@ func (s *LoanService) FindAllLoanRequests(
 		return dto.PageResponse[model.LoanRequest]{}, err
 	}
 
+	totalPages := 0
+	if size > 0 {
+		totalPages = (total + size - 1) / size
+	}
 	return dto.PageResponse[model.LoanRequest]{
 		Content:       requests,
 		Page:          page,
+		Number:        page,
 		Size:          size,
 		TotalElements: total,
+		TotalPages:    totalPages,
 	}, nil
 }
 
@@ -285,11 +291,17 @@ func (s *LoanService) FindClientLoans(
 		})
 	}
 
+	totalPages := 0
+	if size > 0 {
+		totalPages = (total + size - 1) / size
+	}
 	return dto.PageResponse[dto.LoanResponseDTO]{
 		Content:       responses,
 		Page:          page,
+		Number:        page,
 		Size:          size,
 		TotalElements: total,
+		TotalPages:    totalPages,
 	}, nil
 }
 
@@ -378,11 +390,17 @@ func (s *LoanService) FindAllLoans(
 		})
 	}
 
+	totalPages := 0
+	if size > 0 {
+		totalPages = (total + size - 1) / size
+	}
 	return dto.PageResponse[dto.LoanResponseDTO]{
 		Content:       responses,
 		Page:          page,
+		Number:        page,
 		Size:          size,
 		TotalElements: total,
+		TotalPages:    totalPages,
 	}, nil
 }
 

--- a/credit-service-go/migrations/002_dev_seed_loans.sql
+++ b/credit-service-go/migrations/002_dev_seed_loans.sql
@@ -1,0 +1,175 @@
+-- DEV-ONLY seed: loans and installments for Marko Markovic (client_id=1).
+-- Provides realistic data for the mobile Krediti screen:
+--   Loan 1 — PERSONAL (RSD), 24 months, 6 installments paid, ACTIVE
+--   Loan 2 — AUTO    (RSD), 36 months, 3 installments paid, ACTIVE
+--   Loan 3 — STUDENT (RSD), 12 months, fully repaid,        PAID_OFF
+--   Loan 4 — MORTGAGE(EUR), 120 months, 2 installments paid, ACTIVE
+-- All INSERT … WHERE NOT EXISTS so the file is idempotent on re-runs.
+
+-- ============================================================================
+-- Loan 1: Personal cash loan (RSD), 24 months, 6 paid
+-- ============================================================================
+INSERT INTO loan_table (
+    loan_type, account_number, amount, repayment_period,
+    nominal_interest_rate, effective_interest_rate, interest_type,
+    agreement_date, maturity_date, installment_amount,
+    next_installment_date, remaining_debt, currency,
+    status, user_email, username, client_id, installment_count
+)
+SELECT
+    'PERSONAL', '1110001100000000111', 300000.00, 24,
+    0.0850000000, 0.0884000000, 'FIXED',
+    CURRENT_DATE - INTERVAL '6 months',
+    CURRENT_DATE + INTERVAL '18 months',
+    14250.00,
+    (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month')::date,
+    214500.00, 'RSD',
+    'ACTIVE', 'marko.markovic@banka.com', 'Marko Markovic', 1, 6
+WHERE NOT EXISTS (
+    SELECT 1 FROM loan_table WHERE client_id=1 AND loan_type='PERSONAL' AND amount=300000.00
+);
+
+-- ============================================================================
+-- Loan 2: Auto loan (RSD), 36 months, 3 paid
+-- ============================================================================
+INSERT INTO loan_table (
+    loan_type, account_number, amount, repayment_period,
+    nominal_interest_rate, effective_interest_rate, interest_type,
+    agreement_date, maturity_date, installment_amount,
+    next_installment_date, remaining_debt, currency,
+    status, user_email, username, client_id, installment_count
+)
+SELECT
+    'AUTO', '1110001100000000111', 800000.00, 36,
+    0.0720000000, 0.0745000000, 'FIXED',
+    CURRENT_DATE - INTERVAL '3 months',
+    CURRENT_DATE + INTERVAL '33 months',
+    24800.00,
+    (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month')::date,
+    725600.00, 'RSD',
+    'ACTIVE', 'marko.markovic@banka.com', 'Marko Markovic', 1, 3
+WHERE NOT EXISTS (
+    SELECT 1 FROM loan_table WHERE client_id=1 AND loan_type='AUTO' AND amount=800000.00
+);
+
+-- ============================================================================
+-- Loan 3: Student loan (RSD), 12 months, fully paid off
+-- ============================================================================
+INSERT INTO loan_table (
+    loan_type, account_number, amount, repayment_period,
+    nominal_interest_rate, effective_interest_rate, interest_type,
+    agreement_date, maturity_date, installment_amount,
+    next_installment_date, remaining_debt, currency,
+    status, user_email, username, client_id, installment_count
+)
+SELECT
+    'STUDENT', '1110001100000000111', 120000.00, 12,
+    0.0450000000, 0.0460000000, 'FIXED',
+    CURRENT_DATE - INTERVAL '13 months',
+    CURRENT_DATE - INTERVAL '1 month',
+    10200.00,
+    CURRENT_DATE - INTERVAL '1 month',
+    0.00, 'RSD',
+    'PAID_OFF', 'marko.markovic@banka.com', 'Marko Markovic', 1, 12
+WHERE NOT EXISTS (
+    SELECT 1 FROM loan_table WHERE client_id=1 AND loan_type='STUDENT' AND amount=120000.00
+);
+
+-- ============================================================================
+-- Loan 4: Mortgage (EUR FX account), 120 months, 2 paid
+-- ============================================================================
+INSERT INTO loan_table (
+    loan_type, account_number, amount, repayment_period,
+    nominal_interest_rate, effective_interest_rate, interest_type,
+    agreement_date, maturity_date, installment_amount,
+    next_installment_date, remaining_debt, currency,
+    status, user_email, username, client_id, installment_count
+)
+SELECT
+    'MORTGAGE', '1110001100000000221', 85000.00, 120,
+    0.0310000000, 0.0315000000, 'VARIABLE',
+    CURRENT_DATE - INTERVAL '2 months',
+    CURRENT_DATE + INTERVAL '118 months',
+    835.00,
+    (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month')::date,
+    83330.00, 'EUR',
+    'ACTIVE', 'marko.markovic@banka.com', 'Marko Markovic', 1, 2
+WHERE NOT EXISTS (
+    SELECT 1 FROM loan_table WHERE client_id=1 AND loan_type='MORTGAGE' AND amount=85000.00
+);
+
+-- ============================================================================
+-- Installments for Loan 1 (PERSONAL): 6 paid + 1 upcoming
+-- ============================================================================
+INSERT INTO installment_table (loan_id, installment_amount, interest_rate_at_payment, currency, expected_due_date, actual_due_date, payment_status, retry)
+SELECT l.id,
+    14250.00, 0.0884000000, 'RSD',
+    (DATE_TRUNC('month', CURRENT_DATE - INTERVAL '6 months') + INTERVAL '1 month' * gs.n)::date,
+    (DATE_TRUNC('month', CURRENT_DATE - INTERVAL '6 months') + INTERVAL '1 month' * gs.n)::date,
+    'PAID', 0
+FROM loan_table l, generate_series(1,6) AS gs(n)
+WHERE l.client_id=1 AND l.loan_type='PERSONAL' AND l.amount=300000.00
+  AND NOT EXISTS (SELECT 1 FROM installment_table i WHERE i.loan_id=l.id AND i.payment_status='PAID');
+
+INSERT INTO installment_table (loan_id, installment_amount, interest_rate_at_payment, currency, expected_due_date, actual_due_date, payment_status, retry)
+SELECT l.id, 14250.00, 0.0884000000, 'RSD',
+    (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month')::date,
+    NULL, 'UNPAID', 0
+FROM loan_table l
+WHERE l.client_id=1 AND l.loan_type='PERSONAL' AND l.amount=300000.00
+  AND NOT EXISTS (SELECT 1 FROM installment_table i WHERE i.loan_id=l.id AND i.payment_status='UNPAID');
+
+-- ============================================================================
+-- Installments for Loan 2 (AUTO): 3 paid + 1 upcoming
+-- ============================================================================
+INSERT INTO installment_table (loan_id, installment_amount, interest_rate_at_payment, currency, expected_due_date, actual_due_date, payment_status, retry)
+SELECT l.id,
+    24800.00, 0.0745000000, 'RSD',
+    (DATE_TRUNC('month', CURRENT_DATE - INTERVAL '3 months') + INTERVAL '1 month' * gs.n)::date,
+    (DATE_TRUNC('month', CURRENT_DATE - INTERVAL '3 months') + INTERVAL '1 month' * gs.n)::date,
+    'PAID', 0
+FROM loan_table l, generate_series(1,3) AS gs(n)
+WHERE l.client_id=1 AND l.loan_type='AUTO' AND l.amount=800000.00
+  AND NOT EXISTS (SELECT 1 FROM installment_table i WHERE i.loan_id=l.id AND i.payment_status='PAID');
+
+INSERT INTO installment_table (loan_id, installment_amount, interest_rate_at_payment, currency, expected_due_date, actual_due_date, payment_status, retry)
+SELECT l.id, 24800.00, 0.0745000000, 'RSD',
+    (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month')::date,
+    NULL, 'UNPAID', 0
+FROM loan_table l
+WHERE l.client_id=1 AND l.loan_type='AUTO' AND l.amount=800000.00
+  AND NOT EXISTS (SELECT 1 FROM installment_table i WHERE i.loan_id=l.id AND i.payment_status='UNPAID');
+
+-- ============================================================================
+-- Installments for Loan 3 (STUDENT): all 12 paid
+-- ============================================================================
+INSERT INTO installment_table (loan_id, installment_amount, interest_rate_at_payment, currency, expected_due_date, actual_due_date, payment_status, retry)
+SELECT l.id,
+    10200.00, 0.0460000000, 'RSD',
+    (DATE_TRUNC('month', CURRENT_DATE - INTERVAL '13 months') + INTERVAL '1 month' * gs.n)::date,
+    (DATE_TRUNC('month', CURRENT_DATE - INTERVAL '13 months') + INTERVAL '1 month' * gs.n)::date,
+    'PAID', 0
+FROM loan_table l, generate_series(1,12) AS gs(n)
+WHERE l.client_id=1 AND l.loan_type='STUDENT' AND l.amount=120000.00
+  AND NOT EXISTS (SELECT 1 FROM installment_table i WHERE i.loan_id=l.id);
+
+-- ============================================================================
+-- Installments for Loan 4 (MORTGAGE): 2 paid + 1 upcoming
+-- ============================================================================
+INSERT INTO installment_table (loan_id, installment_amount, interest_rate_at_payment, currency, expected_due_date, actual_due_date, payment_status, retry)
+SELECT l.id,
+    835.00, 0.0315000000, 'EUR',
+    (DATE_TRUNC('month', CURRENT_DATE - INTERVAL '2 months') + INTERVAL '1 month' * gs.n)::date,
+    (DATE_TRUNC('month', CURRENT_DATE - INTERVAL '2 months') + INTERVAL '1 month' * gs.n)::date,
+    'PAID', 0
+FROM loan_table l, generate_series(1,2) AS gs(n)
+WHERE l.client_id=1 AND l.loan_type='MORTGAGE' AND l.amount=85000.00
+  AND NOT EXISTS (SELECT 1 FROM installment_table i WHERE i.loan_id=l.id AND i.payment_status='PAID');
+
+INSERT INTO installment_table (loan_id, installment_amount, interest_rate_at_payment, currency, expected_due_date, actual_due_date, payment_status, retry)
+SELECT l.id, 835.00, 0.0315000000, 'EUR',
+    (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month')::date,
+    NULL, 'UNPAID', 0
+FROM loan_table l
+WHERE l.client_id=1 AND l.loan_type='MORTGAGE' AND l.amount=85000.00
+  AND NOT EXISTS (SELECT 1 FROM installment_table i WHERE i.loan_id=l.id AND i.payment_status='UNPAID');

--- a/market-service-go/internal/fx/repository.go
+++ b/market-service-go/internal/fx/repository.go
@@ -2,6 +2,7 @@ package fx
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -19,6 +20,35 @@ func NewRepository(db *pgxpool.Pool) *Repository {
 func (r *Repository) GetRatesByDate(ctx context.Context, date time.Time) ([]ExchangeRate, error) {
 	rows, err := r.db.Query(ctx, `select currency_code, buying_rate::text, selling_rate::text, rate_date, created_at
 		from exchange_rate where rate_date = $1 order by currency_code asc`, date.Format("2006-01-02"))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]ExchangeRate, 0)
+	for rows.Next() {
+		var item ExchangeRate
+		var snapshotDate time.Time
+		var createdAt time.Time
+		var buyingRate string
+		var sellingRate string
+		if err := rows.Scan(&item.CurrencyCode, &buyingRate, &sellingRate, &snapshotDate, &createdAt); err != nil {
+			return nil, err
+		}
+		item.BuyingRate = decimal.RequireFromString(buyingRate)
+		item.SellingRate = decimal.RequireFromString(sellingRate)
+		item.Date = snapshotDate.Format("2006-01-02")
+		item.CreatedAt = createdAt.UTC().Format(time.RFC3339)
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) GetRatesByRange(ctx context.Context, currencyCode string, from, to time.Time) ([]ExchangeRate, error) {
+	rows, err := r.db.Query(ctx, `select currency_code, buying_rate::text, selling_rate::text, rate_date, created_at
+		from exchange_rate
+		where currency_code = $1 and rate_date >= $2 and rate_date <= $3
+		order by rate_date asc`,
+		strings.ToUpper(currencyCode), from.Format("2006-01-02"), to.Format("2006-01-02"))
 	if err != nil {
 		return nil, err
 	}

--- a/market-service-go/internal/fx/service.go
+++ b/market-service-go/internal/fx/service.go
@@ -68,6 +68,18 @@ func (s *Service) GetRate(ctx context.Context, currencyCode, dateText string) (*
 	return nil, fmt.Errorf("rate not found for %s on %s", currencyCode, snapshotDate.Format("2006-01-02"))
 }
 
+func (s *Service) GetRateHistory(ctx context.Context, currencyCode, fromText, toText string) ([]ExchangeRate, error) {
+	from, err := time.Parse("2006-01-02", fromText)
+	if err != nil {
+		return nil, fmt.Errorf("invalid from date: %w", err)
+	}
+	to, err := time.Parse("2006-01-02", toText)
+	if err != nil {
+		return nil, fmt.Errorf("invalid to date: %w", err)
+	}
+	return s.repo.GetRatesByRange(ctx, currencyCode, from, to)
+}
+
 func (s *Service) Calculate(ctx context.Context, fromCurrency, toCurrency, amountText, dateText string, includeCommission bool) (*ConversionResponse, error) {
 	amount, err := decimal.NewFromString(amountText)
 	if err != nil {

--- a/market-service-go/internal/http/handlers.go
+++ b/market-service-go/internal/http/handlers.go
@@ -324,8 +324,20 @@ func (h *Handlers) GetRates(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) GetRateByCurrency(w http.ResponseWriter, r *http.Request) {
-	currencyCode := strings.TrimPrefix(r.URL.Path, "/rates/")
-	rate, err := h.app.FXService.GetRate(r.Context(), currencyCode, r.URL.Query().Get("date"))
+	rawPath := strings.TrimPrefix(r.URL.Path, "/rates/")
+
+	if strings.HasSuffix(rawPath, "/history") {
+		currencyCode := strings.TrimSuffix(rawPath, "/history")
+		rates, err := h.app.FXService.GetRateHistory(r.Context(), currencyCode, r.URL.Query().Get("from"), r.URL.Query().Get("to"))
+		if err != nil {
+			respondFXError(w, err)
+			return
+		}
+		platform.JSON(w, http.StatusOK, rates)
+		return
+	}
+
+	rate, err := h.app.FXService.GetRate(r.Context(), rawPath, r.URL.Query().Get("date"))
 	if err != nil {
 		respondFXError(w, err)
 		return

--- a/market-service-go/migrations/027_dev_seed_fx_history.sql
+++ b/market-service-go/migrations/027_dev_seed_fx_history.sql
@@ -1,0 +1,28 @@
+-- DEV-ONLY seed: 30 days of historical exchange rates for the mobile FX chart.
+-- Without this, the chart only shows today's single data point (flat line).
+-- Rates drift ±0.5% per day from today's baseline using a repeating 7-day cycle
+-- so the chart looks realistic without needing live API data.
+-- ON CONFLICT DO NOTHING — safe to re-run if today's rates already exist.
+
+INSERT INTO exchange_rate (currency_code, buying_rate, selling_rate, rate_date)
+SELECT
+    c.code,
+    ROUND((c.buying  * (1 + (EXTRACT(DOY FROM gs.d)::numeric % 7 - 3) * 0.002))::numeric, 8),
+    ROUND((c.selling * (1 + (EXTRACT(DOY FROM gs.d)::numeric % 7 - 3) * 0.002))::numeric, 8),
+    gs.d::date
+FROM
+    generate_series(
+        CURRENT_DATE - INTERVAL '30 days',
+        CURRENT_DATE - INTERVAL '1 day',
+        '1 day'::interval
+    ) AS gs(d),
+    (VALUES
+        ('EUR', 116.1982008::numeric, 118.5456392::numeric),
+        ('USD', 100.7318169::numeric, 102.7668031::numeric),
+        ('CHF', 126.6239205::numeric, 129.1819795::numeric),
+        ('GBP', 134.5736799::numeric, 137.2923401::numeric),
+        ('JPY', 0.62846581::numeric, 0.64116209::numeric),
+        ('CAD', 72.27608593::numeric, 73.73620887::numeric),
+        ('AUD', 71.1398358::numeric, 72.5770042::numeric)
+    ) AS c(code, buying, selling)
+ON CONFLICT DO NOTHING;

--- a/trading-service-go/migrations/002_devseed_trading.sql
+++ b/trading-service-go/migrations/002_devseed_trading.sql
@@ -657,3 +657,14 @@ SELECT 1, 5, 'LIMIT', 3, 1, 245.00, 245.00, NULL, 'BUY', 'PENDING',
        NULL, false, NOW()-INTERVAL '1 day', 3,
        false, false, false, 18, false, 0
 WHERE NOT EXISTS (SELECT 1 FROM orders WHERE user_id=1 AND listing_id=5 AND status='PENDING');
+
+-- Futures + Forex orders for user 1 / account 18 (so "Moji nalozi" shows non-stock orders)
+INSERT INTO orders (user_id,account_id,listing_id,order_type,direction,status,quantity,contract_size,price_per_unit,remaining_portions,is_done,all_or_none,margin,after_hours,last_modification,created_at,executed_at)
+SELECT v.* FROM (VALUES
+ (1,18,101,'MARKET','BUY','DONE',100,1,117.20,0,true,false,false,false, now(),now(),now()),
+ (1,18,102,'LIMIT','SELL','DONE',50,1,108.50,0,true,false,false,false, now(),now(),now()),
+ (1,18,103,'MARKET','BUY','DONE',200,1,1.08,0,true,false,false,false, now(),now(),now()),
+ (1,18,201,'MARKET','BUY','DONE',2,5000,620.00,0,true,false,false,false, now(),now(),now()),
+ (1,18,202,'LIMIT','BUY','APPROVED',1,1000,78.50,1,false,false,false,false, now(),now(),null)
+) AS v(user_id,account_id,listing_id,order_type,direction,status,quantity,contract_size,price_per_unit,remaining_portions,is_done,all_or_none,margin,after_hours,last_modification,created_at,executed_at)
+WHERE NOT EXISTS (SELECT 1 FROM orders o WHERE o.user_id=v.user_id AND o.listing_id=v.listing_id AND o.order_type=v.order_type);

--- a/trading-service-go/migrations/002_devseed_trading.sql
+++ b/trading-service-go/migrations/002_devseed_trading.sql
@@ -601,3 +601,59 @@ JOIN (
         ('Likvidni Balans RSD', 'WMT', 75, 90.0000)
 ) AS v(fund_name, stock_ticker, quantity, avg_unit_price)
   ON f.naziv = v.fund_name;
+
+-- ============================================================================
+-- source: celina3-mobile-seed — orders for Marko Markovic (user_id=1)
+-- ============================================================================
+-- 4 orders in various states so the mobile "Moji Nalozi" screen is non-empty.
+-- account_id=18 is Marko's RSD checking account in banking-core (id=18 after
+-- the deterministic dev seed: ~9 system accounts + 9 client accounts before his).
+-- listing ids: 1=AAPL, 2=MSFT, 3=GOOGL, 5=TSLA (from market seed).
+
+INSERT INTO orders (
+    user_id, listing_id, order_type, quantity, contract_size,
+    price_per_unit, limit_value, stop_value, direction, status,
+    approved_by, is_done, last_modification, remaining_portions,
+    after_hours, all_or_none, margin, account_id, exchange_closed,
+    reserved_limit_exposure
+)
+SELECT 1, 1, 'MARKET', 10, 1, 311.23, NULL, NULL, 'BUY', 'DONE',
+       NULL, true, NOW()-INTERVAL '20 days', 0,
+       false, false, false, 18, false, 0
+WHERE NOT EXISTS (SELECT 1 FROM orders WHERE user_id=1 AND listing_id=1 AND status='DONE' AND direction='BUY' AND quantity=10);
+
+INSERT INTO orders (
+    user_id, listing_id, order_type, quantity, contract_size,
+    price_per_unit, limit_value, stop_value, direction, status,
+    approved_by, is_done, last_modification, remaining_portions,
+    after_hours, all_or_none, margin, account_id, exchange_closed,
+    reserved_limit_exposure
+)
+SELECT 1, 2, 'LIMIT', 20, 1, 415.00, 415.00, NULL, 'BUY', 'PARTIALLY_FILLED',
+       NULL, false, NOW()-INTERVAL '10 days', 12,
+       false, false, false, 18, false, 0
+WHERE NOT EXISTS (SELECT 1 FROM orders WHERE user_id=1 AND listing_id=2 AND status='PARTIALLY_FILLED');
+
+INSERT INTO orders (
+    user_id, listing_id, order_type, quantity, contract_size,
+    price_per_unit, limit_value, stop_value, direction, status,
+    approved_by, is_done, last_modification, remaining_portions,
+    after_hours, all_or_none, margin, account_id, exchange_closed,
+    reserved_limit_exposure
+)
+SELECT 1, 3, 'MARKET', 5, 1, 180.50, NULL, NULL, 'SELL', 'CANCELLED',
+       NULL, false, NOW()-INTERVAL '5 days', 5,
+       false, false, false, 18, false, 0
+WHERE NOT EXISTS (SELECT 1 FROM orders WHERE user_id=1 AND listing_id=3 AND status='CANCELLED');
+
+INSERT INTO orders (
+    user_id, listing_id, order_type, quantity, contract_size,
+    price_per_unit, limit_value, stop_value, direction, status,
+    approved_by, is_done, last_modification, remaining_portions,
+    after_hours, all_or_none, margin, account_id, exchange_closed,
+    reserved_limit_exposure
+)
+SELECT 1, 5, 'LIMIT', 3, 1, 245.00, 245.00, NULL, 'BUY', 'PENDING',
+       NULL, false, NOW()-INTERVAL '1 day', 3,
+       false, false, false, 18, false, 0
+WHERE NOT EXISTS (SELECT 1 FROM orders WHERE user_id=1 AND listing_id=5 AND status='PENDING');

--- a/user-service-go/migrations/002_dev_seed_data.sql
+++ b/user-service-go/migrations/002_dev_seed_data.sql
@@ -53,3 +53,21 @@ SELECT c.id, 'CLIENT_BASIC'
 FROM clients c
 WHERE c.role = 'CLIENT_BASIC'
 ON CONFLICT DO NOTHING;
+
+-- Marko Markovic (client_id=1) gets CLIENT_TRADING for mobile trading/orders screens.
+UPDATE clients SET role = 'CLIENT_TRADING' WHERE email = 'marko.markovic@banka.com';
+
+INSERT INTO client_permissions (client_id, permission)
+SELECT c.id, 'CLIENT_TRADING'
+FROM clients c
+WHERE c.email = 'marko.markovic@banka.com'
+ON CONFLICT DO NOTHING;
+
+-- Ana Anic gets CLIENT_TRADING as a second trading client.
+UPDATE clients SET role = 'CLIENT_TRADING' WHERE email = 'ana.anic@banka.com';
+
+INSERT INTO client_permissions (client_id, permission)
+SELECT c.id, 'CLIENT_TRADING'
+FROM clients c
+WHERE c.email = 'ana.anic@banka.com'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Mobile gap: push fixes + FX rate-history + dev seed data

Comprehensive branch that closes the remaining mobile-feature gap on `main`. It **includes the mobile push fixes from #325** (so it's a complete, testable branch) **plus** the FX rate-history feature, dev seed data, and a credit pagination fix.

> If you'd rather keep #325 as the focused mobile-push PR, this can be split — see "Relationship to #325" below.

### 1. Mobile push fixes (same as #325)
- `notification-service`: restore `VERIFICATION_OTP` data push (Quick-Approve) alongside the authoritative email; send `ORDER_*` lifecycle events as **data** messages (not notification-only) so the mobile app ingests them into its in-app inbox; re-add `POST /notifications/fcm/test`.
- `go-platform/rabbitmq`: recover a dropped publisher channel/connection (re-dial + reopen + re-declare, mutex-guarded, one-shot retry) so idle-closed channels no longer silently drop notifications.
- `setup`: wire `FCM_PROJECT_ID` + `GOOGLE_APPLICATION_CREDENTIALS` and mount the Firebase credentials into notification-service.

### 2. FX rate-history (mobile 30-day FX chart)
- `market-service`: `GetRateHistory` over a date range (fx repo/service + `/rates/{ccy}/history` handler).
- dev seed `market-service-go/migrations/027_dev_seed_fx_history.sql` — **renumbered from 026** to avoid a Goose collision with upstream's `026_seed_price_history.sql`.

### 3. Dev seed data
- `banking-core` `seed_dev.go`, `trading 002_devseed_trading.sql` (merged with upstream's changes), `user 002_dev_seed_data.sql`, `credit 002_dev_seed_loans.sql`.

### 4. Credit pagination
- `PageResponse` adds `number` + `totalPages` for the mobile paginated lists.

### Verification
- `go build ./...` green for market, credit, banking-core (Docker `golang:1.26.3`); notification-service + go-platform suites green.
- Migration numbering verified unique per service (no duplicate Goose version prefixes); `trading 002` auto-merged with upstream with zero conflict markers.
- Fresh-DB migration/seed execution is validated by CI `docker-validate` (container must stay running after migrations apply).

### Relationship to #325
This branch is a superset of `mobile-fixes` (#325). Recommend **closing #325** in favour of this PR, or tell me and I'll rebase this to FX+seeds-only so #325 stays the focused mobile PR.
