### PR TITLE
Inter-bank interop sa Bankom 2 — plaćanja (oba smera, FX) + ceo OTC lifecycle (accept/exercise/decline/expiry)

### DIFF
--- a/banking-core-service-go/internal/db/db.go
+++ b/banking-core-service-go/internal/db/db.go
@@ -336,7 +336,7 @@ CREATE TABLE IF NOT EXISTS interbank_reservations (
     reservation_id UUID NOT NULL UNIQUE,
     transaction_id_routing INT NOT NULL,
     transaction_id_local VARCHAR(64) NOT NULL,
-    account_number VARCHAR(18) NOT NULL,
+    account_number VARCHAR(34) NOT NULL, -- 34 (IBAN max): Banka 1 koristi 19-cifrene racune, VARCHAR(18) je bacao 22001 i obarao 2PC reserve (sibling interbank_credits je vec VARCHAR(34))
     currency VARCHAR(8) NOT NULL,
     amount NUMERIC(20,4) NOT NULL CHECK (amount > 0),
     status VARCHAR(16) NOT NULL,
@@ -348,6 +348,22 @@ CREATE INDEX IF NOT EXISTS idx_interbank_reservations_tx
     ON interbank_reservations(transaction_id_routing, transaction_id_local);
 CREATE INDEX IF NOT EXISTS idx_interbank_reservations_account_status
     ON interbank_reservations(account_number, status);
+
+CREATE TABLE IF NOT EXISTS interbank_credits (
+    id BIGSERIAL PRIMARY KEY,
+    transaction_id_routing INT NOT NULL,
+    transaction_id_local VARCHAR(64) NOT NULL,
+    account_number VARCHAR(34) NOT NULL, -- 34 (IBAN max): Banka 1 koristi 19-cifrene racune, ne 18
+    posting_currency VARCHAR(8) NOT NULL,
+    posting_amount NUMERIC(20,4) NOT NULL CHECK (posting_amount > 0),
+    credited_currency VARCHAR(8) NOT NULL,
+    credited_amount NUMERIC(20,4) NOT NULL CHECK (credited_amount > 0),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uk_interbank_credits_tx UNIQUE (transaction_id_routing, transaction_id_local)
+);
+
+CREATE INDEX IF NOT EXISTS idx_interbank_credits_account
+    ON interbank_credits(account_number);
 
 CREATE TABLE IF NOT EXISTS gdpr_event_log (
     event_id VARCHAR(64) NOT NULL,

--- a/banking-core-service-go/internal/http/handler.go
+++ b/banking-core-service-go/internal/http/handler.go
@@ -222,6 +222,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	case r.Method == http.MethodPost && path == "/internal/interbank/reserve-monas":
 		h.reserveMonas(w, r)
+	case r.Method == http.MethodPost && path == "/internal/interbank/credit-monas":
+		h.creditMonas(w, r)
 	case r.Method == http.MethodPost && strings.HasPrefix(path, "/internal/interbank/reservations/") && strings.HasSuffix(path, "/commit-monas"):
 		id, _ := trimPrefixSuffix(path, "/internal/interbank/reservations/", "/commit-monas")
 		h.commitMonas(w, r, id)
@@ -483,6 +485,18 @@ func (h *Handler) reserveMonas(w http.ResponseWriter, r *http.Request) {
 	respond(w, service.ReserveMonasResponse{ReservationID: id}, http.StatusOK, err)
 }
 
+func (h *Handler) creditMonas(w http.ResponseWriter, r *http.Request) {
+	if !h.requireServiceRole(w, r) {
+		return
+	}
+	var req service.CreditMonasRequest
+	if !decode(w, r, &req) {
+		return
+	}
+	resp, err := h.services.Interbank.CreditMonas(r.Context(), req)
+	respond(w, resp, http.StatusOK, err)
+}
+
 func (h *Handler) commitMonas(w http.ResponseWriter, r *http.Request, id string) {
 	if !h.requireServiceRole(w, r) {
 		return
@@ -690,7 +704,8 @@ func isKnownPath(path string) bool {
 		"/accounts/createMarginAccount", "/accounts/company/createMarginAccount",
 		"/transactions/stockBuyMarginTransaction", "/transactions/stockSellMarginTransaction",
 		"/transactions/internal/reserve-funds", "/transactions/internal/transfer",
-		"/internal/interbank/reserve-monas", "/internal/interbank/account-by-owner", "/internal/interbank/account-resolve",
+		"/internal/interbank/reserve-monas", "/internal/interbank/credit-monas",
+		"/internal/interbank/account-by-owner", "/internal/interbank/account-resolve",
 		"/internal/accounts/transaction", "/internal/accounts/exchange/buy", "/internal/accounts/exchange/sell",
 		"/internal/accounts/transactionFromBank", "/internal/accounts/debit", "/internal/accounts/credit",
 		"/internal/accounts/creditBank", "/internal/accounts/debitBank",

--- a/banking-core-service-go/internal/service/container.go
+++ b/banking-core-service-go/internal/service/container.go
@@ -58,7 +58,7 @@ func NewContainer(cfg config.Config, db *sql.DB) *Container {
 		MarginAccounts:    marginAccounts,
 		MarginTx:          NewMarginTransactionService(db, cfg, accountSvc, marginAccounts),
 		Internal:          internal,
-		Interbank:         NewInterbankService(db, accountSvc),
+		Interbank:         NewInterbankService(db, accountSvc, market),
 		CardService:       cardSvc,
 		Verification:      verificationSvc,
 		Transactions:      transactionSvc,

--- a/banking-core-service-go/internal/service/interbank.go
+++ b/banking-core-service-go/internal/service/interbank.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 
 	"banka1/banking-core-service-go/internal/decimal"
 	"banka1/banking-core-service-go/internal/uuid"
@@ -15,9 +16,17 @@ const (
 	InterbankReleased  = "RELEASED"
 )
 
+// MonasConverter is the FX seam used by CreditMonas for cross-currency credits.
+// *MarketClient satisfies it via ConvertNoCommission. Kept as an interface so the
+// FX path is unit-testable without a live market-service.
+type MonasConverter interface {
+	ConvertNoCommission(ctx context.Context, amount decimal.Decimal, from, to string) (ConversionResponse, error)
+}
+
 type InterbankService struct {
 	db       *sql.DB
 	accounts *AccountService
+	market   MonasConverter
 }
 
 type ReserveMonasRequest struct {
@@ -32,6 +41,29 @@ type ReserveMonasResponse struct {
 	ReservationID string `json:"reservationId"`
 }
 
+// CreditMonasRequest is the body of POST /internal/interbank/credit-monas.
+// The credit is keyed for idempotency by (TxIDRouting, TxIDLocal): a replay with
+// the same key is a no-op that returns the originally-credited result.
+type CreditMonasRequest struct {
+	AccountNum  string          `json:"accountNum"`
+	Currency    string          `json:"currency"`
+	Amount      decimal.Decimal `json:"amount"`
+	TxIDRouting int             `json:"txIdRouting"`
+	TxIDLocal   string          `json:"txIdLocal"`
+}
+
+// CreditMonasResponse reports what was actually credited. CreditedAmount equals
+// Amount when account.currency == posting.currency, otherwise it is the FX-converted
+// amount in the account's currency. Idempotent is true when the call was a replay.
+type CreditMonasResponse struct {
+	AccountNumber    string          `json:"accountNumber"`
+	PostingCurrency  string          `json:"postingCurrency"`
+	PostingAmount    decimal.Decimal `json:"postingAmount"`
+	CreditedCurrency string          `json:"creditedCurrency"`
+	CreditedAmount   decimal.Decimal `json:"creditedAmount"`
+	Idempotent       bool            `json:"idempotent"`
+}
+
 type AccountResolveResponse struct {
 	OwnerType        string          `json:"ownerType"`
 	OwnerID          int64           `json:"ownerId"`
@@ -43,8 +75,118 @@ type AccountByOwnerResponse struct {
 	AccountNumber string `json:"accountNumber"`
 }
 
-func NewInterbankService(db *sql.DB, accounts *AccountService) *InterbankService {
-	return &InterbankService{db: db, accounts: accounts}
+func NewInterbankService(db *sql.DB, accounts *AccountService, market MonasConverter) *InterbankService {
+	return &InterbankService{db: db, accounts: accounts, market: market}
+}
+
+// CreditMonas credits a recipient/seller account during inter-bank 2PC commit
+// (protocol §2.8.4). It is the settlement-side counterpart of ReserveMonas/CommitReservation
+// (which handle the sender's debit). Two guarantees make it safe to call from the
+// 2PC executor's commit step:
+//
+//   - Idempotent by (TxIDRouting, TxIDLocal): a replay (e.g. after a crash between
+//     credit and status-flip) returns the originally-credited result without double-crediting,
+//     enforced by the interbank_credits unique constraint.
+//   - FX-aware: when the recipient account's currency differs from the posting currency,
+//     the amount is converted via the same bank-pool-leg mechanism used by internal
+//     transfers (InternalService.Transfer) — the bank's pool account of the credited
+//     currency is debited and the recipient is credited the converted amount. No FX
+//     commission is charged: this is settlement of an already-balanced inter-bank tx.
+func (s *InterbankService) CreditMonas(ctx context.Context, req CreditMonasRequest) (CreditMonasResponse, error) {
+	if req.AccountNum == "" || req.Currency == "" || req.TxIDLocal == "" {
+		return CreditMonasResponse{}, BadRequest("accountNum, currency i txIdLocal su obavezni")
+	}
+	if req.Amount.Sign() <= 0 {
+		return CreditMonasResponse{}, BadRequest("Amount must be positive")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return CreditMonasResponse{}, err
+	}
+	defer tx.Rollback()
+
+	// Idempotency: if this (routing, local) was already credited, return that result.
+	if existing, found, err := s.loadCreditForUpdate(ctx, tx, req.TxIDRouting, req.TxIDLocal); err != nil {
+		return CreditMonasResponse{}, err
+	} else if found {
+		existing.Idempotent = true
+		return existing, tx.Commit()
+	}
+
+	account, err := s.accounts.getByNumber(ctx, tx, req.AccountNum, true)
+	if err != nil {
+		return CreditMonasResponse{}, err
+	}
+
+	creditedAmount := req.Amount
+	if !strings.EqualFold(account.Currency, req.Currency) {
+		if s.market == nil {
+			return CreditMonasResponse{}, BadRequest("FX konverzija nije dostupna za %s→%s", req.Currency, account.Currency)
+		}
+		conv, err := s.market.ConvertNoCommission(ctx, req.Amount, req.Currency, account.Currency)
+		if err != nil {
+			return CreditMonasResponse{}, err
+		}
+		creditedAmount = conv.ToAmount
+		if creditedAmount.Sign() <= 0 {
+			return CreditMonasResponse{}, BadRequest("Konvertovani iznos mora biti veci od 0")
+		}
+		// Bank-pool leg: the recipient's currency is sourced from the bank's pool
+		// account of that currency (mirrors InternalService.Transfer cross-ccy path).
+		bank, err := s.accounts.getByOwnerAndCurrency(ctx, tx, -1, account.Currency, true)
+		if err != nil {
+			return CreditMonasResponse{}, err
+		}
+		if err := s.accounts.DebitTx(ctx, tx, bank.AccountNumber, creditedAmount, bank.OwnerID); err != nil {
+			return CreditMonasResponse{}, err
+		}
+	}
+
+	if err := s.accounts.CreditTx(ctx, tx, account.AccountNumber, creditedAmount, account.OwnerID); err != nil {
+		return CreditMonasResponse{}, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO interbank_credits (
+    transaction_id_routing, transaction_id_local,
+    account_number, posting_currency, posting_amount,
+    credited_currency, credited_amount
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+`, req.TxIDRouting, req.TxIDLocal, account.AccountNumber, req.Currency, req.Amount, account.Currency, creditedAmount); err != nil {
+		return CreditMonasResponse{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return CreditMonasResponse{}, err
+	}
+	return CreditMonasResponse{
+		AccountNumber:    account.AccountNumber,
+		PostingCurrency:  req.Currency,
+		PostingAmount:    req.Amount,
+		CreditedCurrency: account.Currency,
+		CreditedAmount:   creditedAmount,
+		Idempotent:       false,
+	}, nil
+}
+
+// loadCreditForUpdate looks up a prior credit for (routing, local) and locks the row.
+// Returns (result, found, err). When found, the returned result mirrors the stored credit.
+func (s *InterbankService) loadCreditForUpdate(ctx context.Context, tx *sql.Tx, routing int, local string) (CreditMonasResponse, bool, error) {
+	var out CreditMonasResponse
+	err := tx.QueryRowContext(ctx, `
+SELECT account_number, posting_currency, posting_amount, credited_currency, credited_amount
+  FROM interbank_credits
+ WHERE transaction_id_routing = $1 AND transaction_id_local = $2
+ FOR UPDATE
+`, routing, local).Scan(&out.AccountNumber, &out.PostingCurrency, &out.PostingAmount, &out.CreditedCurrency, &out.CreditedAmount)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return CreditMonasResponse{}, false, nil
+		}
+		return CreditMonasResponse{}, false, err
+	}
+	return out, true, nil
 }
 
 func (s *InterbankService) ReserveMonas(ctx context.Context, req ReserveMonasRequest) (string, error) {

--- a/banking-core-service-go/internal/service/interbank_credit_test.go
+++ b/banking-core-service-go/internal/service/interbank_credit_test.go
@@ -1,0 +1,421 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"banka1/banking-core-service-go/internal/config"
+	"banka1/banking-core-service-go/internal/decimal"
+)
+
+// ---------------------------------------------------------------------------
+// CreditMonas tests
+//
+// These exercise the dedicated idempotent, FX-aware credit primitive used by the
+// inter-bank 2PC commit step. They run against a minimal in-memory database/sql
+// driver fake (same technique as internal_account_controller_test.go) scoped to
+// the statements CreditMonas issues.
+// ---------------------------------------------------------------------------
+
+// TestCreditMonas_SameCurrency_CreditsRecipient verifies a plain same-currency
+// credit increases the recipient balance by the posting amount.
+func TestCreditMonas_SameCurrency_CreditsRecipient(t *testing.T) {
+	store := newCreditFakeStore()
+	store.addAccount(creditFakeAccount{id: 1, number: "111000000000000001", ownerID: 7, currency: "USD", available: "100", booked: decimal.MustParse("100")})
+	db := openCreditFakeDB(t, store)
+	svc := NewInterbankService(db, NewAccountService(db, config.Config{}, nil), nil)
+
+	resp, err := svc.CreditMonas(context.Background(), CreditMonasRequest{
+		AccountNum: "111000000000000001", Currency: "USD",
+		Amount: decimal.MustParse("250"), TxIDRouting: 222, TxIDLocal: "tx-1",
+	})
+	if err != nil {
+		t.Fatalf("CreditMonas: %v", err)
+	}
+	if resp.Idempotent {
+		t.Errorf("first call should not be idempotent")
+	}
+	if got := resp.CreditedAmount.String(); got != "250" {
+		t.Errorf("creditedAmount=%s want 250", got)
+	}
+	if got := store.account("111000000000000001").booked.String(); got != "350" {
+		t.Errorf("recipient booked=%s want 350 (100+250)", got)
+	}
+}
+
+// TestCreditMonas_Idempotent_DoubleCallSingleCredit verifies a replay with the
+// same (routing, local) key is a no-op: the balance is credited exactly once.
+func TestCreditMonas_Idempotent_DoubleCallSingleCredit(t *testing.T) {
+	store := newCreditFakeStore()
+	store.addAccount(creditFakeAccount{id: 1, number: "111000000000000001", ownerID: 7, currency: "USD", available: "0", booked: decimal.Zero})
+	db := openCreditFakeDB(t, store)
+	svc := NewInterbankService(db, NewAccountService(db, config.Config{}, nil), nil)
+
+	req := CreditMonasRequest{
+		AccountNum: "111000000000000001", Currency: "USD",
+		Amount: decimal.MustParse("250"), TxIDRouting: 222, TxIDLocal: "tx-dup",
+	}
+	if _, err := svc.CreditMonas(context.Background(), req); err != nil {
+		t.Fatalf("first CreditMonas: %v", err)
+	}
+	resp2, err := svc.CreditMonas(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second CreditMonas: %v", err)
+	}
+	if !resp2.Idempotent {
+		t.Errorf("second call should be flagged idempotent")
+	}
+	if got := resp2.CreditedAmount.String(); got != "250" {
+		t.Errorf("replay creditedAmount=%s want original 250", got)
+	}
+	if got := store.account("111000000000000001").booked.String(); got != "250" {
+		t.Errorf("recipient booked=%s want 250 (credited exactly once)", got)
+	}
+}
+
+// TestCreditMonas_FX_ConvertsToAccountCurrency verifies that when the recipient's
+// account currency differs from the posting currency, the converted amount (from
+// the FX seam) is credited and the bank pool of the credited currency is debited.
+func TestCreditMonas_FX_ConvertsToAccountCurrency(t *testing.T) {
+	store := newCreditFakeStore()
+	// Recipient holds RSD; posting arrives in EUR.
+	store.addAccount(creditFakeAccount{id: 1, number: "111000000000000001", ownerID: 7, currency: "RSD", available: "0", booked: decimal.Zero})
+	// Bank pool account for RSD (owner -1).
+	store.addAccount(creditFakeAccount{id: 2, number: "111000110000000002", ownerID: -1, currency: "RSD", available: "1000000", booked: decimal.MustParse("1000000")})
+	db := openCreditFakeDB(t, store)
+	// Converter: 100 EUR -> 11700 RSD.
+	conv := &fakeMonasConverter{toAmount: decimal.MustParse("11700")}
+	svc := NewInterbankService(db, NewAccountService(db, config.Config{}, nil), conv)
+
+	resp, err := svc.CreditMonas(context.Background(), CreditMonasRequest{
+		AccountNum: "111000000000000001", Currency: "EUR",
+		Amount: decimal.MustParse("100"), TxIDRouting: 222, TxIDLocal: "tx-fx",
+	})
+	if err != nil {
+		t.Fatalf("CreditMonas FX: %v", err)
+	}
+	if conv.calls != 1 {
+		t.Errorf("expected exactly 1 conversion call, got %d", conv.calls)
+	}
+	if conv.from != "EUR" || conv.to != "RSD" {
+		t.Errorf("conversion from=%s to=%s, want EUR->RSD", conv.from, conv.to)
+	}
+	if got := resp.CreditedAmount.String(); got != "11700" {
+		t.Errorf("creditedAmount=%s want 11700 (converted)", got)
+	}
+	if got := store.account("111000000000000001").booked.String(); got != "11700" {
+		t.Errorf("recipient booked=%s want 11700", got)
+	}
+	if got := store.account("111000110000000002").booked.String(); got != "988300" {
+		t.Errorf("bank pool booked=%s want 988300 (1000000-11700)", got)
+	}
+}
+
+// TestCreditMonas_RejectsNonPositiveAmount guards the basic validation contract.
+func TestCreditMonas_RejectsNonPositiveAmount(t *testing.T) {
+	store := newCreditFakeStore()
+	db := openCreditFakeDB(t, store)
+	svc := NewInterbankService(db, NewAccountService(db, config.Config{}, nil), nil)
+	if _, err := svc.CreditMonas(context.Background(), CreditMonasRequest{
+		AccountNum: "111000000000000001", Currency: "USD",
+		Amount: decimal.Zero, TxIDRouting: 222, TxIDLocal: "tx-bad",
+	}); err == nil {
+		t.Fatalf("expected error for non-positive amount")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fakeMonasConverter
+// ---------------------------------------------------------------------------
+
+type fakeMonasConverter struct {
+	toAmount  decimal.Decimal
+	from, to  string
+	calls     int
+	forcedErr error
+}
+
+func (f *fakeMonasConverter) ConvertNoCommission(_ context.Context, amount decimal.Decimal, from, to string) (ConversionResponse, error) {
+	f.calls++
+	f.from, f.to = from, to
+	if f.forcedErr != nil {
+		return ConversionResponse{}, f.forcedErr
+	}
+	return ConversionResponse{FromCurrency: from, ToCurrency: to, FromAmount: amount, ToAmount: f.toAmount}, nil
+}
+
+// ---------------------------------------------------------------------------
+// In-memory database/sql driver fake scoped to CreditMonas
+// ---------------------------------------------------------------------------
+
+type creditFakeAccount struct {
+	id        int64
+	number    string
+	ownerID   int64
+	currency  string
+	available string          // raspolozivo_stanje seed (string; not mutated by these tests)
+	booked    decimal.Decimal // stanje, mutated by credits/debits
+}
+
+type creditFakeStore struct {
+	mu         sync.Mutex
+	byNumber   map[string]*creditFakeAccount
+	creditedTx map[string]CreditMonasResponse // key: routing|local
+}
+
+func newCreditFakeStore() *creditFakeStore {
+	return &creditFakeStore{byNumber: map[string]*creditFakeAccount{}, creditedTx: map[string]CreditMonasResponse{}}
+}
+
+// addAccount registers an account. The booked field is seeded from the booked arg
+// passed via creditFakeAccount.booked already being set by the caller helper below.
+func (s *creditFakeStore) addAccount(a creditFakeAccount) {
+	s.byNumber[a.number] = &a
+}
+
+func (s *creditFakeStore) account(number string) *creditFakeAccount {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.byNumber[number]
+}
+
+func txCreditKey(routing int64, local string) string {
+	return strings.Join([]string{decimal.NewFromInt(routing).String(), local}, "|")
+}
+
+const creditFakeDriverName = "interbank-credit-fake"
+
+var (
+	creditFakeDriverOnce sync.Once
+	creditFakeSeq        atomic.Int64
+	creditFakeMu         sync.Mutex
+	creditFakeStores     = map[string]*creditFakeStore{}
+)
+
+func openCreditFakeDB(t *testing.T, store *creditFakeStore) *sql.DB {
+	t.Helper()
+	creditFakeDriverOnce.Do(func() { sql.Register(creditFakeDriverName, creditFakeDriver{}) })
+	dsn := "credit-fake-" + decimal.NewFromInt(creditFakeSeq.Add(1)).String()
+	creditFakeMu.Lock()
+	creditFakeStores[dsn] = store
+	creditFakeMu.Unlock()
+	db, err := sql.Open(creditFakeDriverName, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		creditFakeMu.Lock()
+		delete(creditFakeStores, dsn)
+		creditFakeMu.Unlock()
+		_ = db.Close()
+	})
+	return db
+}
+
+type creditFakeDriver struct{}
+
+func (creditFakeDriver) Open(name string) (driver.Conn, error) {
+	creditFakeMu.Lock()
+	store := creditFakeStores[name]
+	creditFakeMu.Unlock()
+	if store == nil {
+		return nil, errors.New("credit fake: unknown dsn " + name)
+	}
+	return &creditFakeConn{store: store}, nil
+}
+
+type creditFakeConn struct{ store *creditFakeStore }
+
+func (c *creditFakeConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (c *creditFakeConn) Close() error                        { return nil }
+func (c *creditFakeConn) Begin() (driver.Tx, error)           { return creditFakeTx{}, nil }
+func (c *creditFakeConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	return creditFakeTx{}, nil
+}
+
+type creditFakeTx struct{}
+
+func (creditFakeTx) Commit() error   { return nil }
+func (creditFakeTx) Rollback() error { return nil }
+
+func (c *creditFakeConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.store.mu.Lock()
+	defer c.store.mu.Unlock()
+	q := normalize(query)
+	switch {
+	case strings.Contains(q, "from interbank_credits"):
+		// loadCreditForUpdate: args = (routing, local)
+		key := txCreditKey(asInt(args[0].Value), asString(args[1].Value))
+		if r, ok := c.store.creditedTx[key]; ok {
+			return &creditRowsCredit{resp: r, has: true}, nil
+		}
+		return &creditRowsCredit{}, nil
+	case strings.Contains(q, "where a.broj_racuna"):
+		acc := c.store.byNumber[asString(args[0].Value)]
+		return accountRows(acc), nil
+	case strings.Contains(q, "where a.vlasnik") && strings.Contains(q, "c.oznaka"):
+		ownerID := asInt(args[0].Value)
+		currency := asString(args[1].Value)
+		for _, a := range c.store.byNumber {
+			if a.ownerID == ownerID && a.currency == currency {
+				return accountRows(a), nil
+			}
+		}
+		return accountRows(nil), nil
+	}
+	return nil, errors.New("credit fake: unhandled query: " + q)
+}
+
+func (c *creditFakeConn) ExecContext(_ context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	c.store.mu.Lock()
+	defer c.store.mu.Unlock()
+	q := normalize(query)
+	switch {
+	case strings.Contains(q, "update account_table") && strings.Contains(q, "stanje = stanje + $1"):
+		// CreditTx: args = (amount, id)
+		amt := decimal.MustParse(asString(args[0].Value))
+		id := asInt(args[1].Value)
+		if a := c.byID(id); a != nil {
+			a.booked = a.booked.Add(amt)
+		}
+		return driver.RowsAffected(1), nil
+	case strings.Contains(q, "update account_table") && strings.Contains(q, "stanje = stanje - $1"):
+		// DebitTx: args = (amount, id)
+		amt := decimal.MustParse(asString(args[0].Value))
+		id := asInt(args[1].Value)
+		if a := c.byID(id); a != nil {
+			a.booked = a.booked.Sub(amt)
+		}
+		return driver.RowsAffected(1), nil
+	case strings.Contains(q, "insert into interbank_credits"):
+		// args: routing, local, accountNumber, postingCcy, postingAmt, creditedCcy, creditedAmt
+		key := txCreditKey(asInt(args[0].Value), asString(args[1].Value))
+		if _, exists := c.store.creditedTx[key]; exists {
+			return nil, errors.New("duplicate key uk_interbank_credits_tx")
+		}
+		c.store.creditedTx[key] = CreditMonasResponse{
+			AccountNumber:    asString(args[2].Value),
+			PostingCurrency:  asString(args[3].Value),
+			PostingAmount:    decimal.MustParse(asString(args[4].Value)),
+			CreditedCurrency: asString(args[5].Value),
+			CreditedAmount:   decimal.MustParse(asString(args[6].Value)),
+		}
+		return driver.RowsAffected(1), nil
+	}
+	return driver.RowsAffected(0), nil
+}
+
+func (c *creditFakeConn) byID(id int64) *creditFakeAccount {
+	for _, a := range c.store.byNumber {
+		if a.id == id {
+			return a
+		}
+	}
+	return nil
+}
+
+func normalize(q string) string { return strings.ToLower(strings.Join(strings.Fields(q), " ")) }
+
+func asString(v driver.Value) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	}
+	if d, ok := v.(interface{ String() string }); ok {
+		return d.String()
+	}
+	return ""
+}
+
+func asInt(v driver.Value) int64 {
+	switch t := v.(type) {
+	case int64:
+		return t
+	case int:
+		return int64(t)
+	}
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// driver.Rows implementations
+// ---------------------------------------------------------------------------
+
+func accountRows(a *creditFakeAccount) driver.Rows {
+	if a == nil {
+		return &accountRowsImpl{}
+	}
+	return &accountRowsImpl{acc: a, has: true}
+}
+
+type accountRowsImpl struct {
+	acc     *creditFakeAccount
+	has     bool
+	scanned bool
+}
+
+func (r *accountRowsImpl) Columns() []string {
+	return []string{
+		"id", "broj_racuna", "vlasnik", "oznaka", "raspolozivo_stanje",
+		"stanje", "status", "account_type", "email", "username",
+		"dnevni_limit", "mesecni_limit", "dnevna_potrosnja", "mesecna_potrosnja",
+		"has_daily_limit", "has_monthly_limit", "datum_isteka",
+		"daily_limit_remaining", "has_daily_limit_remaining",
+	}
+}
+
+func (r *accountRowsImpl) Close() error { return nil }
+
+func (r *accountRowsImpl) Next(dest []driver.Value) error {
+	if !r.has || r.scanned {
+		return io.EOF
+	}
+	r.scanned = true
+	a := r.acc
+	values := []driver.Value{
+		a.id, a.number, a.ownerID, a.currency, a.available,
+		a.booked.String(), "ACTIVE", "CHECKING", "", "",
+		"0", "0", "0", "0",
+		false, false, nil,
+		"0", false,
+	}
+	copy(dest, values)
+	return nil
+}
+
+type creditRowsCredit struct {
+	resp    CreditMonasResponse
+	has     bool
+	scanned bool
+}
+
+func (r *creditRowsCredit) Columns() []string {
+	return []string{"account_number", "posting_currency", "posting_amount", "credited_currency", "credited_amount"}
+}
+func (r *creditRowsCredit) Close() error { return nil }
+func (r *creditRowsCredit) Next(dest []driver.Value) error {
+	if !r.has || r.scanned {
+		return io.EOF
+	}
+	r.scanned = true
+	copy(dest, []driver.Value{
+		r.resp.AccountNumber, r.resp.PostingCurrency, r.resp.PostingAmount.String(),
+		r.resp.CreditedCurrency, r.resp.CreditedAmount.String(),
+	})
+	return nil
+}
+
+var (
+	_ driver.QueryerContext = (*creditFakeConn)(nil)
+	_ driver.ExecerContext  = (*creditFakeConn)(nil)
+	_ driver.ConnBeginTx    = (*creditFakeConn)(nil)
+)

--- a/interbank-service/cmd/interbank-service/main.go
+++ b/interbank-service/cmd/interbank-service/main.go
@@ -184,7 +184,13 @@ func run() error {
 		logger,
 	)
 
-	// Coordinator uses BankingCoreClient for MONAS account resolution.
+	// Wire the optional contract store into the executor for the option post-accept
+	// lifecycle (S4 buyer-persist on inbound accept, S9 EXERCISED flip after inbound
+	// seller settlement).
+	executor.SetContractStore(contractStore)
+
+	// Coordinator uses BankingCoreClient for MONAS account resolution; bcReserver +
+	// tdClient + contractStore power the outbound exercise coordinator (S7/S8).
 	coordinator := service.NewCoordinator(
 		cfg.Interbank.MyRoutingNumber,
 		executor,
@@ -192,6 +198,9 @@ func run() error {
 		negStore,
 		contractStore, // *store.ContractStore satisfies service.ContractStoreIface
 		bcReserver,    // satisfies service.BankingCoreAccountResolver
+		bcReserver,    // satisfies service.BankingCoreReserver (strike reserve/commit/release)
+		tdClient,      // satisfies service.TradingReserver (CreditPortfolio)
+		contractStore, // satisfies service.ContractWriter (find + EXERCISED flip)
 		logger,
 	)
 	// Fill shim now that coordinator is ready.
@@ -208,6 +217,10 @@ func run() error {
 		registry, // satisfies service.PartnerNameResolver
 		logger,
 	)
+	// Wire the buyer-side held-option list (S4) + the exercise coordinator (S7/S8).
+	otcOutbound.SetContractDeps(contractStore, coordinator)
+	// Wire the outbound regular-payment coordinator (POST /api/interbank/otc/payments).
+	otcOutbound.SetPaymentCoordinator(coordinator)
 
 	// -------------------------------------------------------------------------
 	// API handlers
@@ -265,6 +278,21 @@ func run() error {
 	)
 	schedDone := make(chan error, 1)
 	go func() { schedDone <- retrySched.Run(ctx) }()
+
+	// -------------------------------------------------------------------------
+	// Expiry sweeper (S10) — settles ACTIVE contracts past their settlement date.
+	// contractStore satisfies scheduler.ExpiryContractStore; tdClient satisfies
+	// scheduler.OptionReleaser (ReleaseOption for seller-side reservations).
+	// -------------------------------------------------------------------------
+	expirySched := scheduler.NewExpiryScheduler(
+		contractStore,
+		tdClient,
+		cfg.Interbank.MyRoutingNumber,
+		cfg.Interbank.Expiry.Interval,
+		logger,
+	)
+	expiryDone := make(chan error, 1)
+	go func() { expiryDone <- expirySched.Run(ctx) }()
 
 	// -------------------------------------------------------------------------
 	// HTTP server
@@ -339,6 +367,11 @@ func run() error {
 			cancel()
 			return fmt.Errorf("retry scheduler fatal: %w", err)
 		}
+	case err := <-expiryDone:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			cancel()
+			return fmt.Errorf("expiry scheduler fatal: %w", err)
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -354,11 +387,16 @@ func run() error {
 		logger.Error("http server shutdown error", "err", err)
 	}
 
-	// Wait for scheduler goroutine to exit.
+	// Wait for scheduler goroutines to exit.
 	select {
 	case <-schedDone:
 	case <-shutdownCtx.Done():
 		logger.Warn("timed out waiting for retry scheduler to stop")
+	}
+	select {
+	case <-expiryDone:
+	case <-shutdownCtx.Done():
+		logger.Warn("timed out waiting for expiry scheduler to stop")
 	}
 
 	logger.Info("shutdown complete")
@@ -469,6 +507,10 @@ func (a *bcAdapter) ReserveMonas(ctx context.Context, accountNum, currency strin
 
 func (a *bcAdapter) CommitMonas(ctx context.Context, reservationID string) error {
 	return a.c.CommitMonas(ctx, reservationID)
+}
+
+func (a *bcAdapter) CreditMonas(ctx context.Context, accountNum, currency string, amount decimal.Decimal, txIDRouting int, txIDLocal string) error {
+	return a.c.CreditMonas(ctx, accountNum, currency, amount, txIDRouting, txIDLocal)
 }
 
 func (a *bcAdapter) ReleaseMonas(ctx context.Context, reservationID string) error {

--- a/interbank-service/internal/api/otc_outbound.go
+++ b/interbank-service/internal/api/otc_outbound.go
@@ -136,6 +136,82 @@ func (h *OtcOutboundHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// Contracts handles GET /api/interbank/otc/contracts (+ /contracts/my): the
+// buyer-side held option contracts the caller can exercise (S4).
+func (h *OtcOutboundHandler) Contracts(w http.ResponseWriter, r *http.Request) {
+	principalID := extractPrincipalID(r)
+	isAdmin := hasAdminOrSupervisor(r)
+
+	views, err := h.svc.ListContracts(r.Context(), principalID, isAdmin)
+	if err != nil {
+		h.handleOutboundError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, views)
+}
+
+// MyContracts handles GET /api/interbank/otc/contracts/my — always scoped to the
+// caller's own held options (never admin-wide).
+func (h *OtcOutboundHandler) MyContracts(w http.ResponseWriter, r *http.Request) {
+	principalID := extractPrincipalID(r)
+	views, err := h.svc.ListContracts(r.Context(), principalID, false)
+	if err != nil {
+		h.handleOutboundError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, views)
+}
+
+// ExerciseContract handles POST /api/interbank/otc/contracts/{id}/exercise.
+func (h *OtcOutboundHandler) ExerciseContract(w http.ResponseWriter, r *http.Request) {
+	principalID := extractPrincipalID(r)
+	id := chi.URLParam(r, "id")
+
+	// Optional body: { "accountNumber": "111..." } to pin the strike source account.
+	var body struct {
+		AccountNumber string `json:"accountNumber"`
+	}
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body) // empty/absent body is fine
+	}
+
+	if err := h.svc.ExerciseContract(r.Context(), principalID, id, body.AccountNumber); err != nil {
+		h.handleOutboundError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DeclineContract handles POST /api/interbank/otc/contracts/{id}/decline — the
+// buyer "Odbi" action that abandons a held option early.
+func (h *OtcOutboundHandler) DeclineContract(w http.ResponseWriter, r *http.Request) {
+	principalID := extractPrincipalID(r)
+	id := chi.URLParam(r, "id")
+
+	if err := h.svc.DeclineContract(r.Context(), principalID, id); err != nil {
+		h.handleOutboundError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Payment handles POST /api/interbank/otc/payments — an outbound REGULAR inter-bank
+// money transfer (Banka1→Banka2). Backend capability only (no Banka-1 FE — Tim-1
+// scope). Returns 204 on success.
+func (h *OtcOutboundHandler) Payment(w http.ResponseWriter, r *http.Request) {
+	var body service.PaymentBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid body: "+err.Error())
+		return
+	}
+
+	if err := h.svc.PayOutbound(r.Context(), body); err != nil {
+		h.handleOutboundError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // PartnerPublicStock handles GET /api/interbank/otc/public-stock?bankCode=222.
 func (h *OtcOutboundHandler) PartnerPublicStock(w http.ResponseWriter, r *http.Request) {
 	bankCode := 222 // default: Banka 2
@@ -174,6 +250,8 @@ func (h *OtcOutboundHandler) handleOutboundError(w http.ResponseWriter, r *http.
 	case errors.Is(err, service.ErrNegotiationClosed):
 		writeError(w, http.StatusConflict, err.Error())
 	case errors.Is(err, service.ErrNegotiationInvalid):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, service.ErrInsufficientFunds):
 		writeError(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, service.ErrSenderNotParty):
 		writeError(w, http.StatusForbidden, err.Error())

--- a/interbank-service/internal/api/server.go
+++ b/interbank-service/internal/api/server.go
@@ -96,6 +96,14 @@ func NewRouter(d ServerDeps) http.Handler {
 				r.Post("/negotiations/{id}/accept", d.OtcOutbound.Accept)
 				r.Delete("/negotiations/{id}", d.OtcOutbound.Delete)
 				r.Get("/public-stock", d.OtcOutbound.PartnerPublicStock)
+				// Buyer-side held option contracts (S4) + exercise (S7/S8).
+				r.Get("/contracts", d.OtcOutbound.Contracts)
+				r.Get("/contracts/my", d.OtcOutbound.MyContracts)
+				r.Post("/contracts/{id}/exercise", d.OtcOutbound.ExerciseContract)
+				// Buyer "Odbi" — abandon a held option early (S10 decline).
+				r.Post("/contracts/{id}/decline", d.OtcOutbound.DeclineContract)
+				// Outbound regular inter-bank payment (Banka1→Banka2), backend-only.
+				r.Post("/payments", d.OtcOutbound.Payment)
 			})
 		})
 	}
@@ -143,6 +151,14 @@ func NewRouterWithMock(d ServerDeps, mountMock func(chi.Router)) http.Handler {
 				r.Post("/negotiations/{id}/accept", d.OtcOutbound.Accept)
 				r.Delete("/negotiations/{id}", d.OtcOutbound.Delete)
 				r.Get("/public-stock", d.OtcOutbound.PartnerPublicStock)
+				// Buyer-side held option contracts (S4) + exercise (S7/S8).
+				r.Get("/contracts", d.OtcOutbound.Contracts)
+				r.Get("/contracts/my", d.OtcOutbound.MyContracts)
+				r.Post("/contracts/{id}/exercise", d.OtcOutbound.ExerciseContract)
+				// Buyer "Odbi" — abandon a held option early (S10 decline).
+				r.Post("/contracts/{id}/decline", d.OtcOutbound.DeclineContract)
+				// Outbound regular inter-bank payment (Banka1→Banka2), backend-only.
+				r.Post("/payments", d.OtcOutbound.Payment)
 			})
 		})
 	}

--- a/interbank-service/internal/client/banking_core.go
+++ b/interbank-service/internal/client/banking_core.go
@@ -79,11 +79,11 @@ func (c *BankingCoreClient) FindAccountByOwnerAndCurrency(ctx context.Context, o
 // Returns the reservation UUID. Idempotent per (txIDRouting, txIDLocal) on the server.
 func (c *BankingCoreClient) ReserveMonas(ctx context.Context, accountNum, currency string, amount decimal.Decimal, txIDRouting int, txIDLocal string) (string, error) {
 	body := map[string]any{
-		"accountNum":  accountNum,
-		"currency":    currency,
-		"amount":      amount.String(),
-		"txIdRouting": txIDRouting,
-		"txIdLocal":   txIDLocal,
+		"accountNum":           accountNum,
+		"currency":             currency,
+		"amount":               amount.String(),
+		"transactionIdRouting": txIDRouting,
+		"transactionIdLocal":   txIDLocal,
 	}
 	var resp struct {
 		ReservationID string `json:"reservationId"`
@@ -92,6 +92,21 @@ func (c *BankingCoreClient) ReserveMonas(ctx context.Context, accountNum, curren
 		return "", err
 	}
 	return resp.ReservationID, nil
+}
+
+// CreditMonas credits a recipient/seller account during 2PC commit (protocol §2.8.4).
+// It is idempotent per (txRouting, txLocal) and FX-aware on the banking-core side:
+// when the account currency differs from the posting currency, banking-core converts
+// using its bank-pool-leg mechanism. Returns nil on 2xx.
+func (c *BankingCoreClient) CreditMonas(ctx context.Context, accountNum, currency string, amount decimal.Decimal, txRouting int, txLocal string) error {
+	body := map[string]any{
+		"accountNum":  accountNum,
+		"currency":    currency,
+		"amount":      amount.String(),
+		"txIdRouting": txRouting,
+		"txIdLocal":   txLocal,
+	}
+	return c.do(ctx, http.MethodPost, c.baseURL+"/internal/interbank/credit-monas", body, nil)
 }
 
 // CommitMonas permanently debits the reserved amount. Returns nil on 204.

--- a/interbank-service/internal/client/trading.go
+++ b/interbank-service/internal/client/trading.go
@@ -125,6 +125,18 @@ func (c *TradingClient) ReleaseOption(ctx context.Context, negotiationID protoco
 	return c.do(ctx, http.MethodDelete, u, nil, nil)
 }
 
+// CreditPortfolio delivers `quantity` shares of `ticker` into the buyer's
+// portfolio (the buyer-side leg of an inter-bank option EXERCISE). Inverse of the
+// reserve-stock path. Returns nil on 204.
+func (c *TradingClient) CreditPortfolio(ctx context.Context, buyerUserID int64, ticker string, quantity int) error {
+	body := map[string]any{
+		"buyerUserId": buyerUserID,
+		"ticker":      ticker,
+		"quantity":    quantity,
+	}
+	return c.do(ctx, http.MethodPost, c.baseURL+"/internal/interbank/portfolio/credit", body, nil)
+}
+
 func (c *TradingClient) do(ctx context.Context, method, rawURL string, body, out any) error {
 	req, err := buildRequest(ctx, method, rawURL, body)
 	if err != nil {

--- a/interbank-service/internal/config/config.go
+++ b/interbank-service/internal/config/config.go
@@ -70,6 +70,7 @@ type InterbankConfig struct {
 	Services        ServicesConfig
 	Outbound        OutboundConfig
 	Retry           RetryConfig
+	Expiry          ExpiryConfig
 }
 
 // Partner describes a remote bank used for outbound calls and inbound auth.
@@ -108,6 +109,13 @@ type OutboundConfig struct {
 type RetryConfig struct {
 	Interval   time.Duration `envconfig:"INTERVAL" default:"2m"`
 	MaxRetries int           `envconfig:"MAX_RETRIES" default:"5"`
+}
+
+// ExpiryConfig controls the contract-expiry sweeper (S10).
+// Env prefix: INTERBANK_EXPIRY_*.
+type ExpiryConfig struct {
+	// Interval between expiry sweeps. Mirrors the retry scheduler's interval style.
+	Interval time.Duration `envconfig:"INTERVAL" default:"5m"`
 }
 
 // Load reads all INTERBANK_* env vars into a Config struct.

--- a/interbank-service/internal/grpc/handlers_real_test.go
+++ b/interbank-service/internal/grpc/handlers_real_test.go
@@ -42,6 +42,16 @@ func (f *realNegStore) Insert(_ context.Context, n *store.Negotiation) error {
 	return nil
 }
 
+func (f *realNegStore) FindByID(_ context.Context, id string) (*store.Negotiation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if n, ok := f.rows[id]; ok {
+		cp := *n
+		return &cp, nil
+	}
+	return nil, nil
+}
+
 func (f *realNegStore) FindByAuthoritativeRef(_ context.Context, _ int, id string) (*store.Negotiation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/interbank-service/internal/scheduler/expiry.go
+++ b/interbank-service/internal/scheduler/expiry.go
@@ -1,0 +1,129 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// DefaultExpiryInterval is the fallback sweep interval when none is configured.
+const DefaultExpiryInterval = 5 * time.Minute
+
+// ExpiryContractStore is the subset of *store.ContractStore the expiry sweeper needs.
+type ExpiryContractStore interface {
+	// ListExpirable returns ACTIVE contracts whose settlement_date is in the past.
+	ListExpirable(ctx context.Context) ([]*store.Contract, error)
+	// UpdateStatus flips a contract's status (e.g. ACTIVE→EXPIRED).
+	UpdateStatus(ctx context.Context, id, status string) error
+}
+
+// OptionReleaser releases a seller-side option's HELD reservation so the k shares
+// return to free balance. *client.TradingClient (service.TradingReserver) satisfies
+// it via ReleaseOption.
+type OptionReleaser interface {
+	ReleaseOption(ctx context.Context, negotiationID protocol.ForeignBankId) error
+}
+
+// ExpiryScheduler periodically settles expired inter-bank option contracts (S10).
+//
+// Each tick lists every ACTIVE contract past its settlement date and, per contract:
+//   - SELLER side (we host the OPTION pseudo-account): release the seller's HELD
+//     reservation via ReleaseOption (the k shares return to free), then flip
+//     EXPIRED. The premium STAYS with the seller forever (no money is moved).
+//   - BUYER side (the partner hosts the option): the option simply lapses → flip
+//     EXPIRED. For Banka 1 the buyer reserves the strike only at EXERCISE time, so
+//     there is no standing strike reservation to release and no money to refund.
+//
+// The release + status flip is performed per contract; a failure on one contract is
+// logged (one WARN line) and does NOT abort the remaining contracts.
+type ExpiryScheduler struct {
+	store     ExpiryContractStore
+	releaser  OptionReleaser
+	myRouting int
+	log       *slog.Logger
+	interval  time.Duration
+}
+
+// NewExpiryScheduler constructs the sweeper. interval defaults to 5 minutes if zero;
+// releaser may be nil (seller-side release becomes a no-op, status flip still runs).
+func NewExpiryScheduler(s ExpiryContractStore, releaser OptionReleaser, myRouting int, interval time.Duration, log *slog.Logger) *ExpiryScheduler {
+	if interval <= 0 {
+		interval = DefaultExpiryInterval
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ExpiryScheduler{
+		store:     s,
+		releaser:  releaser,
+		myRouting: myRouting,
+		log:       log,
+		interval:  interval,
+	}
+}
+
+// Run blocks until ctx is canceled, ticking every e.interval. It returns ctx.Err()
+// when the context is cancelled. Mirrors RetryScheduler.Run.
+func (e *ExpiryScheduler) Run(ctx context.Context) error {
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			e.tickOnce(ctx)
+		}
+	}
+}
+
+// TickOnce executes one expiry sweep. Exported for testability.
+func (e *ExpiryScheduler) TickOnce(ctx context.Context) {
+	e.tickOnce(ctx)
+}
+
+func (e *ExpiryScheduler) tickOnce(ctx context.Context) {
+	contracts, err := e.store.ListExpirable(ctx)
+	if err != nil {
+		e.log.WarnContext(ctx, "expiry scheduler: ListExpirable error", "err", err)
+		return
+	}
+	if len(contracts) == 0 {
+		return
+	}
+	e.log.InfoContext(ctx, "expiry scheduler: settling expired contracts", "count", len(contracts))
+
+	for _, c := range contracts {
+		e.expireOne(ctx, c)
+	}
+}
+
+// expireOne settles a single expired contract: release the seller reservation (if we
+// are the seller bank), then flip EXPIRED. Errors are logged (one WARN line) and do
+// not propagate, so one bad contract never aborts the sweep.
+func (e *ExpiryScheduler) expireOne(ctx context.Context, c *store.Contract) {
+	if c.LocalPartyType == store.ContractPartySeller {
+		// We host the OPTION pseudo-account — return the seller's HELD k shares to free.
+		if e.releaser != nil {
+			negID := protocol.ForeignBankId{RoutingNumber: e.myRouting, Id: c.NegotiationID}
+			if err := e.releaser.ReleaseOption(ctx, negID); err != nil {
+				e.log.WarnContext(ctx, "expiry scheduler: ReleaseOption failed — skipping status flip for this contract",
+					"contract", c.ID, "neg", c.NegotiationID, "err", err)
+				return
+			}
+		}
+	}
+	// BUYER side: option just lapses; no reservation to release, premium stays with seller.
+
+	if err := e.store.UpdateStatus(ctx, c.ID, store.ContractStatusExpired); err != nil {
+		e.log.WarnContext(ctx, "expiry scheduler: UpdateStatus(EXPIRED) failed",
+			"contract", c.ID, "neg", c.NegotiationID, "party", c.LocalPartyType, "err", err)
+		return
+	}
+	e.log.InfoContext(ctx, "expiry scheduler: contract EXPIRED",
+		"contract", c.ID, "neg", c.NegotiationID, "party", c.LocalPartyType, "ticker", c.StockTicker, "amount", c.Amount)
+}

--- a/interbank-service/internal/scheduler/expiry_test.go
+++ b/interbank-service/internal/scheduler/expiry_test.go
@@ -1,0 +1,138 @@
+package scheduler_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/scheduler"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+type fakeExpiryStore struct {
+	expirable []*store.Contract
+	statuses  map[string]string // contractID → status set
+	failFlip  map[string]bool   // contractID → UpdateStatus returns error
+}
+
+func newFakeExpiryStore(cs ...*store.Contract) *fakeExpiryStore {
+	return &fakeExpiryStore{expirable: cs, statuses: map[string]string{}, failFlip: map[string]bool{}}
+}
+
+func (f *fakeExpiryStore) ListExpirable(_ context.Context) ([]*store.Contract, error) {
+	return f.expirable, nil
+}
+
+func (f *fakeExpiryStore) UpdateStatus(_ context.Context, id, status string) error {
+	if f.failFlip[id] {
+		return errors.New("fakeExpiryStore: UpdateStatus forced failure for " + id)
+	}
+	f.statuses[id] = status
+	return nil
+}
+
+type fakeOptionReleaser struct {
+	released []string // negotiation ids released
+	failNeg  map[string]bool
+}
+
+func newFakeOptionReleaser() *fakeOptionReleaser {
+	return &fakeOptionReleaser{failNeg: map[string]bool{}}
+}
+
+func (f *fakeOptionReleaser) ReleaseOption(_ context.Context, negID protocol.ForeignBankId) error {
+	if f.failNeg[negID.Id] {
+		return errors.New("fakeOptionReleaser: ReleaseOption forced failure for " + negID.Id)
+	}
+	f.released = append(f.released, negID.Id)
+	return nil
+}
+
+const expiryMyRouting = 111
+
+func pastContract(id, neg, party string) *store.Contract {
+	return &store.Contract{
+		ID:             id,
+		NegotiationID:  neg,
+		BuyerRouting:   222,
+		BuyerID:        "C-2",
+		SellerRouting:  111,
+		SellerID:       "C-5",
+		StockTicker:    "AAPL",
+		Amount:         10,
+		StrikeCurrency: "USD",
+		SettlementDate: time.Now().Add(-1 * time.Hour),
+		Status:         store.ContractStatusActive,
+		LocalPartyType: party,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestExpiry_SellerContract_ReleasesReservationAndFlipsExpired(t *testing.T) {
+	st := newFakeExpiryStore(pastContract("otc-sell-1", "neg-sell-1", store.ContractPartySeller))
+	rel := newFakeOptionReleaser()
+	sched := scheduler.NewExpiryScheduler(st, rel, expiryMyRouting, time.Minute, nil)
+
+	sched.TickOnce(context.Background())
+
+	if len(rel.released) != 1 || rel.released[0] != "neg-sell-1" {
+		t.Errorf("expected ReleaseOption(neg-sell-1) for seller contract, got %v", rel.released)
+	}
+	if st.statuses["otc-sell-1"] != store.ContractStatusExpired {
+		t.Errorf("expected seller contract EXPIRED, got %q", st.statuses["otc-sell-1"])
+	}
+}
+
+func TestExpiry_BuyerContract_FlipsExpired_NoMoneyMove(t *testing.T) {
+	st := newFakeExpiryStore(pastContract("otc-buy-1", "neg-buy-1", store.ContractPartyBuyer))
+	rel := newFakeOptionReleaser()
+	sched := scheduler.NewExpiryScheduler(st, rel, expiryMyRouting, time.Minute, nil)
+
+	sched.TickOnce(context.Background())
+
+	// Buyer side must NOT release any option (no standing reservation in Banka 1).
+	if len(rel.released) != 0 {
+		t.Errorf("buyer contract must not release any reservation, got %v", rel.released)
+	}
+	if st.statuses["otc-buy-1"] != store.ContractStatusExpired {
+		t.Errorf("expected buyer contract EXPIRED, got %q", st.statuses["otc-buy-1"])
+	}
+}
+
+func TestExpiry_FailureOnOneContract_DoesNotAbortOthers(t *testing.T) {
+	c1 := pastContract("otc-sell-bad", "neg-bad", store.ContractPartySeller)
+	c2 := pastContract("otc-sell-good", "neg-good", store.ContractPartySeller)
+	st := newFakeExpiryStore(c1, c2)
+	rel := newFakeOptionReleaser()
+	// First contract's release fails — its flip must be skipped, second must still settle.
+	rel.failNeg["neg-bad"] = true
+	sched := scheduler.NewExpiryScheduler(st, rel, expiryMyRouting, time.Minute, nil)
+
+	sched.TickOnce(context.Background())
+
+	if _, flipped := st.statuses["otc-sell-bad"]; flipped {
+		t.Errorf("contract whose release failed must NOT be flipped EXPIRED, got %q", st.statuses["otc-sell-bad"])
+	}
+	if st.statuses["otc-sell-good"] != store.ContractStatusExpired {
+		t.Errorf("second contract must still be EXPIRED despite first failure, got %q", st.statuses["otc-sell-good"])
+	}
+}
+
+func TestExpiry_NoExpirable_NoOp(t *testing.T) {
+	st := newFakeExpiryStore()
+	rel := newFakeOptionReleaser()
+	sched := scheduler.NewExpiryScheduler(st, rel, expiryMyRouting, time.Minute, nil)
+	sched.TickOnce(context.Background()) // must not panic / do nothing
+	if len(rel.released) != 0 || len(st.statuses) != 0 {
+		t.Errorf("expected no work, got released=%v statuses=%v", rel.released, st.statuses)
+	}
+}

--- a/interbank-service/internal/service/coordinator.go
+++ b/interbank-service/internal/service/coordinator.go
@@ -68,17 +68,22 @@ type BankingCoreAccountResolver interface {
 //  6. MarkClosed negotiation + insert contract ACTIVE.
 //  7. OutboundClient.SendCommitTx (best-effort; retry scheduler covers failures).
 type Coordinator struct {
-	myRouting   int
-	executor    *Executor
-	outbound    OutboundClient
-	negStore    NegotiationStoreIface
-	contractSt  ContractStoreIface
-	bcResolver  BankingCoreAccountResolver
-	log         *slog.Logger
+	myRouting  int
+	executor   *Executor
+	outbound   OutboundClient
+	negStore   NegotiationStoreIface
+	contractSt ContractStoreIface
+	bcResolver BankingCoreAccountResolver
+	bc         BankingCoreReserver // strike reserve/commit/release for outbound exercise (S7/S8)
+	td         TradingReserver     // buyer stock delivery (CreditPortfolio) for outbound exercise
+	contracts  ContractWriter      // buyer contract find + EXERCISED flip
+	log        *slog.Logger
 }
 
 // NewCoordinator constructs a Coordinator. bcResolver may be nil — in that case
 // MONAS account resolution falls back to TxAccount.Person (partner resolves).
+// bc/td/contracts power the outbound exercise coordinator (S7/S8); they may be nil
+// in pure-accept tests (ExerciseOutbound then returns an error if invoked).
 func NewCoordinator(
 	myRouting int,
 	executor *Executor,
@@ -86,6 +91,9 @@ func NewCoordinator(
 	negStore NegotiationStoreIface,
 	contractSt ContractStoreIface,
 	bcResolver BankingCoreAccountResolver,
+	bc BankingCoreReserver,
+	td TradingReserver,
+	contracts ContractWriter,
 	log *slog.Logger,
 ) *Coordinator {
 	if log == nil {
@@ -98,6 +106,9 @@ func NewCoordinator(
 		negStore:   negStore,
 		contractSt: contractSt,
 		bcResolver: bcResolver,
+		bc:         bc,
+		td:         td,
+		contracts:  contracts,
 		log:        log,
 	}
 }
@@ -111,8 +122,11 @@ func (c *Coordinator) AcceptNegotiation(ctx context.Context, neg *store.Negotiat
 		partnerRouting = neg.SellerRouting
 	}
 
-	// Total premium = premium_amount (per-unit) × amount.
-	totalPremium := neg.PremiumAmount.Mul(decimal.NewFromInt(int64(neg.Amount)))
+	// Premija je UKUPNA premija ugovora (O.premium, jedan MonetaryValue po §2.8.2 /
+	// §3.6.1) — NE per-unit. Protokol accept posting je "Buyer Credit O.premium" bez
+	// ×amount. neg.PremiumAmount je vec ukupna premija (kako je razmenjena na zici i
+	// kako je vraca negotiation view) — mnozenje sa amount je duplo naplacivanje.
+	totalPremium := neg.PremiumAmount
 	premCurrency := neg.PremiumCurrency
 	strikeCurrency := neg.PriceCurrency
 
@@ -229,6 +243,308 @@ func (c *Coordinator) AcceptNegotiation(ctx context.Context, neg *store.Negotiat
 
 	c.log.InfoContext(ctx, "accepted negotiation — contract ACTIVE",
 		"neg", neg.ID, "contract", contract.ID, "tx", txID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// ExerciseOutbound — BUYER-bank exercise coordinator (S7/S8)
+// ---------------------------------------------------------------------------
+
+// ExerciseOutbound runs the BUYER-bank side of an inter-bank option EXERCISE for a
+// held buyer-side contract. It is the mirror of AcceptNegotiation but for the
+// exercise round:
+//
+//  1. Reserve the buyer's strike (k×pi) on the chosen/auto account (the strike is
+//     reserved at EXERCISE time, not at accept — protocol default).
+//  2. Build the 4-posting EXERCISE tx against the SELLER-bank OPTION account.
+//  3. Send NEW_TX to the seller bank.
+//  4. On partner YES: commit the buyer's strike reservation, deliver the buyer's
+//     shares (CreditPortfolio), send COMMIT_TX, flip the contract → EXERCISED.
+//  5. On partner NO / error: release the strike reservation and roll back the
+//     partner (safe — both sides end clean).
+//
+// chosenAccountNum optionally pins the buyer's source cash account; when empty the
+// account is resolved from (buyerLocalUserID, strikeCurrency).
+func (c *Coordinator) ExerciseOutbound(ctx context.Context, contract *store.Contract, buyerLocalUserID int64, chosenAccountNum string) error {
+	if c.bc == nil || c.td == nil || c.contracts == nil {
+		return fmt.Errorf("%w: exercise coordinator not wired (bc/td/contracts nil)", ErrInterbankProtocol)
+	}
+	sellerRouting := contract.SellerRouting
+	if sellerRouting == c.myRouting {
+		return fmt.Errorf("%w: exercise of a same-bank option is not an inter-bank flow", ErrNegotiationInvalid)
+	}
+
+	k := int64(contract.Amount)
+	kDec := decimal.NewFromInt(k)
+	kPi := contract.StrikeAmount.Mul(kDec)
+	strikeCurrency := contract.StrikeCurrency
+
+	// 1. Resolve and reserve the buyer's strike (k×pi).
+	accountNum := chosenAccountNum
+	if accountNum == "" {
+		num, err := c.bc.FindAccountByOwnerAndCurrency(ctx, buyerLocalUserID, strikeCurrency)
+		if err != nil || num == "" {
+			return fmt.Errorf("%w: resolve buyer %d %s account: %v", ErrNegotiationInvalid, buyerLocalUserID, strikeCurrency, err)
+		}
+		accountNum = num
+	}
+
+	// The OPTION pseudo-account sent to the seller bank must carry the id the SELLER
+	// hosts the option under — its AUTHORITATIVE negotiation id. contract.NegotiationID
+	// is OUR LOCAL interbank_negotiations.id (the FK target); for a buyer-side held
+	// option that is a mirror row whose remote_negotiation_id is the seller's id. Resolve
+	// it so the seller can locate the option (sending our local id would 404 there).
+	remoteNegID, err := c.resolveRemoteNegotiationID(ctx, contract.NegotiationID)
+	if err != nil {
+		return fmt.Errorf("%w: resolve remote negotiation id for %q: %v", ErrInterbankProtocol, contract.NegotiationID, err)
+	}
+
+	txID := protocol.ForeignBankId{RoutingNumber: c.myRouting, Id: generateTxID()}
+	reservationID, err := c.bc.ReserveMonas(ctx, accountNum, strikeCurrency, kPi, txID.RoutingNumber, txID.Id)
+	if err != nil {
+		return fmt.Errorf("%w: reserve buyer strike: %v", ErrInterbankProtocol, err)
+	}
+
+	// 2. Build the 4-posting EXERCISE tx against the seller-bank OPTION account.
+	optionAcc := &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: sellerRouting, Id: remoteNegID}}
+	sellerCashAcc := protocol.TxAccount(&protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: contract.SellerRouting, Id: contract.SellerID}})
+	buyerPerson := &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: contract.BuyerRouting, Id: contract.BuyerID}}
+
+	postings := []protocol.Posting{
+		// p1: Debit OPTION money +k×pi (consumes the buyer's reserved strike).
+		{Account: optionAcc, Amount: kPi, Asset: &protocol.MonasAsset{Currency: strikeCurrency}},
+		// p2: Credit the seller's real cash -k×pi (the strike → seller).
+		{Account: sellerCashAcc, Amount: kPi.Neg(), Asset: &protocol.MonasAsset{Currency: strikeCurrency}},
+		// p3: Credit OPTION stocks -k (releases the seller's reservation).
+		{Account: optionAcc, Amount: kDec.Neg(), Asset: &protocol.StockAsset{Ticker: contract.StockTicker}},
+		// p4: Debit BUYER portfolio +k stocks (delivery).
+		{Account: buyerPerson, Amount: kDec, Asset: &protocol.StockAsset{Ticker: contract.StockTicker}},
+	}
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId:  txID,
+		Postings:       postings,
+		Message:        "OTC exercise for negotiation " + remoteNegID,
+		PaymentCode:    "289",
+		PaymentPurpose: "OTC option exercise — strike + stock delivery",
+	}
+
+	// 3. Send NEW_TX to the seller bank (the seller hosts the OPTION account).
+	partnerVote, err := c.outbound.SendNewTx(ctx, sellerRouting, tx)
+	if err != nil {
+		c.releaseStrike(ctx, reservationID)
+		return fmt.Errorf("%w: partner prepare exception: %v", ErrInterbankProtocol, err)
+	}
+	if partnerVote.Vote != protocol.VoteYes {
+		c.releaseStrike(ctx, reservationID)
+		c.safeRollbackPartner(ctx, sellerRouting, txID)
+		return fmt.Errorf("%w: partner rejected exercise: %v", ErrInterbankProtocol, partnerVote.Reasons)
+	}
+
+	// 4a. Commit the buyer's strike reservation (money leaves the buyer).
+	if err := c.bc.CommitMonas(ctx, reservationID); err != nil {
+		c.safeRollbackPartner(ctx, sellerRouting, txID)
+		return fmt.Errorf("%w: commit buyer strike: %v", ErrInterbankProtocol, err)
+	}
+
+	// 4b. Deliver the buyer's shares.
+	if err := c.td.CreditPortfolio(ctx, buyerLocalUserID, contract.StockTicker, int(k)); err != nil {
+		// The strike is committed and the partner voted YES; we cannot cleanly undo.
+		// Log loudly — the contract stays ACTIVE so a retry/manual fix is possible.
+		c.log.ErrorContext(ctx, "exercise: buyer stock delivery failed AFTER strike commit — manual reconciliation needed",
+			"neg", contract.NegotiationID, "buyer", buyerLocalUserID, "err", err)
+		c.safeRollbackPartner(ctx, sellerRouting, txID)
+		return fmt.Errorf("%w: buyer stock delivery: %v", ErrInterbankProtocol, err)
+	}
+
+	// 4c. Partner commit — best-effort (retry scheduler covers a transient failure).
+	if err := c.outbound.SendCommitTx(ctx, sellerRouting, txID); err != nil {
+		c.log.WarnContext(ctx, "exercise: SendCommitTx to seller bank failed — retry scheduler will pick it up",
+			"sellerRouting", sellerRouting, "txID", txID, "err", err)
+	}
+
+	// 4d. Flip the buyer contract → EXERCISED.
+	if err := c.contracts.UpdateStatus(ctx, contract.ID, store.ContractStatusExercised); err != nil {
+		c.log.ErrorContext(ctx, "exercise: failed to flip buyer contract EXERCISED (settlement already done)",
+			"contract", contract.ID, "err", err)
+	}
+
+	c.log.InfoContext(ctx, "exercised buyer option — contract EXERCISED",
+		"neg", contract.NegotiationID, "contract", contract.ID, "tx", txID)
+	return nil
+}
+
+func (c *Coordinator) releaseStrike(ctx context.Context, reservationID string) {
+	if reservationID == "" {
+		return
+	}
+	if err := c.bc.ReleaseMonas(ctx, reservationID); err != nil {
+		c.log.WarnContext(ctx, "exercise: releaseStrike failed", "reservationID", reservationID, "err", err)
+	}
+}
+
+// resolveRemoteNegotiationID maps a contract's LOCAL negotiation id to the
+// authoritative id the partner (seller) bank hosts the option under, so the
+// outbound EXERCISE tx addresses an OPTION account the seller can locate.
+//
+//   - mirror row (we are the buyer; partner is authoritative): the negotiation's
+//     remote_negotiation_id IS the seller's id → return it.
+//   - authoritative row (we host the negotiation): the partner mirrors us by our
+//     own id → return localNegID unchanged.
+//
+// When negStore is nil or the row is not found, fall back to localNegID — the
+// pre-existing behaviour — so same-bank/test wiring keeps working.
+func (c *Coordinator) resolveRemoteNegotiationID(ctx context.Context, localNegID string) (string, error) {
+	if c.negStore == nil {
+		return localNegID, nil
+	}
+	// MORA biti FindByID (po LOKALNOM id-u): contract.NegotiationID je nas lokalni id.
+	// FindByAuthoritativeRef mapira mirror SAMO po remote_negotiation_id, pa za mirror
+	// pozvan sa lokalnim id-om vraca nil -> fallback na lokalni id -> pogresan id na zici
+	// (partner glasa OPTION_NEGOTIATION_NOT_FOUND). FindByID nalazi mirror po njegovom id-u.
+	neg, err := c.negStore.FindByID(ctx, localNegID)
+	if err != nil {
+		return "", err
+	}
+	if neg == nil {
+		// No local row maps to this id — keep the id as-is rather than fail; the
+		// seller-side prepare validation will reject if it is genuinely unknown.
+		return localNegID, nil
+	}
+	if !neg.IsAuthoritative && neg.RemoteNegotiationID != nil && *neg.RemoteNegotiationID != "" {
+		return *neg.RemoteNegotiationID, nil
+	}
+	return neg.ID, nil
+}
+
+// ---------------------------------------------------------------------------
+// ExecutePayment — outbound REGULAR inter-bank payment coordinator (Banka1→Banka2)
+// ---------------------------------------------------------------------------
+
+// PaymentRequest is the input to ExecutePayment: a plain cross-bank money transfer
+// from one of our 18-digit accounts to a person/account at the target bank.
+type PaymentRequest struct {
+	FromAccount string          // our 18-digit sender account
+	ToRouting   int             // target bank routing number
+	ToAccount   string          // recipient id at the target bank (their account/person id)
+	Amount      decimal.Decimal // positive amount in Currency
+	Currency    string          // ISO currency of the transfer
+	Purpose     string          // free-text payment purpose
+}
+
+// ExecutePayment runs the 2PC coordinator for a REGULAR (non-OTC) inter-bank
+// payment. It mirrors the OTC accept coordinator's prepare/commit/rollback
+// structure but without any negotiation/contract steps — just a balanced two-posting
+// money transfer:
+//
+//	a) sender CREDIT (−amount) on OUR real account  → reserved on PrepareLocal,
+//	   committed on CommitLocal.
+//	b) recipient DEBIT (+amount) on the target bank's account → the partner
+//	   credits it on their own commit.
+//
+// Flow:
+//  1. Synchronous FX-aware sufficient-funds guard BEFORE any reservation (clean 4xx).
+//  2. PrepareLocal (reserve sender) → SendNewTx(targetRouting) (partner prepare).
+//  3. On partner YES: CommitLocal + SendCommitTx (best-effort; retry scheduler covers).
+//  4. On partner NO / error: release the sender reservation (RollbackLocal) and send
+//     ROLLBACK_TX — both sides end clean.
+func (c *Coordinator) ExecutePayment(ctx context.Context, req PaymentRequest) error {
+	if c.bc == nil {
+		return fmt.Errorf("%w: payment coordinator not wired (bc nil)", ErrInterbankProtocol)
+	}
+	if req.ToRouting == c.myRouting {
+		return fmt.Errorf("%w: toRouting must not be our own routing (%d) — this is an inter-bank payment",
+			ErrNegotiationInvalid, c.myRouting)
+	}
+	if req.FromAccount == "" || req.ToAccount == "" {
+		return fmt.Errorf("%w: fromAccount and toAccount are required", ErrNegotiationInvalid)
+	}
+	if req.Amount.IsZero() || req.Amount.IsNegative() {
+		return fmt.Errorf("%w: amount must be positive", ErrNegotiationInvalid)
+	}
+	if req.Currency == "" {
+		return fmt.Errorf("%w: currency is required", ErrNegotiationInvalid)
+	}
+
+	// 1. Funds guard — resolve the sender account and verify same-currency cover.
+	//    A foreign-currency sender leg cannot be debited here without conversion
+	//    (out of this wave's scope, mirroring validateRealAccount), so we require the
+	//    sender account currency to match the transfer currency before reserving.
+	info, err := c.bc.ResolveAccount(ctx, req.FromAccount)
+	if err != nil {
+		return fmt.Errorf("%w: resolve sender account %s: %v", ErrNegotiationInvalid, req.FromAccount, err)
+	}
+	if info == nil {
+		return fmt.Errorf("%w: sender account %s not found", ErrNegotiationInvalid, req.FromAccount)
+	}
+	if info.Currency != req.Currency {
+		return fmt.Errorf("%w: sender account %s holds %s, cannot pay %s without conversion",
+			ErrNegotiationInvalid, req.FromAccount, info.Currency, req.Currency)
+	}
+	if info.AvailableBalance.LessThan(req.Amount) {
+		return fmt.Errorf("%w: sender account %s available %s < amount %s",
+			ErrInsufficientFunds, req.FromAccount, info.AvailableBalance, req.Amount)
+	}
+
+	// 2. Build the balanced 2-posting payment tx.
+	// Primalac je POZNAT broj racuna na partnerskoj banci → RealAccount{Num} (type=ACCOUNT),
+	// NE PersonAccount (to bi gurnulo broj racuna u Person id pa bi partner pokusao da
+	// ga razresi kao client-id → NO_SUCH_ACCOUNT). Partner kredituje RealAccount po prefiksu
+	// (prve 3 cifre = njegov routing); isto kao nas outbound (TxAccount.Account) i kao
+	// Banka-1 sopstveni inbound credit (resolveCreditAccount podrzava RealAccount).
+	senderAcc := &protocol.RealAccount{Num: req.FromAccount}
+	recipient := &protocol.RealAccount{Num: req.ToAccount}
+	postings := []protocol.Posting{
+		// a) Sender CREDIT (−amount): money leaves our account.
+		{Account: senderAcc, Amount: req.Amount.Neg(), Asset: &protocol.MonasAsset{Currency: req.Currency}},
+		// b) Recipient DEBIT (+amount): partner credits the recipient on commit.
+		{Account: recipient, Amount: req.Amount, Asset: &protocol.MonasAsset{Currency: req.Currency}},
+	}
+
+	txID := protocol.ForeignBankId{RoutingNumber: c.myRouting, Id: generateTxID()}
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId:  txID,
+		Postings:       postings,
+		Message:        "Inter-bank payment from " + req.FromAccount,
+		PaymentCode:    "289",
+		PaymentPurpose: req.Purpose,
+	}
+
+	// 3. PrepareLocal — reserve the sender.
+	localVote, err := c.executor.PrepareLocal(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("%w: local prepare infra failure: %v", ErrInterbankProtocol, err)
+	}
+	if localVote.Vote != protocol.VoteYes {
+		return fmt.Errorf("%w: local prepare rejected: %v", ErrInterbankProtocol, localVote.Reasons)
+	}
+
+	// 4. Partner prepare.
+	partnerVote, err := c.outbound.SendNewTx(ctx, req.ToRouting, tx)
+	if err != nil {
+		c.safeRollbackLocal(ctx, txID)
+		return fmt.Errorf("%w: partner prepare exception: %v", ErrInterbankProtocol, err)
+	}
+	if partnerVote.Vote != protocol.VoteYes {
+		c.safeRollbackLocal(ctx, txID)
+		c.safeRollbackPartner(ctx, req.ToRouting, txID)
+		return fmt.Errorf("%w: partner rejected payment: %v", ErrInterbankProtocol, partnerVote.Reasons)
+	}
+
+	// 5. CommitLocal — finalize the sender debit.
+	if err := c.executor.CommitLocal(ctx, txID); err != nil {
+		c.safeRollbackPartner(ctx, req.ToRouting, txID)
+		return fmt.Errorf("%w: catastrophic commitLocal failure: %v", ErrInterbankProtocol, err)
+	}
+
+	// 6. Partner commit — best-effort (retry scheduler covers a transient failure).
+	if err := c.outbound.SendCommitTx(ctx, req.ToRouting, txID); err != nil {
+		c.log.WarnContext(ctx, "payment: SendCommitTx to partner failed — retry scheduler will pick it up",
+			"toRouting", req.ToRouting, "txID", txID, "err", err)
+	}
+
+	c.log.InfoContext(ctx, "executed outbound inter-bank payment",
+		"from", req.FromAccount, "toRouting", req.ToRouting, "toAccount", req.ToAccount,
+		"amount", req.Amount, "currency", req.Currency, "tx", txID)
 	return nil
 }
 

--- a/interbank-service/internal/service/coordinator_exercise_test.go
+++ b/interbank-service/internal/service/coordinator_exercise_test.go
@@ -1,0 +1,230 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// ExerciseOutbound (S7/S8) — buyer-bank exercise coordinator.
+
+func buildExerciseCoordinator(outbound OutboundClient, bc *fakeBankingCoreReserver, td *fakeTradingReserver, cw *fakeContractWriter) *Coordinator {
+	return buildExerciseCoordinatorWithNegStore(outbound, bc, td, cw, newFakeNegotiationStore())
+}
+
+func buildExerciseCoordinatorWithNegStore(outbound OutboundClient, bc *fakeBankingCoreReserver, td *fakeTradingReserver, cw *fakeContractWriter, negStore *fakeNegotiationStore) *Coordinator {
+	es := newCoordExecStore()
+	negLookup := NewNegotiationSellerLookup(newFakeNegotiationStore())
+	exec := NewExecutor(myRouting, es, bc, td, negLookup, nil)
+	return NewCoordinator(myRouting, exec, outbound, negStore, &fakeContractStore{}, bc, bc, td, cw, nil)
+}
+
+func buyerExerciseContract() *store.Contract {
+	return &store.Contract{
+		ID:             "otc-buy-1",
+		NegotiationID:  "neg-buy-1",
+		BuyerRouting:   myRouting,
+		BuyerID:        "C-7",
+		SellerRouting:  theirRouting,
+		SellerID:       "C-2",
+		StockTicker:    "AAPL",
+		Amount:         10,
+		StrikeCurrency: "USD",
+		StrikeAmount:   decimal.NewFromInt(150),
+		SettlementDate: time.Now().Add(24 * time.Hour),
+		Status:         store.ContractStatusActive,
+		LocalPartyType: store.ContractPartyBuyer,
+	}
+}
+
+func TestExerciseOutbound_HappyPath(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000007": {Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(7, "USD"): "111000000000000007"}
+	td := &fakeTradingReserver{}
+	cw := newFakeContractWriter()
+	c := buyerExerciseContract()
+	cw.byNeg["neg-buy-1"] = c
+	outbound := &fakeOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildExerciseCoordinator(outbound, bc, td, cw)
+
+	if err := coord.ExerciseOutbound(context.Background(), c, 7, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Strike reserved (k*pi = 1500) then committed.
+	if len(bc.reserved) != 1 {
+		t.Errorf("expected 1 strike reservation, got %v", bc.reserved)
+	}
+	if len(bc.committed) != 1 {
+		t.Errorf("expected the strike reservation committed, got %v", bc.committed)
+	}
+	if len(bc.released) != 0 {
+		t.Errorf("strike must not be released on the happy path, got %v", bc.released)
+	}
+	// Buyer shares delivered (k = 10).
+	if len(td.creditedPortfolio) != 1 || td.creditedPortfolio[0].quantity != 10 ||
+		td.creditedPortfolio[0].ticker != "AAPL" || td.creditedPortfolio[0].buyerUserID != 7 {
+		t.Errorf("expected CreditPortfolio(7, AAPL, 10), got %v", td.creditedPortfolio)
+	}
+	// Partner committed + contract EXERCISED.
+	if !outbound.committed {
+		t.Error("expected SendCommitTx to the seller bank")
+	}
+	if cw.statuses["otc-buy-1"] != store.ContractStatusExercised {
+		t.Errorf("expected contract EXERCISED, got %v", cw.statuses)
+	}
+}
+
+func TestExerciseOutbound_BalancedExerciseTx(t *testing.T) {
+	// Capture the tx the coordinator builds and verify it is a balanced 4-posting
+	// EXERCISE tx: OPTION money +1500, seller cash -1500, OPTION stock -10, buyer +10.
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000007": {Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(7, "USD"): "111000000000000007"}
+	td := &fakeTradingReserver{}
+	cw := newFakeContractWriter()
+	c := buyerExerciseContract()
+	cw.byNeg["neg-buy-1"] = c
+	cap := &capturingOutbound{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildExerciseCoordinator(cap, bc, td, cw)
+
+	if err := coord.ExerciseOutbound(context.Background(), c, 7, "111000000000000007"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v := NewValidator(myRouting, nil, nil, nil)
+	if reasons := v.BalanceCheck(cap.tx.Postings); len(reasons) != 0 {
+		t.Fatalf("exercise tx must be balanced, got %v", reasons)
+	}
+	if len(cap.tx.Postings) != 4 {
+		t.Fatalf("expected 4 postings, got %d", len(cap.tx.Postings))
+	}
+	var optMoney, optStock, sellerCash, buyerStock *protocol.Posting
+	for i := range cap.tx.Postings {
+		p := &cap.tx.Postings[i]
+		switch p.Account.(type) {
+		case *protocol.OptionPseudoAccount:
+			if _, ok := p.Asset.(*protocol.MonasAsset); ok {
+				optMoney = p
+			} else {
+				optStock = p
+			}
+		case *protocol.PersonAccount:
+			if _, ok := p.Asset.(*protocol.MonasAsset); ok {
+				sellerCash = p
+			} else {
+				buyerStock = p
+			}
+		}
+	}
+	if optMoney == nil || optMoney.Amount.String() != "1500" {
+		t.Errorf("OPTION money debit must be +1500, got %v", optMoney)
+	}
+	if optStock == nil || optStock.Amount.String() != "-10" {
+		t.Errorf("OPTION stock credit must be -10, got %v", optStock)
+	}
+	if sellerCash == nil || sellerCash.Amount.String() != "-1500" {
+		t.Errorf("seller cash credit must be -1500, got %v", sellerCash)
+	}
+	if buyerStock == nil || buyerStock.Amount.String() != "10" {
+		t.Errorf("buyer stock delivery must be +10, got %v", buyerStock)
+	}
+}
+
+// TestExerciseOutbound_UsesRemoteNegotiationID verifies the buyer-bank exercise sends
+// the SELLER's authoritative negotiation id (our remote_negotiation_id) on the OPTION
+// pseudo-account, even though the local contract is keyed on our LOCAL negotiation id.
+// This is the exercise-side counterpart of the FK fix: the contract now stores the local
+// id (FK target), so the coordinator must resolve it to the remote id for the wire.
+func TestExerciseOutbound_UsesRemoteNegotiationID(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000007": {Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(7, "USD"): "111000000000000007"}
+	td := &fakeTradingReserver{}
+	cw := newFakeContractWriter()
+	c := buyerExerciseContract()
+	c.NegotiationID = "neg-local-buy-1" // OUR local id (FK target)
+	cw.byNeg["neg-local-buy-1"] = c
+
+	// Seed the local mirror row: local id "neg-local-buy-1" → remote "318222f9-remote".
+	negStore := newFakeNegotiationStore()
+	remote := "318222f9-remote"
+	_ = negStore.Insert(context.Background(), &store.Negotiation{
+		ID:                  "neg-local-buy-1",
+		IsAuthoritative:     false,
+		RemoteNegotiationID: &remote,
+		SellerRouting:       theirRouting,
+	})
+
+	cap := &capturingOutbound{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildExerciseCoordinatorWithNegStore(cap, bc, td, cw, negStore)
+
+	if err := coord.ExerciseOutbound(context.Background(), c, 7, "111000000000000007"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The OPTION pseudo-account id sent to the seller MUST be the remote id, not our local id.
+	var optID string
+	for i := range cap.tx.Postings {
+		if opt, ok := cap.tx.Postings[i].Account.(*protocol.OptionPseudoAccount); ok {
+			optID = opt.Id.Id
+			break
+		}
+	}
+	if optID != remote {
+		t.Fatalf("OPTION account must carry the remote negotiation id %q (seller hosts it); got %q", remote, optID)
+	}
+}
+
+func TestExerciseOutbound_PartnerRejects_ReleasesStrike(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000007": {Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(7, "USD"): "111000000000000007"}
+	td := &fakeTradingReserver{}
+	cw := newFakeContractWriter()
+	c := buyerExerciseContract()
+	cw.byNeg["neg-buy-1"] = c
+	outbound := &fakeOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteNo, Reasons: []protocol.NoVoteReason{{Reason: protocol.ReasonOptionUsedOrExpired}}}}
+	coord := buildExerciseCoordinator(outbound, bc, td, cw)
+
+	err := coord.ExerciseOutbound(context.Background(), c, 7, "")
+	if err == nil {
+		t.Fatal("expected error when partner rejects exercise")
+	}
+	// Strike must be released; nothing committed; no shares delivered.
+	if len(bc.released) != 1 {
+		t.Errorf("expected strike released on partner reject, got %v", bc.released)
+	}
+	if len(bc.committed) != 0 {
+		t.Errorf("strike must NOT be committed on reject, got %v", bc.committed)
+	}
+	if len(td.creditedPortfolio) != 0 {
+		t.Errorf("no shares should be delivered on reject, got %v", td.creditedPortfolio)
+	}
+	if !outbound.rolledBack {
+		t.Error("expected partner rollback on reject")
+	}
+	if cw.statuses["otc-buy-1"] == store.ContractStatusExercised {
+		t.Error("contract must NOT be EXERCISED on reject")
+	}
+}
+
+// capturingOutbound records the tx sent via SendNewTx for posting assertions.
+type capturingOutbound struct {
+	vote       protocol.TransactionVote
+	tx         protocol.InterbankTransactionPayload
+	committed  bool
+	rolledBack bool
+}
+
+func (f *capturingOutbound) SendNewTx(_ context.Context, _ int, tx protocol.InterbankTransactionPayload) (protocol.TransactionVote, error) {
+	f.tx = tx
+	return f.vote, nil
+}
+func (f *capturingOutbound) SendCommitTx(_ context.Context, _ int, _ protocol.ForeignBankId) error {
+	f.committed = true
+	return nil
+}
+func (f *capturingOutbound) SendRollbackTx(_ context.Context, _ int, _ protocol.ForeignBankId) error {
+	f.rolledBack = true
+	return nil
+}

--- a/interbank-service/internal/service/coordinator_test.go
+++ b/interbank-service/internal/service/coordinator_test.go
@@ -130,6 +130,9 @@ func (fakeTDReserver) ReserveOption(_ context.Context, _ protocol.ForeignBankId,
 }
 func (fakeTDReserver) ExerciseOption(_ context.Context, _ protocol.ForeignBankId) error { return nil }
 func (fakeTDReserver) ReleaseOption(_ context.Context, _ protocol.ForeignBankId) error  { return nil }
+func (fakeTDReserver) CreditPortfolio(_ context.Context, _ int64, _ string, _ int) error {
+	return nil
+}
 
 // fakeBCReserverFull implements BankingCoreReserver with correct signatures.
 type fakeBCReserverFull struct{}
@@ -147,6 +150,9 @@ func (f fakeBCReserverFull) ReserveMonas(ctx context.Context, accountNum, curren
 }
 
 func (f fakeBCReserverFull) CommitMonas(ctx context.Context, reservationID string) error { return nil }
+func (f fakeBCReserverFull) CreditMonas(ctx context.Context, accountNum, currency string, amount decimal.Decimal, txIDRouting int, txIDLocal string) error {
+	return nil
+}
 func (f fakeBCReserverFull) ReleaseMonas(ctx context.Context, reservationID string) error { return nil }
 
 // ---------------------------------------------------------------------------
@@ -183,7 +189,7 @@ func buildCoordinator(outbound OutboundClient, negStore NegotiationStoreIface, c
 	// Wire NegotiationSellerLookup so the Validator can resolve option negotiations.
 	negLookup := NewNegotiationSellerLookup(negStore)
 	exec := NewExecutor(myRouting, es, fakeBCReserverFull{}, fakeTDReserver{}, negLookup, nil)
-	return NewCoordinator(myRouting, exec, outbound, negStore, contractSt, fakeBCReserverFull{}, nil)
+	return NewCoordinator(myRouting, exec, outbound, negStore, contractSt, fakeBCReserverFull{}, nil, nil, nil, nil)
 }
 
 // ---------------------------------------------------------------------------
@@ -280,5 +286,163 @@ func TestCoordinator_CommitTxSendFailure_NonFatal(t *testing.T) {
 	}
 	if len(cs.inserted) == 0 {
 		t.Error("contract must be inserted even if SendCommitTx fails")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ExecutePayment — outbound REGULAR inter-bank payment coordinator (Banka1→Banka2)
+// ---------------------------------------------------------------------------
+
+// buildPaymentCoordinator wires a coordinator whose executor + bc share the same
+// map-backed fakeBankingCoreReserver so the funds guard (ResolveAccount), the
+// sender reservation (ReserveMonas), commit (CommitMonas) and release (ReleaseMonas)
+// all land on one fake we can assert against.
+func buildPaymentCoordinator(outbound OutboundClient, bc *fakeBankingCoreReserver) *Coordinator {
+	es := newCoordExecStore()
+	negLookup := NewNegotiationSellerLookup(newFakeNegotiationStore())
+	exec := NewExecutor(myRouting, es, bc, &fakeTradingReserver{}, negLookup, nil)
+	return NewCoordinator(myRouting, exec, outbound, newFakeNegotiationStore(), &fakeContractStore{}, bc, bc, &fakeTradingReserver{}, newFakeContractWriter(), nil)
+}
+
+func paymentReq() PaymentRequest {
+	return PaymentRequest{
+		FromAccount: "111000000000000015",
+		ToRouting:   theirRouting,
+		ToAccount:   "222000000000000099",
+		Amount:      decimal.NewFromInt(500),
+		Currency:    "USD",
+		Purpose:     "rent",
+	}
+}
+
+func TestExecutePayment_HappyPath_BalancedTxCommits(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)},
+	})
+	cap := &capturingOutbound{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildPaymentCoordinator(cap, bc)
+
+	if err := coord.ExecutePayment(context.Background(), paymentReq()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Built tx must be a balanced 2-posting payment.
+	v := NewValidator(myRouting, nil, nil, nil)
+	if reasons := v.BalanceCheck(cap.tx.Postings); len(reasons) != 0 {
+		t.Fatalf("payment tx must be balanced, got %v", reasons)
+	}
+	if len(cap.tx.Postings) != 2 {
+		t.Fatalf("expected 2 postings, got %d", len(cap.tx.Postings))
+	}
+	// Sender debited via reservation-commit; nothing released.
+	if len(bc.reserved) != 1 || len(bc.committed) != 1 || len(bc.released) != 0 {
+		t.Errorf("expected reserve+commit (no release): reserved=%v committed=%v released=%v", bc.reserved, bc.committed, bc.released)
+	}
+	if !cap.committed {
+		t.Error("expected SendCommitTx to partner")
+	}
+	// Recipient is partner-side; we must NOT credit it locally.
+	if len(bc.credited) != 0 {
+		t.Errorf("recipient is partner-side — no local credit expected, got %v", bc.credited)
+	}
+}
+
+// TestExecutePayment_RecipientIsRealAccount is the RealAccount red-proof: the
+// recipient posting MUST be a *protocol.RealAccount (type=ACCOUNT) carrying the
+// raw ToAccount number, NOT a *protocol.PersonAccount (which would make the partner
+// try to resolve the account number as a client-id → NO_SUCH_ACCOUNT — a live-test
+// failure). Both legs are RealAccount, so sender vs recipient is told apart by the
+// account number rather than the type. Flipping recipient to PersonAccount in
+// coordinator.go makes THIS test fail.
+func TestExecutePayment_RecipientIsRealAccount(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)},
+	})
+	cap := &capturingOutbound{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildPaymentCoordinator(cap, bc)
+	if err := coord.ExecutePayment(context.Background(), paymentReq()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var sender, recipient *protocol.Posting
+	for i := range cap.tx.Postings {
+		p := &cap.tx.Postings[i]
+		ra, ok := p.Account.(*protocol.RealAccount)
+		if !ok {
+			t.Fatalf("every payment posting must be a *protocol.RealAccount, got %T", p.Account)
+		}
+		switch ra.Num {
+		case "111000000000000015":
+			sender = p
+		case "222000000000000099":
+			recipient = p
+		default:
+			t.Fatalf("unexpected account number %q in posting", ra.Num)
+		}
+	}
+	if recipient == nil {
+		t.Fatal("recipient posting (RealAccount{Num: ToAccount}) not found — recipient must be a RealAccount, not a PersonAccount")
+	}
+	// Directions: sender CREDIT (−amount), recipient DEBIT (+amount).
+	if sender == nil || sender.Amount.String() != "-500" {
+		t.Errorf("sender CREDIT must be -500 on RealAccount sender, got %v", sender)
+	}
+	if recipient.Amount.String() != "500" {
+		t.Errorf("recipient DEBIT must be +500 on RealAccount recipient, got %v", recipient)
+	}
+}
+
+func TestExecutePayment_PartnerRejects_SafeRollback(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)},
+	})
+	outbound := &fakeOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteNo, Reasons: []protocol.NoVoteReason{{Reason: protocol.ReasonNoSuchAccount}}}}
+	coord := buildPaymentCoordinator(outbound, bc)
+
+	err := coord.ExecutePayment(context.Background(), paymentReq())
+	if err == nil {
+		t.Fatal("expected error when partner rejects payment")
+	}
+	// Sender reservation must be released; never committed.
+	if len(bc.reserved) != 1 || len(bc.released) != 1 || len(bc.committed) != 0 {
+		t.Errorf("expected reserve+release (no commit): reserved=%v released=%v committed=%v", bc.reserved, bc.released, bc.committed)
+	}
+	if !outbound.rolledBack {
+		t.Error("expected partner ROLLBACK_TX on reject")
+	}
+}
+
+func TestExecutePayment_InsufficientFunds_NoReservation(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(100)}, // < 500
+	})
+	cap := &capturingOutbound{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildPaymentCoordinator(cap, bc)
+
+	err := coord.ExecutePayment(context.Background(), paymentReq())
+	if !errors.Is(err, ErrInsufficientFunds) {
+		t.Fatalf("expected ErrInsufficientFunds, got %v", err)
+	}
+	// Guard runs BEFORE any reservation and before contacting the partner.
+	if len(bc.reserved) != 0 {
+		t.Errorf("no reservation must be made on insufficient funds, got %v", bc.reserved)
+	}
+	if cap.tx.TransactionId.Id != "" {
+		t.Errorf("partner must not be contacted on insufficient funds, got tx %v", cap.tx.TransactionId)
+	}
+}
+
+func TestExecutePayment_CurrencyMismatch_Rejected(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000015": {Currency: "EUR", AvailableBalance: decimal.NewFromInt(100000)},
+	})
+	outbound := &fakeOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildPaymentCoordinator(outbound, bc)
+
+	err := coord.ExecutePayment(context.Background(), paymentReq()) // USD vs EUR account
+	if !errors.Is(err, ErrNegotiationInvalid) {
+		t.Fatalf("expected ErrNegotiationInvalid for currency mismatch, got %v", err)
+	}
+	if len(bc.reserved) != 0 {
+		t.Errorf("no reservation on currency mismatch, got %v", bc.reserved)
 	}
 }

--- a/interbank-service/internal/service/errors.go
+++ b/interbank-service/internal/service/errors.go
@@ -35,4 +35,8 @@ var (
 	// ErrInterbankProtocol signals a protocol-level failure during 2PC
 	// (e.g. local prepare failed, partner rejected, catastrophic commit).
 	ErrInterbankProtocol = errors.New("service: inter-bank protocol failure")
+
+	// ErrInsufficientFunds is returned by the outbound regular-payment funds guard
+	// when the sender account cannot cover the requested amount. Mapped to 400.
+	ErrInsufficientFunds = errors.New("service: insufficient funds")
 )

--- a/interbank-service/internal/service/executor.go
+++ b/interbank-service/internal/service/executor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/shopspring/decimal"
 
@@ -46,6 +47,9 @@ type BankingCoreReserver interface {
 	CommitMonas(ctx context.Context, reservationID string) error
 	// ReleaseMonas frees a previously reserved amount back to available balance.
 	ReleaseMonas(ctx context.Context, reservationID string) error
+	// CreditMonas credits a recipient/seller account on commit (protocol §2.8.4).
+	// Idempotent per (txIDRouting, txIDLocal) and FX-aware on the banking-core side.
+	CreditMonas(ctx context.Context, accountNum, currency string, amount decimal.Decimal, txIDRouting int, txIDLocal string) error
 }
 
 // TradingReserver provides stock and option reservation actions toward
@@ -60,10 +64,27 @@ type TradingReserver interface {
 	ReleaseStock(ctx context.Context, reservationID string) error
 	// ReserveOption marks an option contract as reserved (idempotent per spec §3.6).
 	ReserveOption(ctx context.Context, negotiationID protocol.ForeignBankId, sellerForeignID, ticker string, quantity int) error
-	// ExerciseOption marks an option contract as exercised (spec §2.7.2).
+	// ExerciseOption marks an option contract as exercised (spec §2.7.2): commits
+	// the seller's HELD stock reservation (removes the k shares) and flips the
+	// option to EXERCISED. Run ONLY from the real exercise round, never on accept.
 	ExerciseOption(ctx context.Context, negotiationID protocol.ForeignBankId) error
 	// ReleaseOption frees an option reservation.
 	ReleaseOption(ctx context.Context, negotiationID protocol.ForeignBankId) error
+	// CreditPortfolio delivers `quantity` shares of `ticker` into the buyer's
+	// portfolio — the buyer-side leg of an inter-bank option EXERCISE.
+	CreditPortfolio(ctx context.Context, buyerUserID int64, ticker string, quantity int) error
+}
+
+// ContractWriter is the persistence seam the Executor uses to persist buyer-side
+// option contracts (S4) and to flip a contract to EXERCISED after settlement (S9).
+// Production wiring adapts *store.ContractStore; tests use an in-memory fake.
+type ContractWriter interface {
+	// Insert persists a new contract row.
+	Insert(ctx context.Context, c *store.Contract) error
+	// FindByNegotiationID returns (nil, nil) when no contract matches.
+	FindByNegotiationID(ctx context.Context, negotiationID string) (*store.Contract, error)
+	// UpdateStatus flips a contract's status (e.g. ACTIVE→EXERCISED).
+	UpdateStatus(ctx context.Context, id, status string) error
 }
 
 // OptionNegotiationLookup resolves an option negotiation to its seller foreign-id.
@@ -73,6 +94,24 @@ type OptionNegotiationLookup interface {
 	// FindSellerID returns the seller's foreign-id string for the given negotiation id.
 	// Returns a non-nil error (and empty string) when the negotiation is not found.
 	FindSellerID(ctx context.Context, negID string) (string, error)
+
+	// ResolveLocalNegotiationID maps a negotiation id carried on the wire to the id
+	// of the row that ACTUALLY EXISTS in our interbank_negotiations table — the one
+	// the interbank_contracts.negotiation_id FK references.
+	//
+	// When WE are the inter-bank BUYER, the partner (authoritative seller) sends us
+	// the option keyed on ITS negotiation id (our remote_negotiation_id). We stored
+	// that negotiation under a DIFFERENT local id (is_authoritative=false,
+	// remote_negotiation_id=<wire id>). Persisting a buyer-side contract on the raw
+	// wire id violates the FK; we must first resolve it to our local id.
+	//
+	// Resolution rules (mirrors store.NegotiationStore.FindByAuthoritativeRef):
+	//   - authoritative row whose id == wireID            → returns wireID (already local)
+	//   - mirror row whose remote_negotiation_id == wireID → returns its local id
+	//
+	// Returns (localID, true, nil) on a hit; ("", false, nil) when no negotiation row
+	// maps to wireID; ("", false, err) on an infrastructure failure.
+	ResolveLocalNegotiationID(ctx context.Context, wireID string) (string, bool, error)
 }
 
 // ---------------------------------------------------------------------------
@@ -91,9 +130,15 @@ type Executor struct {
 	bc        BankingCoreReserver
 	td        TradingReserver
 	negLookup OptionNegotiationLookup
+	contracts ContractWriter // optional — wired via SetContractStore for option lifecycle (S4/S9)
 	validator *Validator
 	log       *slog.Logger
 }
+
+// SetContractStore wires the optional contract persistence seam used by the option
+// post-accept lifecycle: buyer-side contract persist on inbound accept (S4) and the
+// EXERCISED flip after inbound seller settlement (S9). Left nil in pure 2PC tests.
+func (e *Executor) SetContractStore(c ContractWriter) { e.contracts = c }
 
 // NewExecutor constructs an Executor. negLookup is used only during
 // reservePosting for the OPTION branch (looking up the seller's foreign-id).
@@ -142,6 +187,53 @@ func (e *Executor) PrepareLocal(ctx context.Context, tx protocol.InterbankTransa
 	// 1. Balance check — pure local computation.
 	if reasons := e.validator.BalanceCheck(tx.Postings); len(reasons) > 0 {
 		return protocol.TransactionVote{Vote: protocol.VoteNo, Reasons: reasons}, nil
+	}
+
+	// 1b. Exercise-shape detection. When WE host the OPTION pseudo-account, an
+	// inbound EXERCISE tx is validated at the transaction level (the per-posting
+	// validator cannot tell the seller's negative cash-credit leg from a debit, and
+	// the OPTION account carries MONAS/STOCK rather than an OptionAsset). On a valid
+	// exercise the seller side has nothing to reserve (the shares are already HELD
+	// from accept; the seller receives cash on commit), so we vote YES and persist.
+	if legs, _, isExercise := e.classifyOptionTx(tx.Postings); isExercise && legs.negRouting == e.myRouting {
+		if reasons := e.validator.ValidateExerciseTx(ctx, legs.negID, legs.optionMoneyDebit, legs.optionStockCredit); len(reasons) > 0 {
+			return protocol.TransactionVote{Vote: protocol.VoteNo, Reasons: reasons}, nil
+		}
+		// Contract-status gate: the validator can only reach the negotiation row, but
+		// "option already used/expired" is the CONTRACT status. A freshly-accepted,
+		// not-yet-exercised, before-settlement contract is ACTIVE and MUST pass; an
+		// already EXERCISED / EXPIRED / DECLINED / RELEASED one MUST be rejected
+		// (prevents double-exercise at prepare time). When no contract store is wired
+		// (pure 2PC tests) or no contract row exists yet, fall through — the validator's
+		// settlement-date check and settleSellerExercise's status gate still apply.
+		if e.contracts != nil {
+			c, err := e.contracts.FindByNegotiationID(ctx, legs.negID)
+			if err != nil {
+				return protocol.TransactionVote{}, fmt.Errorf("executor: find contract for exercise: %w", err)
+			}
+			if c != nil && c.Status != store.ContractStatusActive {
+				return protocol.TransactionVote{Vote: protocol.VoteNo,
+					Reasons: []protocol.NoVoteReason{{Reason: protocol.ReasonOptionUsedOrExpired}}}, nil
+			}
+		}
+		postingsJSON, _ := json.Marshal(tx.Postings)
+		metaJSON, _ := json.Marshal(map[string]any{
+			"message":        tx.Message,
+			"callNumber":     tx.CallNumber,
+			"paymentCode":    tx.PaymentCode,
+			"paymentPurpose": tx.PaymentPurpose,
+		})
+		row := &store.Transaction{
+			TransactionIdRouting: tx.TransactionId.RoutingNumber,
+			TransactionIdLocal:   tx.TransactionId.Id,
+			Status:               store.TxStatusPrepared,
+			PostingsJSON:         string(postingsJSON),
+			MessageMeta:          string(metaJSON),
+		}
+		if err := e.store.PersistPrepared(ctx, row); err != nil {
+			return protocol.TransactionVote{}, fmt.Errorf("executor: persist prepared (exercise): %w", err)
+		}
+		return protocol.TransactionVote{Vote: protocol.VoteYes}, nil
 	}
 
 	// 2. Filter postings that belong to our side.
@@ -250,7 +342,350 @@ func (e *Executor) CommitLocal(ctx context.Context, txID protocol.ForeignBankId)
 		}
 	}
 
+	// Credit OUR positive (recipient/seller) MONAS legs (protocol §2.8.4). These are
+	// NOT reserved on prepare (positive legs are skipped in the reserve loop), so they
+	// have no ReservationRef — they must be credited here. CreditMonas is idempotent per
+	// (routing, local), so a crash-and-retry after partial crediting is safe.
+	if err := e.creditPositiveMonasLegs(ctx, tx, txID); err != nil {
+		if updateErr := e.store.UpdateTxStatus(ctx, txID.RoutingNumber, txID.Id, store.TxStatusFailed); updateErr != nil {
+			e.log.ErrorContext(ctx, "commitLocal: failed to flip status to FAILED",
+				"txID", txID, "err", updateErr)
+		}
+		return fmt.Errorf("executor: credit positive legs: %w", err)
+	}
+
+	// Option post-accept lifecycle (S4 buyer-persist / S9 seller-settlement). Runs
+	// off the stored postings: an accept-shape tx persists a buyer-side contract
+	// when WE are the buyer; an exercise-shape tx settles the option when WE are
+	// the seller bank (release reservation, credit seller strike, flip EXERCISED).
+	if err := e.settleOptionLifecycle(ctx, tx, txID); err != nil {
+		if updateErr := e.store.UpdateTxStatus(ctx, txID.RoutingNumber, txID.Id, store.TxStatusFailed); updateErr != nil {
+			e.log.ErrorContext(ctx, "commitLocal: failed to flip status to FAILED",
+				"txID", txID, "err", updateErr)
+		}
+		return fmt.Errorf("executor: option lifecycle: %w", err)
+	}
+
 	return e.store.UpdateTxStatus(ctx, txID.RoutingNumber, txID.Id, store.TxStatusCommitted)
+}
+
+// optionLegs is the parsed view of an option-bearing transaction's postings used
+// to classify accept-shape vs exercise-shape and drive the post-accept lifecycle.
+type optionLegs struct {
+	// shared
+	negID      string
+	negRouting int
+	optionDesc *protocol.OptionDescription
+
+	// accept-shape: a Person@ourRouting leg that receives the option (+option).
+	buyerOptionPerson *protocol.PersonAccount
+
+	// exercise-shape: OPTION account hosted by us with a money-debit + stock-credit.
+	optionMoneyDebit  *decimal.Decimal  // +k*pi on OUR OPTION account (MONAS)
+	optionStockCredit *decimal.Decimal  // -k on OUR OPTION account (STOCK)
+	sellerCashLeg     *protocol.Posting // the -k*pi seller real-cash credit leg (ours)
+}
+
+// classifyOptionTx scans the stored postings and returns (legs, isAccept, isExercise).
+// Accept-shape: contains an OptionAsset posting. Exercise-shape: contains an OPTION
+// pseudo-account WE host carrying a MONAS debit + a STOCK credit (no OptionAsset).
+func (e *Executor) classifyOptionTx(postings []protocol.Posting) (optionLegs, bool, bool) {
+	var legs optionLegs
+	hasOptionAsset := false
+	hostsOptionMoneyStock := false
+
+	for i := range postings {
+		p := postings[i]
+		switch asset := p.Asset.(type) {
+		case *protocol.OptionAsset:
+			hasOptionAsset = true
+			d := asset.OptionDescription
+			legs.optionDesc = &d
+			legs.negID = asset.NegotiationId.Id
+			legs.negRouting = asset.NegotiationId.RoutingNumber
+			// Buyer side: a Person@ourRouting leg that receives the option (+).
+			if person, ok := p.Account.(*protocol.PersonAccount); ok &&
+				person.Id.RoutingNumber == e.myRouting && p.Amount.IsPositive() {
+				legs.buyerOptionPerson = person
+			}
+		case *protocol.MonasAsset:
+			if opt, ok := p.Account.(*protocol.OptionPseudoAccount); ok && opt.Id.RoutingNumber == e.myRouting {
+				amt := p.Amount
+				legs.optionMoneyDebit = &amt
+				legs.negID = opt.Id.Id
+				legs.negRouting = opt.Id.RoutingNumber
+				hostsOptionMoneyStock = true
+			} else if e.isOurs(p) && p.Amount.IsNegative() {
+				// The seller's real-cash credit leg (protocol "credit" = negative).
+				cp := p
+				legs.sellerCashLeg = &cp
+			}
+		case *protocol.StockAsset:
+			if opt, ok := p.Account.(*protocol.OptionPseudoAccount); ok && opt.Id.RoutingNumber == e.myRouting {
+				amt := p.Amount
+				legs.optionStockCredit = &amt
+				legs.negID = opt.Id.Id
+				legs.negRouting = opt.Id.RoutingNumber
+			}
+		}
+	}
+
+	isExercise := hostsOptionMoneyStock && legs.optionStockCredit != nil && !hasOptionAsset
+	isAccept := hasOptionAsset
+	return legs, isAccept, isExercise
+}
+
+// settleOptionLifecycle drives the post-accept option lifecycle off the stored
+// postings. No-op for non-option transactions.
+func (e *Executor) settleOptionLifecycle(ctx context.Context, tx *store.Transaction, txID protocol.ForeignBankId) error {
+	if tx.PostingsJSON == "" {
+		return nil
+	}
+	var postings []protocol.Posting
+	if err := json.Unmarshal([]byte(tx.PostingsJSON), &postings); err != nil {
+		return fmt.Errorf("unmarshal stored postings: %w", err)
+	}
+	legs, isAccept, isExercise := e.classifyOptionTx(postings)
+
+	switch {
+	case isExercise:
+		return e.settleSellerExercise(ctx, legs, txID)
+	case isAccept:
+		return e.persistBuyerContractIfOurs(ctx, legs)
+	default:
+		return nil
+	}
+}
+
+// persistBuyerContractIfOurs persists a buyer-side Contract (S4) when an inbound
+// accept-COMMIT delivers the option to a Person on OUR routing. When WE host the
+// OPTION pseudo-account (we are the seller side) this is a no-op — the seller-side
+// contract is created by the accept Coordinator, not here.
+func (e *Executor) persistBuyerContractIfOurs(ctx context.Context, legs optionLegs) error {
+	if legs.buyerOptionPerson == nil || legs.optionDesc == nil {
+		return nil
+	}
+	// If WE host the option (seller side), do not double-persist a buyer contract.
+	if legs.negRouting == e.myRouting {
+		return nil
+	}
+	if e.contracts == nil {
+		e.log.WarnContext(ctx, "buyer-side accept: no contract store wired — skipping persist", "neg", legs.negID)
+		return nil
+	}
+
+	// FK resolution: legs.negID is the negotiation id as it travels on the wire — the
+	// AUTHORITATIVE (seller-bank) id. When WE are the buyer that is the partner's id,
+	// which we mirror locally under a DIFFERENT interbank_negotiations.id (with
+	// remote_negotiation_id=legs.negID). interbank_contracts.negotiation_id has an FK
+	// to interbank_negotiations(id), so the contract MUST reference our LOCAL id, not
+	// the wire/remote id — otherwise the INSERT violates
+	// interbank_contracts_negotiation_id_fkey and the whole accept-COMMIT 500s.
+	localNegID := legs.negID
+	if e.negLookup != nil {
+		resolved, found, rerr := e.negLookup.ResolveLocalNegotiationID(ctx, legs.negID)
+		if rerr != nil {
+			return fmt.Errorf("resolve local negotiation for wire id %q: %w", legs.negID, rerr)
+		}
+		if !found {
+			// No local negotiation row maps to this wire id. Persisting anyway would
+			// FK-violate; refuse loudly rather than 500 deep in the INSERT or, worse,
+			// silently drop referential integrity. A missing local mirror is itself a
+			// bug (the buyer flow always creates one on CreateOutbound/counter), so the
+			// caller marks the tx FAILED and it can be retried/diagnosed.
+			return fmt.Errorf("buyer-side accept: no local negotiation mirrors wire id %q — cannot persist contract without violating FK", legs.negID)
+		}
+		localNegID = resolved
+	}
+
+	// Idempotent: skip if a contract already exists for this negotiation (keyed on the
+	// local id, matching what we insert below and what the seller-side path uses).
+	existing, err := e.contracts.FindByNegotiationID(ctx, localNegID)
+	if err != nil {
+		return fmt.Errorf("find buyer contract %q: %w", localNegID, err)
+	}
+	if existing != nil {
+		e.log.DebugContext(ctx, "buyer-side accept: contract already exists — idempotent", "neg", localNegID)
+		return nil
+	}
+
+	desc := legs.optionDesc
+	settlement, perr := time.Parse(time.RFC3339, desc.SettlementDate)
+	if perr != nil {
+		return fmt.Errorf("parse settlementDate %q: %w", desc.SettlementDate, perr)
+	}
+	// Razresi prodavcev foreign id iz (mirror) pregovora — NIJE opaque: negotiation
+	// mirror cuva seller_id. Bez ovoga buyer contract ima SellerID="" pa exercise salje
+	// prazan seller Person id na seller-cash nozi -> partner N3 authz odbija (UNACCEPTABLE_ASSET).
+	sellerForeignID := ""
+	if e.negLookup != nil {
+		sid, serr := e.negLookup.FindSellerID(ctx, legs.negID)
+		if serr != nil {
+			return fmt.Errorf("resolve seller foreign id for buyer contract %q: %w", legs.negID, serr)
+		}
+		sellerForeignID = sid
+	}
+	c := &store.Contract{
+		ID:                       generateContractID(),
+		NegotiationID:            localNegID,
+		BuyerRouting:             legs.buyerOptionPerson.Id.RoutingNumber,
+		BuyerID:                  legs.buyerOptionPerson.Id.Id,
+		SellerRouting:            legs.negRouting, // option lives at the seller bank (§3.6.1)
+		SellerID:                 sellerForeignID,
+		StockTicker:              desc.Stock.Ticker,
+		Amount:                   desc.Amount,
+		StrikeCurrency:           desc.PricePerUnit.Currency,
+		StrikeAmount:             desc.PricePerUnit.Amount,
+		SettlementDate:           settlement,
+		Status:                   store.ContractStatusActive,
+		OptionPseudoOwnerRouting: legs.buyerOptionPerson.Id.RoutingNumber,
+		OptionPseudoOwnerID:      legs.buyerOptionPerson.Id.Id,
+		LocalPartyType:           store.ContractPartyBuyer,
+	}
+	if err := e.contracts.Insert(ctx, c); err != nil {
+		return fmt.Errorf("insert buyer contract %q: %w", localNegID, err)
+	}
+	e.log.InfoContext(ctx, "persisted buyer-side option contract",
+		"localNeg", localNegID, "wireNeg", legs.negID, "contract", c.ID,
+		"buyer", c.BuyerID, "ticker", c.StockTicker, "amount", c.Amount)
+	return nil
+}
+
+// settleSellerExercise performs the real inbound exercise settlement (S9) when WE
+// are the seller bank hosting the OPTION pseudo-account: release the seller's HELD
+// reservation and remove the k shares (ExerciseOption), credit the seller's real
+// cash account k*pi via the idempotent FX-aware CreditMonas, then flip the contract
+// to EXERCISED — transactionally, only after settlement. A bare status flip is
+// non-conformant.
+func (e *Executor) settleSellerExercise(ctx context.Context, legs optionLegs, txID protocol.ForeignBankId) error {
+	if legs.negID == "" {
+		return errors.New("exercise tx missing OPTION negotiation id")
+	}
+	if e.td == nil {
+		return errors.New("executor: TradingReserver is nil for exercise settlement")
+	}
+
+	// (a0) Double-exercise guard: refuse to settle a non-ACTIVE contract BEFORE any
+	// irreversible side effect (ExerciseOption removes shares; CreditMonas books cash).
+	// A contract already EXERCISED/EXPIRED/DECLINED/RELEASED must not be settled again.
+	// Looked up once here and reused for the status flip in (c).
+	var contract *store.Contract
+	if e.contracts != nil {
+		c, err := e.contracts.FindByNegotiationID(ctx, legs.negID)
+		if err != nil {
+			return fmt.Errorf("find contract %q for exercise: %w", legs.negID, err)
+		}
+		if c != nil && c.Status != store.ContractStatusActive {
+			e.log.WarnContext(ctx, "refusing to settle non-ACTIVE contract on exercise",
+				"neg", legs.negID, "contract", c.ID, "status", c.Status)
+			return fmt.Errorf("executor: contract %q not ACTIVE (status=%s) — refusing double exercise", c.ID, c.Status)
+		}
+		contract = c
+	}
+
+	// (a) Release the seller's reservation and remove the k shares.
+	if err := e.td.ExerciseOption(ctx, protocol.ForeignBankId{RoutingNumber: legs.negRouting, Id: legs.negID}); err != nil {
+		return fmt.Errorf("ExerciseOption neg=%s: %w", legs.negID, err)
+	}
+
+	// (b) Credit the seller's real cash account k*pi via CreditMonas (FX-aware).
+	if legs.sellerCashLeg != nil {
+		if e.bc == nil {
+			return errors.New("executor: BankingCoreReserver is nil for seller strike credit")
+		}
+		monas, ok := legs.sellerCashLeg.Asset.(*protocol.MonasAsset)
+		if !ok {
+			return fmt.Errorf("seller cash leg is not MONAS: %T", legs.sellerCashLeg.Asset)
+		}
+		accountNum, err := e.resolveCreditAccount(ctx, *legs.sellerCashLeg, monas)
+		if err != nil {
+			return fmt.Errorf("resolve seller cash account: %w", err)
+		}
+		if accountNum != "" {
+			if err := e.bc.CreditMonas(ctx, accountNum, monas.Currency, legs.sellerCashLeg.Amount.Abs(),
+				txID.RoutingNumber, txID.Id); err != nil {
+				return fmt.Errorf("CreditMonas seller strike account=%s: %w", accountNum, err)
+			}
+		}
+	}
+
+	// (c) Flip the contract → EXERCISED, only after settlement. Reuses the row read
+	// in (a0); it was verified ACTIVE there, so this is the single ACTIVE→EXERCISED
+	// transition that locks out any subsequent re-settlement.
+	if e.contracts != nil && contract != nil {
+		if err := e.contracts.UpdateStatus(ctx, contract.ID, store.ContractStatusExercised); err != nil {
+			return fmt.Errorf("flip contract %q EXERCISED: %w", contract.ID, err)
+		}
+	}
+	e.log.InfoContext(ctx, "settled inbound seller exercise", "neg", legs.negID, "txID", txID)
+	return nil
+}
+
+// creditPositiveMonasLegs credits each of OUR positive (DEBIT / recipient) MONAS
+// postings via banking-core's idempotent FX-aware credit primitive. Resolves the
+// account from a RealAccount number or a PERSON@<ourRouting> reference.
+func (e *Executor) creditPositiveMonasLegs(ctx context.Context, tx *store.Transaction, txID protocol.ForeignBankId) error {
+	if tx.PostingsJSON == "" {
+		return nil
+	}
+	var postings []protocol.Posting
+	if err := json.Unmarshal([]byte(tx.PostingsJSON), &postings); err != nil {
+		return fmt.Errorf("unmarshal stored postings: %w", err)
+	}
+	for _, p := range postings {
+		// Only OUR positive MONAS legs get credited.
+		if p.Amount.IsNegative() || p.Amount.IsZero() {
+			continue
+		}
+		monas, ok := p.Asset.(*protocol.MonasAsset)
+		if !ok {
+			continue
+		}
+		if !e.isOurs(p) {
+			continue
+		}
+		if e.bc == nil {
+			return errors.New("executor: BankingCoreReserver is nil for MONAS credit")
+		}
+
+		accountNum, err := e.resolveCreditAccount(ctx, p, monas)
+		if err != nil {
+			return err
+		}
+		if accountNum == "" {
+			// Not resolvable on our side (e.g. partner-side person) — skip.
+			continue
+		}
+		if err := e.bc.CreditMonas(ctx, accountNum, monas.Currency, p.Amount.Abs(), txID.RoutingNumber, txID.Id); err != nil {
+			return fmt.Errorf("CreditMonas account=%s: %w", accountNum, err)
+		}
+	}
+	return nil
+}
+
+// resolveCreditAccount resolves the destination account number for a positive MONAS leg.
+// RealAccount → its account number. PersonAccount (ours) → resolve owner+currency to
+// an account number. Returns ("", nil) when the leg is not ours to credit.
+func (e *Executor) resolveCreditAccount(ctx context.Context, p protocol.Posting, monas *protocol.MonasAsset) (string, error) {
+	switch acc := p.Account.(type) {
+	case *protocol.RealAccount:
+		return acc.Num, nil
+	case *protocol.PersonAccount:
+		if acc.Id.RoutingNumber != e.myRouting {
+			return "", nil
+		}
+		ownerID, err := parseOwnerID(acc.Id.Id)
+		if err != nil {
+			return "", fmt.Errorf("parse recipient owner id %q: %w", acc.Id.Id, err)
+		}
+		num, err := e.bc.FindAccountByOwnerAndCurrency(ctx, ownerID, monas.Currency)
+		if err != nil || num == "" {
+			return "", fmt.Errorf("resolve recipient person %d to %s account: %w", ownerID, monas.Currency, err)
+		}
+		return num, nil
+	default:
+		return "", nil
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -448,16 +883,17 @@ func (e *Executor) commitRef(ctx context.Context, ref store.ReservationRef) erro
 		return e.td.CommitStock(ctx, ref.ReservationID)
 
 	case store.RefKindOption:
-		if e.td == nil {
-			return errors.New("executor: TradingReserver is nil for OPTION exercise")
-		}
-		if ref.NegotiationRouting == nil || ref.NegotiationID == nil {
-			return errors.New("executor: OPTION reservation ref missing negotiation fields")
-		}
-		return e.td.ExerciseOption(ctx, protocol.ForeignBankId{
-			RoutingNumber: *ref.NegotiationRouting,
-			Id:            *ref.NegotiationID,
-		})
+		// [S3 BUG FIX] On the accept-COMMIT we must KEEP the option's HELD
+		// reservation — committing the option leg here does NOT mean "exercise".
+		// Exercising at accept-time would strip the seller's shares immediately,
+		// which is wrong: the strike has not been paid and the buyer has not
+		// chosen to exercise. ReserveOption (run on accept-PREPARE) already holds
+		// the seller's reservedQuantity; the real ExerciseOption only runs from
+		// the dedicated exercise round (inbound EXERCISE tx, executor S9 path).
+		// So this is intentionally a no-op.
+		e.log.DebugContext(ctx, "commitRef OPTION accept-COMMIT — keeping HELD reservation (no exercise)",
+			"negotiationRouting", ref.NegotiationRouting, "negotiationID", ref.NegotiationID)
+		return nil
 
 	default:
 		e.log.Warn("executor: commitRef: unknown ref kind — skipping", "kind", ref.Kind)

--- a/interbank-service/internal/service/executor_test.go
+++ b/interbank-service/internal/service/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 
@@ -82,11 +83,22 @@ type fakeBankingCoreReserver struct {
 	reserved  []string // reservation IDs created
 	committed []string
 	released  []string
+	credited  []creditCall // CreditMonas calls recorded (positive-leg credits)
 
 	failReserve bool
 	reserveErr  error
+	creditErr   error // forced CreditMonas failure
 	// failAfter: if > 0, the Nth call to ReserveMonas (1-indexed) will fail.
 	failAfter int
+}
+
+// creditCall records a single CreditMonas invocation for assertions.
+type creditCall struct {
+	accountNum  string
+	currency    string
+	amount      decimal.Decimal
+	txIDRouting int
+	txIDLocal   string
 }
 
 func newFakeBC(accounts map[string]*AccountInfo) *fakeBankingCoreReserver {
@@ -141,6 +153,17 @@ func (f *fakeBankingCoreReserver) CommitMonas(_ context.Context, reservationID s
 	return nil
 }
 
+func (f *fakeBankingCoreReserver) CreditMonas(_ context.Context, accountNum, currency string, amount decimal.Decimal, txIDRouting int, txIDLocal string) error {
+	if f.creditErr != nil {
+		return f.creditErr
+	}
+	f.credited = append(f.credited, creditCall{
+		accountNum: accountNum, currency: currency, amount: amount,
+		txIDRouting: txIDRouting, txIDLocal: txIDLocal,
+	})
+	return nil
+}
+
 func (f *fakeBankingCoreReserver) ReleaseMonas(_ context.Context, reservationID string) error {
 	f.released = append(f.released, reservationID)
 	return nil
@@ -154,6 +177,17 @@ type fakeTradingReserver struct {
 
 	failReserveStock bool
 	optionSellers    map[string]string // negotiation id → sellerForeignID (for lookup validation)
+
+	// CreditPortfolio tracking (S7/S8 buyer-side delivery + S9 settlement tests).
+	creditedPortfolio   []creditPortfolioCall
+	failCreditPortfolio bool
+}
+
+// creditPortfolioCall records a single CreditPortfolio invocation for assertions.
+type creditPortfolioCall struct {
+	buyerUserID int64
+	ticker      string
+	quantity    int
 }
 
 func (f *fakeTradingReserver) ReserveStock(_ context.Context, sellerUserID int64, ticker string, quantity int, txIDRouting int, txIDLocal string) (string, error) {
@@ -191,6 +225,14 @@ func (f *fakeTradingReserver) ReleaseOption(_ context.Context, negotiationID pro
 	return nil
 }
 
+func (f *fakeTradingReserver) CreditPortfolio(_ context.Context, buyerUserID int64, ticker string, quantity int) error {
+	if f.failCreditPortfolio {
+		return errors.New("fakeTradingReserver: CreditPortfolio forced failure")
+	}
+	f.creditedPortfolio = append(f.creditedPortfolio, creditPortfolioCall{buyerUserID: buyerUserID, ticker: ticker, quantity: quantity})
+	return nil
+}
+
 // fakeNegotiationLookup implements NegotiationReader for the Executor's validator needs,
 // and also serves as OptionNegotiationLookup for reservePosting.
 type fakeNegotiationLookup struct {
@@ -198,10 +240,15 @@ type fakeNegotiationLookup struct {
 }
 
 type fakeNegForExec struct {
-	SellerID   string
-	IsOngoing  bool
-	Amount     int
-	Settlement string // RFC3339
+	SellerID     string
+	IsOngoing    bool
+	Amount       int
+	Settlement   string          // RFC3339 (parsed into NegotiationLite.SettlementDate when set)
+	PricePerUnit decimal.Decimal // per-unit strike; drives ValidateExerciseTx amount check
+	// RemoteID, when set, marks this as a non-authoritative mirror row whose
+	// remote_negotiation_id == RemoteID (the wire/partner id). Drives
+	// ResolveLocalNegotiationID's remote→local mapping.
+	RemoteID string
 }
 
 func (f *fakeNegotiationLookup) FindNegotiation(ctx context.Context, id protocol.ForeignBankId) (*NegotiationLite, error) {
@@ -209,15 +256,41 @@ func (f *fakeNegotiationLookup) FindNegotiation(ctx context.Context, id protocol
 	if !ok {
 		return nil, errors.New("not found")
 	}
-	return &NegotiationLite{IsOngoing: n.IsOngoing, Amount: n.Amount}, nil
+	lite := &NegotiationLite{IsOngoing: n.IsOngoing, Amount: n.Amount, PricePerUnit: n.PricePerUnit}
+	if n.Settlement != "" {
+		if t, perr := time.Parse(time.RFC3339, n.Settlement); perr == nil {
+			lite.SettlementDate = t
+		}
+	}
+	return lite, nil
 }
 
 func (f *fakeNegotiationLookup) FindSellerID(ctx context.Context, negID string) (string, error) {
-	n, ok := f.negs[negID]
-	if !ok {
-		return "", errors.New("negotiation not found: " + negID)
+	// Match the real FindByAuthoritativeRef: by local key OR by remote id (mirror row).
+	if n, ok := f.negs[negID]; ok {
+		return n.SellerID, nil
 	}
-	return n.SellerID, nil
+	for _, n := range f.negs {
+		if n.RemoteID == negID {
+			return n.SellerID, nil
+		}
+	}
+	return "", errors.New("negotiation not found: " + negID)
+}
+
+// ResolveLocalNegotiationID mirrors store.NegotiationStore.FindByAuthoritativeRef:
+// an entry keyed by its own (local) id resolves to itself (authoritative); an entry
+// whose RemoteID == wireID resolves to its local key (mirror row).
+func (f *fakeNegotiationLookup) ResolveLocalNegotiationID(ctx context.Context, wireID string) (string, bool, error) {
+	if _, ok := f.negs[wireID]; ok {
+		return wireID, true, nil
+	}
+	for localID, n := range f.negs {
+		if n.RemoteID == wireID {
+			return localID, true, nil
+		}
+	}
+	return "", false, nil
 }
 
 // discardLogger returns a slog.Logger that discards all output.
@@ -603,8 +676,12 @@ func TestRollbackLocal_AlreadyTerminal_NoOp(t *testing.T) {
 // Additional tests
 // ---------------------------------------------------------------------------
 
-// Test 13: CommitLocal with OPTION ref → ExerciseOption called.
-func TestCommitLocal_OptionRef_Exercises(t *testing.T) {
+// Test 13 [S3 FIX]: CommitLocal of an accept-COMMIT carrying an OPTION ref must
+// KEEP the seller's HELD reservation — it must NOT exercise (strip the seller's
+// shares) on accept. The real ExerciseOption runs only from the dedicated exercise
+// round (inbound EXERCISE tx). So no ExerciseOption is called here; the tx still
+// transitions to COMMITTED.
+func TestCommitLocal_OptionRef_KeepsHeldReservation_NoExercise(t *testing.T) {
 	td := &fakeTradingReserver{}
 	negID := "neg-exercise-1"
 	negRouting := 111
@@ -626,8 +703,12 @@ func TestCommitLocal_OptionRef_Exercises(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CommitLocal: %v", err)
 	}
-	if len(td.committed) != 1 || td.committed[0] != "option-exercise-"+negID {
-		t.Errorf("expected ExerciseOption(%q), got td.committed=%v", negID, td.committed)
+	// S3: accept-commit must NOT exercise → no commit/exercise side effect on the option.
+	if len(td.committed) != 0 {
+		t.Errorf("accept-commit must KEEP the HELD reservation (no exercise), got td.committed=%v", td.committed)
+	}
+	if len(td.released) != 0 {
+		t.Errorf("accept-commit must not release the option, got td.released=%v", td.released)
 	}
 	tx := s.txns[txKey(222, "tx-option-commit")]
 	if tx.Status != store.TxStatusCommitted {

--- a/interbank-service/internal/service/helpers_unit_test.go
+++ b/interbank-service/internal/service/helpers_unit_test.go
@@ -181,8 +181,15 @@ func TestCommitRef_AllKinds(t *testing.T) {
 			t.Errorf("commitRef %s: %v", ref.Kind, err)
 		}
 	}
-	if len(bc.committed) != 1 || len(td.committed) != 2 {
-		t.Errorf("expected 1 monas + 2 trading commits, got bc=%d td=%d", len(bc.committed), len(td.committed))
+	// [S3 FIX] commitRef for an OPTION ref is intentionally a no-op (the accept-commit
+	// KEEPS the seller's HELD reservation; the real ExerciseOption only runs from the
+	// dedicated exercise round). So: 1 MONAS commit + 1 STOCK commit, and the OPTION
+	// ref produces NO trading commit or release.
+	if len(bc.committed) != 1 || len(td.committed) != 1 {
+		t.Errorf("expected 1 monas + 1 trading (stock) commit, got bc=%d td=%d", len(bc.committed), len(td.committed))
+	}
+	if len(td.released) != 0 {
+		t.Errorf("expected no option release on commit, got td.released=%v", td.released)
 	}
 }
 

--- a/interbank-service/internal/service/interbank_credit_branch_test.go
+++ b/interbank-service/internal/service/interbank_credit_branch_test.go
@@ -1,0 +1,207 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Executor CommitLocal — positive (recipient/DEBIT) MONAS-leg crediting.
+//
+// On an inbound REGULAR payment (partner sender → OUR account), the recipient
+// leg is positive and is NOT reserved on prepare. CommitLocal must credit it via
+// the idempotent FX-aware CreditMonas primitive (protocol §2.8.4); otherwise the
+// money is debited from the sender but never booked on our recipient.
+// ---------------------------------------------------------------------------
+
+// inboundPaymentTx builds a balanced 2-posting payment: partner sender CREDIT
+// (negative, partner-side) + OUR recipient DEBIT (positive, ours).
+func inboundPaymentTx(txID, ourRecipient string, amount int64, currency string) protocol.InterbankTransactionPayload {
+	return protocol.InterbankTransactionPayload{
+		TransactionId: protocol.ForeignBankId{RoutingNumber: 222, Id: txID},
+		Postings: []protocol.Posting{
+			// a) partner sender CREDIT (negative) — partner-routed, not ours.
+			{Account: &protocol.RealAccount{Num: "222000000000000099"}, Amount: decimal.NewFromInt(-amount), Asset: &protocol.MonasAsset{Currency: currency}},
+			// b) OUR recipient DEBIT (positive) — credited on commit.
+			{Account: &protocol.RealAccount{Num: ourRecipient}, Amount: decimal.NewFromInt(amount), Asset: &protocol.MonasAsset{Currency: currency}},
+		},
+	}
+}
+
+// TestCommitLocal_CreditsOurPositiveRealAccountLeg verifies the recipient RealAccount
+// is credited via CreditMonas on commit, with the tx id passed as the idempotency key.
+func TestCommitLocal_CreditsOurPositiveRealAccountLeg(t *testing.T) {
+	const ourAcc = "1110001000000000322" // 19-digit B1 account (prefix 111 = ours)
+	bc := newFakeBC(map[string]*AccountInfo{
+		ourAcc: {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)},
+	})
+	s := &fakeExecStore{}
+	e := newTestExecutor(111, s, bc, nil)
+
+	tx := inboundPaymentTx("tx-inbound-1", ourAcc, 250, "USD")
+	vote, err := e.PrepareLocal(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteYes {
+		t.Fatalf("expected YES, got %q reasons=%v", vote.Vote, vote.Reasons)
+	}
+	// Positive recipient leg is not reserved on prepare.
+	if len(bc.reserved) != 0 {
+		t.Errorf("positive recipient leg must NOT be reserved, got %v", bc.reserved)
+	}
+
+	if err := e.CommitLocal(context.Background(), tx.TransactionId); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	if len(bc.credited) != 1 {
+		t.Fatalf("expected exactly 1 CreditMonas call, got %d (%v)", len(bc.credited), bc.credited)
+	}
+	c := bc.credited[0]
+	if c.accountNum != ourAcc {
+		t.Errorf("credited account=%s want %s", c.accountNum, ourAcc)
+	}
+	if c.currency != "USD" || c.amount.String() != "250" {
+		t.Errorf("credited %s %s, want USD 250", c.amount.String(), c.currency)
+	}
+	// Idempotency key = the inbound tx id (routing, local).
+	if c.txIDRouting != 222 || c.txIDLocal != "tx-inbound-1" {
+		t.Errorf("credit idempotency key=(%d,%s), want (222,tx-inbound-1)", c.txIDRouting, c.txIDLocal)
+	}
+	if st := s.txns[txKey(222, "tx-inbound-1")].Status; st != store.TxStatusCommitted {
+		t.Errorf("tx status=%s want COMMITTED", st)
+	}
+}
+
+// TestCommitLocal_DoesNotCreditPartnerSidePositiveLeg verifies that a positive MONAS
+// leg on a partner-routed account is NOT credited by us (partner books its own side).
+func TestCommitLocal_DoesNotCreditPartnerSidePositiveLeg(t *testing.T) {
+	const ourSender = "1110001000000000322"
+	bc := newFakeBC(map[string]*AccountInfo{
+		ourSender: {Currency: "USD", AvailableBalance: decimal.NewFromInt(1000)},
+	})
+	s := &fakeExecStore{}
+	e := newTestExecutor(111, s, bc, nil)
+
+	// Outbound payment: OUR sender CREDIT (negative, reserved) + partner recipient DEBIT (positive, theirs).
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: protocol.ForeignBankId{RoutingNumber: 111, Id: "tx-outbound-1"},
+		Postings: []protocol.Posting{
+			{Account: &protocol.RealAccount{Num: ourSender}, Amount: decimal.NewFromInt(-100), Asset: &protocol.MonasAsset{Currency: "USD"}},
+			{Account: &protocol.RealAccount{Num: "222000000000000099"}, Amount: decimal.NewFromInt(100), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		},
+	}
+	if vote, err := e.PrepareLocal(context.Background(), tx); err != nil || vote.Vote != protocol.VoteYes {
+		t.Fatalf("PrepareLocal vote=%v err=%v", vote, err)
+	}
+	if err := e.CommitLocal(context.Background(), tx.TransactionId); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	// Our sender reservation is committed; the partner recipient is NOT our credit.
+	if len(bc.credited) != 0 {
+		t.Errorf("must not credit partner-side recipient, got %v", bc.credited)
+	}
+	if len(bc.committed) != 1 {
+		t.Errorf("expected our sender reservation committed once, got %v", bc.committed)
+	}
+}
+
+// TestCommitLocal_CreditsOurPositivePersonLeg verifies a PERSON@ourRouting positive
+// MONAS leg is resolved (owner+currency) and credited.
+func TestCommitLocal_CreditsOurPositivePersonLeg(t *testing.T) {
+	const resolved = "1110001000000000777"
+	bc := newFakeBC(map[string]*AccountInfo{
+		resolved: {Currency: "EUR", AvailableBalance: decimal.NewFromInt(0)},
+	})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "EUR"): resolved}
+	s := &fakeExecStore{}
+	e := newTestExecutor(111, s, bc, nil)
+
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-person-credit"},
+		Postings: []protocol.Posting{
+			{Account: &protocol.RealAccount{Num: "222000000000000099"}, Amount: decimal.NewFromInt(-40), Asset: &protocol.MonasAsset{Currency: "EUR"}},
+			{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "C-15"}}, Amount: decimal.NewFromInt(40), Asset: &protocol.MonasAsset{Currency: "EUR"}},
+		},
+	}
+	if vote, err := e.PrepareLocal(context.Background(), tx); err != nil || vote.Vote != protocol.VoteYes {
+		t.Fatalf("PrepareLocal vote=%v err=%v", vote, err)
+	}
+	if err := e.CommitLocal(context.Background(), tx.TransactionId); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	if len(bc.credited) != 1 || bc.credited[0].accountNum != resolved {
+		t.Fatalf("expected 1 credit to resolved person account %s, got %v", resolved, bc.credited)
+	}
+	if bc.credited[0].amount.String() != "40" || bc.credited[0].currency != "EUR" {
+		t.Errorf("credited %s %s want EUR 40", bc.credited[0].amount.String(), bc.credited[0].currency)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validator cross-currency acceptance (DEBIT/recipient leg) — protocol §2.8.4.
+//
+// A positive (recipient) MONAS leg with a currency mismatch must be ACCEPTED
+// (converted on commit via CreditMonas), NOT rejected with NO_SUCH_ASSET. Only the
+// negative (sender) leg requires same-currency funds.
+// ---------------------------------------------------------------------------
+
+// TestValidatePosting_CrossCcy_PositiveLegAccepted verifies a positive recipient leg
+// with an account/posting currency mismatch is accepted (no NO vote).
+func TestValidatePosting_CrossCcy_PositiveLegAccepted(t *testing.T) {
+	bc := &fakeBC{
+		byNum: map[string]fakeAccountInfo{
+			"1110001000000000322": {Currency: "RSD", AvailableBalance: decimal.NewFromInt(0)},
+		},
+	}
+	v := NewValidator(111, nil, bc, nil)
+	// Recipient leg: +100 EUR into an RSD account → accepted (converted on commit).
+	p := mkRealAccountMonas("1110001000000000322", decimal.NewFromInt(100), "EUR")
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Errorf("cross-ccy DEBIT (recipient) leg must be accepted, got NO reason %+v", r)
+	}
+}
+
+// TestValidatePosting_CrossCcy_NegativeLegRejected verifies the sender (negative) leg
+// still requires same-currency funds: a mismatch is NO_SUCH_ASSET.
+func TestValidatePosting_CrossCcy_NegativeLegRejected(t *testing.T) {
+	bc := &fakeBC{
+		byNum: map[string]fakeAccountInfo{
+			"1110001000000000322": {Currency: "RSD", AvailableBalance: decimal.NewFromInt(100000)},
+		},
+	}
+	v := NewValidator(111, nil, bc, nil)
+	// Sender leg: -100 EUR from an RSD account → NO_SUCH_ASSET.
+	p := mkRealAccountMonas("1110001000000000322", decimal.NewFromInt(-100), "EUR")
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil || r.Reason != protocol.ReasonNoSuchAsset {
+		t.Errorf("cross-ccy CREDIT (sender) leg must be NO_SUCH_ASSET, got %+v", r)
+	}
+}
+
+// TestAccountIsOurs_19DigitOwnAccount is the regression guard for the accountIsOurs
+// prefix fix: B1's 19-digit own accounts (prefix 111) must be recognised as ours.
+func TestAccountIsOurs_19DigitOwnAccount(t *testing.T) {
+	v := NewValidator(111, nil, nil, nil)
+	if !v.accountIsOurs("1110001000000000322") {
+		t.Error("19-digit account with our 111 prefix must be recognised as ours")
+	}
+	if v.accountIsOurs("2220001000000000322") {
+		t.Error("foreign 222-prefixed account must NOT be ours")
+	}
+	if v.accountIsOurs("11") {
+		t.Error("too-short account must not be ours")
+	}
+}

--- a/interbank-service/internal/service/option_lifecycle_test.go
+++ b/interbank-service/internal/service/option_lifecycle_test.go
@@ -1,0 +1,652 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// Wave-2 option post-accept lifecycle tests: S3 (no exercise on accept),
+// S4 (buyer contract persisted on inbound accept), S6 (settlement/amount guards),
+// S9 (inbound seller settlement flips EXERCISED).
+
+// ---------------------------------------------------------------------------
+// Shared test fakes for the option lifecycle (ContractWriter + JSON helper)
+// ---------------------------------------------------------------------------
+
+// fakeContractWriter implements ContractWriter (S4/S9 option lifecycle).
+type fakeContractWriter struct {
+	byNeg     map[string]*store.Contract
+	inserted  []*store.Contract
+	statuses  map[string]string // contractID → last status set
+	insertErr error
+}
+
+func newFakeContractWriter() *fakeContractWriter {
+	return &fakeContractWriter{byNeg: map[string]*store.Contract{}, statuses: map[string]string{}}
+}
+
+func (f *fakeContractWriter) Insert(_ context.Context, c *store.Contract) error {
+	if f.insertErr != nil {
+		return f.insertErr
+	}
+	cp := *c
+	f.inserted = append(f.inserted, &cp)
+	f.byNeg[c.NegotiationID] = &cp
+	return nil
+}
+
+func (f *fakeContractWriter) FindByNegotiationID(_ context.Context, negotiationID string) (*store.Contract, error) {
+	c, ok := f.byNeg[negotiationID]
+	if !ok {
+		return nil, nil
+	}
+	cp := *c
+	return &cp, nil
+}
+
+func (f *fakeContractWriter) UpdateStatus(_ context.Context, id, status string) error {
+	f.statuses[id] = status
+	for _, c := range f.byNeg {
+		if c.ID == id {
+			c.Status = status
+		}
+	}
+	return nil
+}
+
+func mustPostingsJSON(t *testing.T, postings []protocol.Posting) string {
+	t.Helper()
+	b, err := json.Marshal(postings)
+	if err != nil {
+		t.Fatalf("marshal postings: %v", err)
+	}
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// S3 — accept-COMMIT must NOT exercise (keep HELD reservation)
+// ---------------------------------------------------------------------------
+
+// TestCommitLocal_OptionRef_DoesNotExerciseOnAccept is the canonical S3 guard at
+// the CommitLocal level: an accept-COMMIT carrying an OPTION reservation ref must
+// keep the seller's HELD reservation — no ExerciseOption, no ReleaseOption.
+func TestCommitLocal_OptionRef_DoesNotExerciseOnAccept(t *testing.T) {
+	td := &fakeTradingReserver{}
+	negID := "neg-accept-s3"
+	negRouting := 111
+	s := &fakeExecStore{
+		txns: map[string]*store.Transaction{
+			txKey(222, "tx-s3"): {
+				TransactionIdRouting: 222,
+				TransactionIdLocal:   "tx-s3",
+				Status:               store.TxStatusPrepared,
+				ReservationRefs: []store.ReservationRef{
+					{Kind: store.RefKindOption, NegotiationRouting: &negRouting, NegotiationID: &negID},
+				},
+			},
+		},
+	}
+	e := newTestExecutor(111, s, &fakeBankingCoreReserver{}, td)
+
+	if err := e.CommitLocal(context.Background(), protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-s3"}); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	if len(td.committed) != 0 {
+		t.Errorf("accept-commit must NOT exercise the option, got td.committed=%v", td.committed)
+	}
+	if len(td.released) != 0 {
+		t.Errorf("accept-commit must NOT release the option, got td.released=%v", td.released)
+	}
+	if s.txns[txKey(222, "tx-s3")].Status != store.TxStatusCommitted {
+		t.Errorf("expected COMMITTED")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// S6/S9 posting builders
+// ---------------------------------------------------------------------------
+
+// exerciseShapePostingsSellerSide builds a 4-posting EXERCISE tx where WE (routing
+// 111) are the SELLER bank hosting the OPTION pseudo-account; the buyer is on the
+// partner (routing 222). k=10, pi=150 → k*pi = 1500.
+func exerciseShapePostingsSellerSide() []protocol.Posting {
+	return []protocol.Posting{
+		// p1: OPTION account money debit +k*pi (consumes buyer's reserved strike)
+		{Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-sell-1"}}, Amount: decimal.NewFromInt(1500), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		// p2: seller real cash credit -k*pi (the strike → seller)
+		{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "C-15"}}, Amount: decimal.NewFromInt(-1500), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		// p3: OPTION account stock credit -k (releases seller reservation)
+		{Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-sell-1"}}, Amount: decimal.NewFromInt(-10), Asset: &protocol.StockAsset{Ticker: "AAPL"}},
+		// p4: buyer (partner) portfolio stock debit +k (delivery)
+		{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 222, Id: "C-2"}}, Amount: decimal.NewFromInt(10), Asset: &protocol.StockAsset{Ticker: "AAPL"}},
+	}
+}
+
+// newExerciseTestExecutor builds an executor whose negotiation lookup knows the
+// hosted negotiation (so the validator can check the exercise amounts).
+func newExerciseTestExecutor(s *fakeExecStore, bc *fakeBankingCoreReserver, td *fakeTradingReserver, neg *fakeNegForExec) *Executor {
+	negs := &fakeNegotiationLookup{negs: map[string]*fakeNegForExec{"neg-sell-1": neg}}
+	return newExecutorWithNegs(111, s, bc, td, negs)
+}
+
+// ---------------------------------------------------------------------------
+// S6 — inbound EXERCISE validation (we are the SELLER bank)
+// ---------------------------------------------------------------------------
+
+func TestPrepareLocal_SellerExercise_Valid_YesVote(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000000000000015"}
+	td := &fakeTradingReserver{}
+	s := &fakeExecStore{}
+	e := newExerciseTestExecutor(s, bc, td, &fakeNegForExec{
+		SellerID: "C-15", IsOngoing: true, Amount: 10,
+		PricePerUnit: decimal.NewFromInt(150), Settlement: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+	})
+
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-exec"},
+		Postings:      exerciseShapePostingsSellerSide(),
+	}
+	vote, err := e.PrepareLocal(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteYes {
+		t.Fatalf("expected YES, got %q reasons=%v", vote.Vote, vote.Reasons)
+	}
+	// Nothing should be reserved on the seller side at exercise prepare.
+	if len(bc.reserved) != 0 {
+		t.Errorf("expected no MONAS reservations on seller exercise prepare, got %v", bc.reserved)
+	}
+	if len(s.txns) != 1 {
+		t.Errorf("expected exercise tx persisted PREPARED, got %d", len(s.txns))
+	}
+}
+
+func TestPrepareLocal_SellerExercise_WrongMoney_NoVote(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000000000000015"}
+	e := newExerciseTestExecutor(&fakeExecStore{}, bc, &fakeTradingReserver{}, &fakeNegForExec{
+		SellerID: "C-15", IsOngoing: true, Amount: 10,
+		PricePerUnit: decimal.NewFromInt(150), Settlement: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+	})
+	postings := exerciseShapePostingsSellerSide()
+	// Corrupt the OPTION money debit (p1) to 1499 and rebalance the seller cash leg
+	// so only the OPTION amount check (not the balance check) trips.
+	postings[0].Amount = decimal.NewFromInt(1499)
+	postings[1].Amount = decimal.NewFromInt(-1499)
+
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-exec-bad"},
+		Postings:      postings,
+	}
+	vote, err := e.PrepareLocal(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteNo {
+		t.Fatalf("expected NO, got %q", vote.Vote)
+	}
+	if !hasReason(vote.Reasons, protocol.ReasonOptionAmountIncorrect) {
+		t.Errorf("expected OPTION_AMOUNT_INCORRECT, got %v", vote.Reasons)
+	}
+}
+
+func TestPrepareLocal_SellerExercise_PastSettlement_NoVote(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000000000000015"}
+	e := newExerciseTestExecutor(&fakeExecStore{}, bc, &fakeTradingReserver{}, &fakeNegForExec{
+		SellerID: "C-15", IsOngoing: true, Amount: 10,
+		PricePerUnit: decimal.NewFromInt(150), Settlement: time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+	})
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-exec-late"},
+		Postings:      exerciseShapePostingsSellerSide(),
+	}
+	vote, err := e.PrepareLocal(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteNo {
+		t.Fatalf("expected NO, got %q", vote.Vote)
+	}
+	if !hasReason(vote.Reasons, protocol.ReasonOptionUsedOrExpired) {
+		t.Errorf("expected OPTION_USED_OR_EXPIRED, got %v", vote.Reasons)
+	}
+}
+
+func hasReason(reasons []protocol.NoVoteReason, want string) bool {
+	for _, r := range reasons {
+		if r.Reason == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// BUG 2 repro — exercise validation must NOT gate on negotiation IsOngoing.
+//
+// After an OTC accept concludes, the negotiation row is CORRECTLY is_ongoing=false
+// (the deal is done), while the resulting CONTRACT is ACTIVE and exercisable until
+// settlement. The old `!neg.IsOngoing` rejection in ValidateExerciseTx rejected
+// EVERY legitimate inter-bank exercise (we as seller) as OPTION_USED_OR_EXPIRED.
+// These tests pin the corrected behaviour: IsOngoing is irrelevant; the gate is
+// settlement-date (validator) + contract status (executor).
+// ---------------------------------------------------------------------------
+
+// TestPrepareLocal_SellerExercise_ConcludedNegotiation_YesVote is the BUG-2 repro.
+// The negotiation is is_ongoing=false (deal concluded on accept) but the contract is
+// ACTIVE and before settlement → the exercise MUST be accepted (YES vote). Before the
+// fix this returned NO + OPTION_USED_OR_EXPIRED, blocking every inbound exercise.
+func TestPrepareLocal_SellerExercise_ConcludedNegotiation_YesVote(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000000000000015"}
+	s := &fakeExecStore{}
+	e := newExerciseTestExecutor(s, bc, &fakeTradingReserver{}, &fakeNegForExec{
+		// is_ongoing=false: the negotiation concluded on accept — the realistic state.
+		SellerID: "C-15", IsOngoing: false, Amount: 10,
+		PricePerUnit: decimal.NewFromInt(150), Settlement: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+	})
+	// Wire an ACTIVE contract — the option has not yet been exercised.
+	cw := newFakeContractWriter()
+	cw.byNeg["neg-sell-1"] = &store.Contract{
+		ID: "otc-active", NegotiationID: "neg-sell-1", Status: store.ContractStatusActive,
+		StockTicker: "AAPL", Amount: 10, StrikeCurrency: "USD", StrikeAmount: decimal.NewFromInt(150),
+		LocalPartyType: store.ContractPartySeller,
+	}
+	e.SetContractStore(cw)
+
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-exec-concluded"},
+		Postings:      exerciseShapePostingsSellerSide(),
+	}
+	vote, err := e.PrepareLocal(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteYes {
+		t.Fatalf("BUG 2: a concluded (is_ongoing=false) but ACTIVE before-settlement option must PASS exercise validation, got %q reasons=%v", vote.Vote, vote.Reasons)
+	}
+	if len(s.txns) != 1 {
+		t.Errorf("expected exercise tx persisted PREPARED, got %d", len(s.txns))
+	}
+}
+
+// TestValidateExerciseTx_IgnoresIsOngoing is the tightest unit-level BUG-2 repro:
+// directly against the validator, a concluded (is_ongoing=false) before-settlement
+// option with the correct amounts must validate with NO reasons.
+func TestValidateExerciseTx_IgnoresIsOngoing(t *testing.T) {
+	negs := &fakeNegotiationLookup{negs: map[string]*fakeNegForExec{
+		"neg-sell-1": {
+			SellerID: "C-15", IsOngoing: false, Amount: 10,
+			PricePerUnit: decimal.NewFromInt(150), Settlement: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+		},
+	}}
+	v := NewValidator(111, negs, nil, nil)
+	money := decimal.NewFromInt(1500) // k*pi = 10*150
+	stock := decimal.NewFromInt(-10)  // -k
+	reasons := v.ValidateExerciseTx(context.Background(), "neg-sell-1", &money, &stock)
+	if len(reasons) != 0 {
+		t.Fatalf("BUG 2: is_ongoing=false must not reject a valid before-settlement exercise, got %v", reasons)
+	}
+}
+
+// TestPrepareLocal_SellerExercise_AlreadyExercised_NoVote proves the executor
+// contract-status gate rejects a re-exercise of an already-EXERCISED contract.
+func TestPrepareLocal_SellerExercise_AlreadyExercised_NoVote(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000000000000015"}
+	s := &fakeExecStore{}
+	e := newExerciseTestExecutor(s, bc, &fakeTradingReserver{}, &fakeNegForExec{
+		SellerID: "C-15", IsOngoing: false, Amount: 10,
+		PricePerUnit: decimal.NewFromInt(150), Settlement: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+	})
+	cw := newFakeContractWriter()
+	cw.byNeg["neg-sell-1"] = &store.Contract{
+		ID: "otc-used", NegotiationID: "neg-sell-1", Status: store.ContractStatusExercised,
+		StockTicker: "AAPL", Amount: 10, StrikeCurrency: "USD", StrikeAmount: decimal.NewFromInt(150),
+		LocalPartyType: store.ContractPartySeller,
+	}
+	e.SetContractStore(cw)
+
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-exec-dup"},
+		Postings:      exerciseShapePostingsSellerSide(),
+	}
+	vote, err := e.PrepareLocal(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteNo {
+		t.Fatalf("expected NO for already-EXERCISED contract, got %q", vote.Vote)
+	}
+	if !hasReason(vote.Reasons, protocol.ReasonOptionUsedOrExpired) {
+		t.Errorf("expected OPTION_USED_OR_EXPIRED, got %v", vote.Reasons)
+	}
+	if len(s.txns) != 0 {
+		t.Errorf("nothing should be persisted on NO vote, got %d", len(s.txns))
+	}
+}
+
+// TestSettleSellerExercise_RefusesNonActiveContract proves the commit-side
+// double-exercise guard: settleSellerExercise must refuse (error, no side effects)
+// when the contract is already EXERCISED, so a replayed/duplicate EXERCISE commit
+// cannot remove shares or credit cash twice.
+func TestSettleSellerExercise_RefusesNonActiveContract(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000000000000015"}
+	td := &fakeTradingReserver{}
+	postings := exerciseShapePostingsSellerSide()
+	s := &fakeExecStore{
+		txns: map[string]*store.Transaction{
+			txKey(222, "tx-exec-replay"): {
+				TransactionIdRouting: 222,
+				TransactionIdLocal:   "tx-exec-replay",
+				Status:               store.TxStatusPrepared,
+				PostingsJSON:         mustPostingsJSON(t, postings),
+			},
+		},
+	}
+	cw := newFakeContractWriter()
+	cw.byNeg["neg-sell-1"] = &store.Contract{
+		ID: "otc-1", NegotiationID: "neg-sell-1", Status: store.ContractStatusExercised,
+		StockTicker: "AAPL", Amount: 10, StrikeCurrency: "USD", StrikeAmount: decimal.NewFromInt(150),
+		LocalPartyType: store.ContractPartySeller,
+	}
+	e := newTestExecutor(111, s, bc, td)
+	e.SetContractStore(cw)
+
+	err := e.CommitLocal(context.Background(), protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-exec-replay"})
+	if err == nil {
+		t.Fatal("expected CommitLocal to fail when settling an already-EXERCISED contract")
+	}
+	// No irreversible side effects: no shares removed, no cash credited.
+	if len(td.committed) != 0 {
+		t.Errorf("ExerciseOption must NOT run for a non-ACTIVE contract, got td.committed=%v", td.committed)
+	}
+	if len(bc.credited) != 0 {
+		t.Errorf("CreditMonas must NOT run for a non-ACTIVE contract, got bc.credited=%v", bc.credited)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// S4 — buyer-side Contract persistence on inbound accept-COMMIT
+// ---------------------------------------------------------------------------
+
+// acceptShapePostingsBuyerSide builds a 4-posting ACCEPT tx where WE (routing 111)
+// are the BUYER and the partner (routing 222) hosts the OPTION pseudo-account.
+func acceptShapePostingsBuyerSide() []protocol.Posting {
+	optDesc := protocol.OptionDescription{
+		NegotiationId:  protocol.ForeignBankId{RoutingNumber: 222, Id: "neg-buy-1"},
+		Stock:          protocol.StockDescription{Ticker: "AAPL"},
+		PricePerUnit:   protocol.MonetaryValue{Currency: "USD", Amount: decimal.NewFromInt(150)},
+		SettlementDate: "2999-01-01T00:00:00Z",
+		Amount:         10,
+	}
+	return []protocol.Posting{
+		{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "C-7"}}, Amount: decimal.NewFromInt(-50), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 222, Id: "C-2"}}, Amount: decimal.NewFromInt(50), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		{Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 222, Id: "neg-buy-1"}}, Amount: decimal.NewFromInt(-1), Asset: &protocol.OptionAsset{OptionDescription: optDesc}},
+		{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "C-7"}}, Amount: decimal.NewFromInt(1), Asset: &protocol.OptionAsset{OptionDescription: optDesc}},
+	}
+}
+
+func TestCommitLocal_BuyerSideAccept_PersistsContract(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000007": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)},
+	})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(7, "USD"): "111000000000000007"}
+	postings := acceptShapePostingsBuyerSide()
+	s := &fakeExecStore{
+		txns: map[string]*store.Transaction{
+			txKey(222, "tx-accept-buy"): {
+				TransactionIdRouting: 222,
+				TransactionIdLocal:   "tx-accept-buy",
+				Status:               store.TxStatusPrepared,
+				PostingsJSON:         mustPostingsJSON(t, postings),
+			},
+		},
+	}
+	cw := newFakeContractWriter()
+	// We are the BUYER (routing 111); the wire/option id "neg-buy-1" is the SELLER
+	// bank's authoritative id. We mirror it locally under "neg-local-buy-1" with
+	// remote_negotiation_id="neg-buy-1". The persisted contract must reference the
+	// LOCAL id (FK target), not the wire id.
+	negs := &fakeNegotiationLookup{negs: map[string]*fakeNegForExec{
+		"neg-local-buy-1": {SellerID: "C-2", IsOngoing: true, RemoteID: "neg-buy-1"},
+	}}
+	e := newExecutorWithNegs(111, s, bc, &fakeTradingReserver{}, negs)
+	e.SetContractStore(cw)
+
+	if err := e.CommitLocal(context.Background(), protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-accept-buy"}); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	if len(cw.inserted) != 1 {
+		t.Fatalf("expected 1 buyer-side contract persisted, got %d", len(cw.inserted))
+	}
+	c := cw.inserted[0]
+	if c.LocalPartyType != store.ContractPartyBuyer {
+		t.Errorf("expected localPartyType=BUYER, got %q", c.LocalPartyType)
+	}
+	// Contract keyed on the LOCAL negotiation id (FK satisfied), NOT the wire id.
+	if c.NegotiationID != "neg-local-buy-1" || c.StockTicker != "AAPL" || c.Amount != 10 {
+		t.Errorf("contract copy wrong: %+v", c)
+	}
+	if c.StrikeAmount.String() != "150" || c.StrikeCurrency != "USD" {
+		t.Errorf("expected strike 150 USD, got %s %s", c.StrikeAmount, c.StrikeCurrency)
+	}
+	if c.Status != store.ContractStatusActive {
+		t.Errorf("expected ACTIVE, got %q", c.Status)
+	}
+	if c.SellerRouting != 222 {
+		t.Errorf("expected sellerRouting 222 (option lives at seller bank), got %d", c.SellerRouting)
+	}
+}
+
+// fkEnforcingContractWriter wraps a fakeContractWriter and rejects an Insert whose
+// NegotiationID is not present in localNegIDs — modelling the real Postgres
+// interbank_contracts_negotiation_id_fkey constraint to interbank_negotiations(id).
+// This lets the unit test reproduce the live 500 deterministically without a DB.
+type fkEnforcingContractWriter struct {
+	*fakeContractWriter
+	localNegIDs map[string]bool
+}
+
+func (w *fkEnforcingContractWriter) Insert(ctx context.Context, c *store.Contract) error {
+	if !w.localNegIDs[c.NegotiationID] {
+		// Mirrors pgx error: insert or update on table "interbank_contracts" violates
+		// foreign key constraint "interbank_contracts_negotiation_id_fkey".
+		return errors.New(`ERROR: insert or update on table "interbank_contracts" violates foreign key constraint "interbank_contracts_negotiation_id_fkey" (SQLSTATE 23503)`)
+	}
+	return w.fakeContractWriter.Insert(ctx, c)
+}
+
+// TestCommitLocal_BuyerSideAccept_RemoteNegID_FKViolation_Reproducer is the
+// regression test for the reverse-direction (B1=buyer) accept-COMMIT 500. The inbound
+// accept's OptionDescription.negotiationId is the SELLER bank's authoritative id
+// ("neg-buy-1"); our only matching interbank_negotiations row is the local mirror
+// ("neg-local-buy-1", remote_negotiation_id="neg-buy-1"). Persisting the buyer contract
+// on the raw wire id violates the FK. The fix resolves wire→local first, so the contract
+// is keyed on the local id and the FK is satisfied.
+func TestCommitLocal_BuyerSideAccept_RemoteNegID_FKViolation_Reproducer(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000007": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)},
+	})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(7, "USD"): "111000000000000007"}
+	postings := acceptShapePostingsBuyerSide() // wire/option id = "neg-buy-1"
+	s := &fakeExecStore{
+		txns: map[string]*store.Transaction{
+			txKey(222, "tx-accept-buy"): {
+				TransactionIdRouting: 222,
+				TransactionIdLocal:   "tx-accept-buy",
+				Status:               store.TxStatusPrepared,
+				PostingsJSON:         mustPostingsJSON(t, postings),
+			},
+		},
+	}
+	// FK enforcer: only the LOCAL mirror id exists in interbank_negotiations.
+	cw := &fkEnforcingContractWriter{
+		fakeContractWriter: newFakeContractWriter(),
+		localNegIDs:        map[string]bool{"neg-local-buy-1": true},
+	}
+	negs := &fakeNegotiationLookup{negs: map[string]*fakeNegForExec{
+		"neg-local-buy-1": {SellerID: "C-2", IsOngoing: true, RemoteID: "neg-buy-1"},
+	}}
+	e := newExecutorWithNegs(111, s, bc, &fakeTradingReserver{}, negs)
+	e.SetContractStore(cw)
+
+	// With the fix the COMMIT_TX handler must NOT 500: the contract is keyed on the
+	// local id, which the FK enforcer accepts.
+	if err := e.CommitLocal(context.Background(), protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-accept-buy"}); err != nil {
+		t.Fatalf("CommitLocal must not fail (FK must be satisfied via local id): %v", err)
+	}
+	if len(cw.inserted) != 1 {
+		t.Fatalf("expected 1 buyer contract persisted, got %d", len(cw.inserted))
+	}
+	if got := cw.inserted[0].NegotiationID; got != "neg-local-buy-1" {
+		t.Fatalf("contract must be keyed on the LOCAL negotiation id; got %q (wire id leaked → FK violation)", got)
+	}
+	// And the tx is COMMITTED, not FAILED, so is_ongoing flips and the buyer can list/exercise.
+	tx, _ := s.FindTx(context.Background(), 222, "tx-accept-buy")
+	if tx == nil || tx.Status != store.TxStatusCommitted {
+		t.Fatalf("tx must be COMMITTED after a clean buyer-accept, got %+v", tx)
+	}
+}
+
+// TestCommitLocal_BuyerSideAccept_NoLocalMirror_FailsCleanly proves that when NO local
+// negotiation maps to the wire id we refuse to insert (rather than FK-500 or silently
+// drop referential integrity) — the option lifecycle returns an error and the tx is
+// flipped FAILED.
+func TestCommitLocal_BuyerSideAccept_NoLocalMirror_FailsCleanly(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000007": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)},
+	})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(7, "USD"): "111000000000000007"}
+	postings := acceptShapePostingsBuyerSide()
+	s := &fakeExecStore{
+		txns: map[string]*store.Transaction{
+			txKey(222, "tx-accept-buy"): {
+				TransactionIdRouting: 222,
+				TransactionIdLocal:   "tx-accept-buy",
+				Status:               store.TxStatusPrepared,
+				PostingsJSON:         mustPostingsJSON(t, postings),
+			},
+		},
+	}
+	cw := newFakeContractWriter()
+	// Empty lookup → no local negotiation maps to "neg-buy-1".
+	negs := &fakeNegotiationLookup{negs: map[string]*fakeNegForExec{}}
+	e := newExecutorWithNegs(111, s, bc, &fakeTradingReserver{}, negs)
+	e.SetContractStore(cw)
+
+	err := e.CommitLocal(context.Background(), protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-accept-buy"})
+	if err == nil {
+		t.Fatal("expected CommitLocal to fail when no local negotiation maps to the wire id")
+	}
+	if len(cw.inserted) != 0 {
+		t.Fatalf("no contract must be inserted without a resolvable local negotiation, got %+v", cw.inserted)
+	}
+	tx, _ := s.FindTx(context.Background(), 222, "tx-accept-buy")
+	if tx == nil || tx.Status != store.TxStatusFailed {
+		t.Fatalf("tx must be flipped FAILED on lifecycle error, got %+v", tx)
+	}
+}
+
+func TestCommitLocal_SellerSideAccept_DoesNotPersistBuyerContract(t *testing.T) {
+	optDesc := protocol.OptionDescription{
+		NegotiationId:  protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-sell-1"},
+		Stock:          protocol.StockDescription{Ticker: "AAPL"},
+		PricePerUnit:   protocol.MonetaryValue{Currency: "USD", Amount: decimal.NewFromInt(150)},
+		SettlementDate: "2999-01-01T00:00:00Z",
+		Amount:         10,
+	}
+	postings := []protocol.Posting{
+		{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 222, Id: "C-2"}}, Amount: decimal.NewFromInt(-50), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "C-15"}}, Amount: decimal.NewFromInt(50), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		{Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-sell-1"}}, Amount: decimal.NewFromInt(-1), Asset: &protocol.OptionAsset{OptionDescription: optDesc}},
+		{Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: 222, Id: "C-2"}}, Amount: decimal.NewFromInt(1), Asset: &protocol.OptionAsset{OptionDescription: optDesc}},
+	}
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000000000000015"}
+	s := &fakeExecStore{
+		txns: map[string]*store.Transaction{
+			txKey(222, "tx-accept-sell"): {
+				TransactionIdRouting: 222,
+				TransactionIdLocal:   "tx-accept-sell",
+				Status:               store.TxStatusPrepared,
+				PostingsJSON:         mustPostingsJSON(t, postings),
+			},
+		},
+	}
+	cw := newFakeContractWriter()
+	e := newTestExecutor(111, s, bc, &fakeTradingReserver{})
+	e.SetContractStore(cw)
+
+	if err := e.CommitLocal(context.Background(), protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-accept-sell"}); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	if len(cw.inserted) != 0 {
+		t.Errorf("seller-side accept must NOT persist a buyer contract here, got %+v", cw.inserted)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// S9 — inbound seller exercise settlement
+// ---------------------------------------------------------------------------
+
+func TestCommitLocal_SellerExercise_SettlesAndFlips(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{"111000000000000015": {Currency: "USD", AvailableBalance: decimal.NewFromInt(0)}})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000000000000015"}
+	td := &fakeTradingReserver{}
+	postings := exerciseShapePostingsSellerSide()
+	s := &fakeExecStore{
+		txns: map[string]*store.Transaction{
+			txKey(222, "tx-exec-sell"): {
+				TransactionIdRouting: 222,
+				TransactionIdLocal:   "tx-exec-sell",
+				Status:               store.TxStatusPrepared,
+				PostingsJSON:         mustPostingsJSON(t, postings),
+			},
+		},
+	}
+	cw := newFakeContractWriter()
+	cw.byNeg["neg-sell-1"] = &store.Contract{
+		ID: "otc-1", NegotiationID: "neg-sell-1", Status: store.ContractStatusActive,
+		StockTicker: "AAPL", Amount: 10, StrikeCurrency: "USD", StrikeAmount: decimal.NewFromInt(150),
+		LocalPartyType: store.ContractPartySeller,
+	}
+	e := newTestExecutor(111, s, bc, td)
+	e.SetContractStore(cw)
+
+	if err := e.CommitLocal(context.Background(), protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-exec-sell"}); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	// ExerciseOption must have been called for the negotiation.
+	if len(td.committed) != 1 || td.committed[0] != "option-exercise-neg-sell-1" {
+		t.Errorf("expected ExerciseOption(neg-sell-1), got td.committed=%v", td.committed)
+	}
+	// Seller cash credited k*pi = 1500 via CreditMonas.
+	if len(bc.credited) != 1 {
+		t.Fatalf("expected exactly 1 CreditMonas (seller strike), got %d: %+v", len(bc.credited), bc.credited)
+	}
+	got := bc.credited[0]
+	if got.accountNum != "111000000000000015" || got.currency != "USD" || got.amount.String() != "1500" {
+		t.Errorf("seller credit = %+v, want account=111000000000000015 USD 1500", got)
+	}
+	// Contract flipped EXERCISED.
+	if cw.statuses["otc-1"] != store.ContractStatusExercised {
+		t.Errorf("expected contract EXERCISED, got statuses=%v", cw.statuses)
+	}
+	if s.txns[txKey(222, "tx-exec-sell")].Status != store.TxStatusCommitted {
+		t.Errorf("expected tx COMMITTED")
+	}
+}

--- a/interbank-service/internal/service/otc_negotiation.go
+++ b/interbank-service/internal/service/otc_negotiation.go
@@ -55,6 +55,10 @@ func (a IntAmount) MarshalJSON() ([]byte, error) {
 type NegotiationStoreIface interface {
 	Insert(ctx context.Context, n *store.Negotiation) error
 	FindByAuthoritativeRef(ctx context.Context, routing int, id string) (*store.Negotiation, error)
+	// FindByID looks a negotiation up by its LOCAL primary-key id (unlike
+	// FindByAuthoritativeRef, which matches a mirror only by remote_negotiation_id).
+	// Needed by exercise outbound to resolve a held mirror's remote id from its local id.
+	FindByID(ctx context.Context, id string) (*store.Negotiation, error)
 	UpdateCounter(ctx context.Context, n *store.Negotiation) error
 	MarkClosed(ctx context.Context, id string) error
 }
@@ -364,6 +368,23 @@ func (l *NegotiationSellerLookup) FindSellerID(ctx context.Context, negID string
 		return "", fmt.Errorf("%w: %s", ErrNegotiationNotFound, negID)
 	}
 	return neg.SellerID, nil
+}
+
+// ResolveLocalNegotiationID maps a wire negotiation id to the local
+// interbank_negotiations.id that the interbank_contracts FK references. It reuses
+// FindByAuthoritativeRef, which matches an authoritative row by its own id or a
+// mirror row by its remote_negotiation_id. The returned id is always neg.ID — i.e.
+// our LOCAL primary key — so a contract keyed on it satisfies the FK regardless of
+// whether we authored the negotiation (authoritative) or mirror a partner's.
+func (l *NegotiationSellerLookup) ResolveLocalNegotiationID(ctx context.Context, wireID string) (string, bool, error) {
+	neg, err := l.store.FindByAuthoritativeRef(ctx, 0, wireID)
+	if err != nil {
+		return "", false, err
+	}
+	if neg == nil {
+		return "", false, nil
+	}
+	return neg.ID, true, nil
 }
 
 // FindNegotiation adapts to service.NegotiationReader for Validator use.

--- a/interbank-service/internal/service/otc_negotiation_test.go
+++ b/interbank-service/internal/service/otc_negotiation_test.go
@@ -36,6 +36,17 @@ func (f *fakeNegotiationStore) Insert(_ context.Context, n *store.Negotiation) e
 	return nil
 }
 
+func (f *fakeNegotiationStore) FindByID(_ context.Context, id string) (*store.Negotiation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n, ok := f.rows[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *n
+	return &cp, nil
+}
+
 func (f *fakeNegotiationStore) FindByAuthoritativeRef(_ context.Context, _ int, id string) (*store.Negotiation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/interbank-service/internal/service/otc_outbound.go
+++ b/interbank-service/internal/service/otc_outbound.go
@@ -104,6 +104,54 @@ type PartnerNameResolver interface {
 	DisplayName(routing int) string
 }
 
+// ContractReader is the read/write seam for buyer-side held option contracts:
+// S4 list, S6 exercise lookups, and the buyer "Odbi"/decline status flip.
+// *store.ContractStore satisfies it.
+type ContractReader interface {
+	FindByID(ctx context.Context, id string) (*store.Contract, error)
+	ListBuyerContracts(ctx context.Context, buyerID string) ([]*store.Contract, error)
+	UpdateStatus(ctx context.Context, id, status string) error
+}
+
+// ExerciseCoordinator is the seam to the buyer-bank exercise coordinator (S7/S8).
+// *Coordinator satisfies it via ExerciseOutbound.
+type ExerciseCoordinator interface {
+	ExerciseOutbound(ctx context.Context, contract *store.Contract, buyerLocalUserID int64, chosenAccountNum string) error
+}
+
+// PaymentCoordinator is the seam to the outbound regular-payment 2PC coordinator.
+// *Coordinator satisfies it via ExecutePayment.
+type PaymentCoordinator interface {
+	ExecutePayment(ctx context.Context, req PaymentRequest) error
+}
+
+// PaymentBody is the JSON body for POST /api/interbank/otc/payments — a regular
+// (non-OTC) cross-bank money transfer initiated by our bank.
+type PaymentBody struct {
+	FromAccount string          `json:"fromAccount"`
+	ToRouting   int             `json:"toRouting"`
+	ToAccount   string          `json:"toAccount"`
+	Amount      decimal.Decimal `json:"amount"`
+	Currency    string          `json:"currency"`
+	Purpose     string          `json:"purpose"`
+}
+
+// ContractView is the FE-facing held-option representation.
+type ContractView struct {
+	ID             string          `json:"id"`
+	NegotiationID  string          `json:"negotiationId"`
+	LocalPartyType string          `json:"localPartyType"`
+	BuyerID        string          `json:"buyerId"`
+	SellerRouting  int             `json:"sellerRoutingNumber"`
+	SellerID       string          `json:"sellerId"`
+	StockTicker    string          `json:"stockTicker"`
+	Amount         int             `json:"amount"`
+	StrikeCurrency string          `json:"strikeCurrency"`
+	StrikeAmount   decimal.Decimal `json:"strikeAmount"`
+	SettlementDate time.Time       `json:"settlementDate"`
+	Status         string          `json:"status"`
+}
+
 // ---------------------------------------------------------------------------
 // OtcOutboundService
 // ---------------------------------------------------------------------------
@@ -122,7 +170,24 @@ type OtcOutboundService struct {
 	client    OtcOutboundClient
 	otcSvc    *OtcNegotiationService // for local authoritative counter-offer path
 	partners  PartnerNameResolver
+	contracts ContractReader      // optional — buyer-side held option list (S4)
+	exerciser ExerciseCoordinator // optional — buyer-bank exercise coordinator (S7/S8)
+	payer     PaymentCoordinator  // optional — outbound regular-payment coordinator
 	log       *slog.Logger
+}
+
+// SetContractDeps wires the optional contract read seam (list held buyer options,
+// S4) and the buyer-bank exercise coordinator (S7/S8). Left nil in API-layer tests
+// that only exercise the negotiation routes.
+func (s *OtcOutboundService) SetContractDeps(contracts ContractReader, exerciser ExerciseCoordinator) {
+	s.contracts = contracts
+	s.exerciser = exerciser
+}
+
+// SetPaymentCoordinator wires the optional outbound regular-payment 2PC coordinator
+// (POST /api/interbank/otc/payments). Left nil in tests that do not exercise payments.
+func (s *OtcOutboundService) SetPaymentCoordinator(payer PaymentCoordinator) {
+	s.payer = payer
 }
 
 // NewOtcOutboundService constructs the service.
@@ -508,6 +573,156 @@ func (s *OtcOutboundService) FetchPartnerPublicStock(ctx context.Context, bankCo
 		return []protocol.PublicStockEntry{}, nil
 	}
 	return s.client.OutboundFetchPublicStock(ctx, bankCode)
+}
+
+// ---------------------------------------------------------------------------
+// ListContracts — GET /api/interbank/otc/contracts (+ /contracts/my)
+// ---------------------------------------------------------------------------
+
+// ListContracts returns the buyer-side held option contracts for principalUserID
+// (or all of them when isAdmin). These are the options our user holds the right to
+// exercise (local_party_type=BUYER), so the FE can list & exercise them (S4).
+func (s *OtcOutboundService) ListContracts(ctx context.Context, principalUserID int64, isAdmin bool) ([]ContractView, error) {
+	if s.contracts == nil {
+		return []ContractView{}, nil
+	}
+	var buyerID string
+	if !isAdmin {
+		if principalUserID == 0 {
+			return nil, fmt.Errorf("%w: principalUserID is zero and isAdmin is false", ErrNegotiationInvalid)
+		}
+		buyerID = fmt.Sprintf("C-%d", principalUserID)
+	}
+	rows, err := s.contracts.ListBuyerContracts(ctx, buyerID)
+	if err != nil {
+		return nil, fmt.Errorf("outbound: list contracts: %w", err)
+	}
+	views := make([]ContractView, 0, len(rows))
+	for _, c := range rows {
+		views = append(views, contractToView(c))
+	}
+	return views, nil
+}
+
+// ---------------------------------------------------------------------------
+// ExerciseContract — POST /api/interbank/otc/contracts/{id}/exercise
+// ---------------------------------------------------------------------------
+
+// ExerciseContract exercises a held buyer-side option. Guards (S6): the contract
+// must exist, be a BUYER contract, ACTIVE, and not past its settlement date. It
+// then delegates the 2PC exercise round to the buyer-bank coordinator (S7/S8).
+func (s *OtcOutboundService) ExerciseContract(ctx context.Context, principalUserID int64, contractID, chosenAccountNum string) error {
+	if s.contracts == nil || s.exerciser == nil {
+		return fmt.Errorf("%w: exercise not available (contract deps not wired)", ErrInterbankProtocol)
+	}
+	c, err := s.contracts.FindByID(ctx, contractID)
+	if err != nil {
+		return fmt.Errorf("outbound: find contract: %w", err)
+	}
+	if c == nil {
+		return fmt.Errorf("%w: contract %s", ErrNegotiationNotFound, contractID)
+	}
+	if c.LocalPartyType != store.ContractPartyBuyer {
+		return fmt.Errorf("%w: contract %s is not a buyer-side held option", ErrNegotiationInvalid, contractID)
+	}
+	if c.Status != store.ContractStatusActive {
+		return fmt.Errorf("%w: contract %s status is %s (must be ACTIVE)", ErrNegotiationClosed, contractID, c.Status)
+	}
+	if !c.SettlementDate.IsZero() && !c.SettlementDate.After(time.Now()) {
+		return fmt.Errorf("%w: contract %s settlement date has passed", ErrNegotiationClosed, contractID)
+	}
+
+	buyerUserID := principalUserID
+	if id, perr := parseOwnerID(c.BuyerID); perr == nil {
+		// Prefer the contract's recorded buyer so admins can exercise on behalf.
+		buyerUserID = id
+	}
+	return s.exerciser.ExerciseOutbound(ctx, c, buyerUserID, chosenAccountNum)
+}
+
+// ---------------------------------------------------------------------------
+// DeclineContract — POST /api/interbank/otc/contracts/{id}/decline
+// ---------------------------------------------------------------------------
+
+// DeclineContract is the buyer "Odbi" action: abandon a held option early instead
+// of exercising it. Guards mirror ExerciseContract — the contract must exist, be a
+// BUYER-side held option, ACTIVE, and not past its settlement date. It flips the
+// contract → DECLINED (terminal, distinct from EXPIRED/EXERCISED).
+//
+// No money moves: for Banka 1 the buyer's strike is reserved only at EXERCISE time
+// (protocol default), so a non-exercised buyer holds no standing strike reservation
+// to release. The premium was paid at accept and stays with the seller. This is a
+// pure local close of the buyer's holding — no shares are transferred and no
+// inter-bank message is sent (the seller's option lapses on its own expiry sweep).
+func (s *OtcOutboundService) DeclineContract(ctx context.Context, principalUserID int64, contractID string) error {
+	if s.contracts == nil {
+		return fmt.Errorf("%w: decline not available (contract deps not wired)", ErrInterbankProtocol)
+	}
+	c, err := s.contracts.FindByID(ctx, contractID)
+	if err != nil {
+		return fmt.Errorf("outbound: find contract: %w", err)
+	}
+	if c == nil {
+		return fmt.Errorf("%w: contract %s", ErrNegotiationNotFound, contractID)
+	}
+	if c.LocalPartyType != store.ContractPartyBuyer {
+		return fmt.Errorf("%w: contract %s is not a buyer-side held option", ErrNegotiationClosed, contractID)
+	}
+	if c.Status != store.ContractStatusActive {
+		return fmt.Errorf("%w: contract %s status is %s (must be ACTIVE)", ErrNegotiationClosed, contractID, c.Status)
+	}
+	if !c.SettlementDate.IsZero() && !c.SettlementDate.After(time.Now()) {
+		return fmt.Errorf("%w: contract %s settlement date has passed", ErrNegotiationClosed, contractID)
+	}
+	if err := s.contracts.UpdateStatus(ctx, c.ID, store.ContractStatusDeclined); err != nil {
+		return fmt.Errorf("outbound: decline contract %s: %w", contractID, err)
+	}
+	s.log.InfoContext(ctx, "declined buyer-side option contract (Odbi)",
+		"contract", c.ID, "neg", c.NegotiationID, "buyer", c.BuyerID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// PayOutbound — POST /api/interbank/otc/payments
+// ---------------------------------------------------------------------------
+
+// PayOutbound initiates a REGULAR (non-OTC) inter-bank payment from one of our
+// accounts to a recipient at the target bank. It validates the request shape and
+// delegates the 2PC (funds-guard → reserve → partner prepare → commit/rollback) to
+// the payment coordinator. Backend capability only — no Banka-1 FE for this (Tim-1
+// scope).
+func (s *OtcOutboundService) PayOutbound(ctx context.Context, body PaymentBody) error {
+	if s.payer == nil {
+		return fmt.Errorf("%w: payments not available (payment coordinator not wired)", ErrInterbankProtocol)
+	}
+	if body.ToRouting == s.myRouting {
+		return fmt.Errorf("%w: toRouting must not be our own routing (%d)", ErrNegotiationInvalid, s.myRouting)
+	}
+	return s.payer.ExecutePayment(ctx, PaymentRequest{
+		FromAccount: body.FromAccount,
+		ToRouting:   body.ToRouting,
+		ToAccount:   body.ToAccount,
+		Amount:      body.Amount,
+		Currency:    body.Currency,
+		Purpose:     body.Purpose,
+	})
+}
+
+func contractToView(c *store.Contract) ContractView {
+	return ContractView{
+		ID:             c.ID,
+		NegotiationID:  c.NegotiationID,
+		LocalPartyType: c.LocalPartyType,
+		BuyerID:        c.BuyerID,
+		SellerRouting:  c.SellerRouting,
+		SellerID:       c.SellerID,
+		StockTicker:    c.StockTicker,
+		Amount:         c.Amount,
+		StrikeCurrency: c.StrikeCurrency,
+		StrikeAmount:   c.StrikeAmount,
+		SettlementDate: c.SettlementDate,
+		Status:         c.Status,
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/interbank-service/internal/service/otc_outbound_contracts_test.go
+++ b/interbank-service/internal/service/otc_outbound_contracts_test.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// S4 list + S6 guard tests for OtcOutboundService.ListContracts / ExerciseContract.
+
+// fakeContractReader implements ContractReader.
+type fakeContractReader struct {
+	byID      map[string]*store.Contract
+	buyerList []*store.Contract
+	listErr   error
+	updateErr error
+	updated   map[string]string
+}
+
+func newFakeContractReader() *fakeContractReader {
+	return &fakeContractReader{byID: map[string]*store.Contract{}, updated: map[string]string{}}
+}
+
+func (f *fakeContractReader) FindByID(_ context.Context, id string) (*store.Contract, error) {
+	c, ok := f.byID[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *c
+	return &cp, nil
+}
+
+func (f *fakeContractReader) ListBuyerContracts(_ context.Context, buyerID string) ([]*store.Contract, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if buyerID == "" {
+		return f.buyerList, nil
+	}
+	var out []*store.Contract
+	for _, c := range f.buyerList {
+		if c.BuyerID == buyerID {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeContractReader) UpdateStatus(_ context.Context, id, status string) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	f.updated[id] = status
+	return nil
+}
+
+// fakeExerciseCoordinator implements ExerciseCoordinator.
+type fakeExerciseCoordinator struct {
+	called      bool
+	gotContract *store.Contract
+	gotBuyer    int64
+	gotAccount  string
+	err         error
+}
+
+func (f *fakeExerciseCoordinator) ExerciseOutbound(_ context.Context, c *store.Contract, buyer int64, account string) error {
+	f.called = true
+	f.gotContract = c
+	f.gotBuyer = buyer
+	f.gotAccount = account
+	return f.err
+}
+
+func activeBuyerContract(id string) *store.Contract {
+	return &store.Contract{
+		ID:             id,
+		NegotiationID:  "neg-" + id,
+		BuyerRouting:   testOutboundMyRouting,
+		BuyerID:        "C-7",
+		SellerRouting:  testOutboundPartnerRN,
+		SellerID:       "C-2",
+		StockTicker:    "AAPL",
+		Amount:         10,
+		StrikeCurrency: "USD",
+		StrikeAmount:   decimal.NewFromInt(150),
+		SettlementDate: time.Now().Add(24 * time.Hour),
+		Status:         store.ContractStatusActive,
+		LocalPartyType: store.ContractPartyBuyer,
+	}
+}
+
+func newContractsSvc(cr ContractReader, ex ExerciseCoordinator) *OtcOutboundService {
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	svc.SetContractDeps(cr, ex)
+	return svc
+}
+
+func TestListContracts_BuyerScoped(t *testing.T) {
+	cr := newFakeContractReader()
+	cr.buyerList = []*store.Contract{activeBuyerContract("otc-1"), activeBuyerContract("otc-2")}
+	svc := newContractsSvc(cr, &fakeExerciseCoordinator{})
+
+	views, err := svc.ListContracts(context.Background(), 7, false)
+	if err != nil {
+		t.Fatalf("ListContracts: %v", err)
+	}
+	if len(views) != 2 {
+		t.Fatalf("expected 2 buyer contracts, got %d", len(views))
+	}
+	if views[0].LocalPartyType != store.ContractPartyBuyer || views[0].StrikeAmount.String() != "150" {
+		t.Errorf("unexpected view: %+v", views[0])
+	}
+}
+
+func TestListContracts_NoDepsWired_EmptySlice(t *testing.T) {
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	views, err := svc.ListContracts(context.Background(), 7, false)
+	if err != nil || len(views) != 0 {
+		t.Errorf("expected empty, got views=%v err=%v", views, err)
+	}
+}
+
+func TestExerciseContract_HappyPath_DelegatesToCoordinator(t *testing.T) {
+	cr := newFakeContractReader()
+	c := activeBuyerContract("otc-1")
+	cr.byID["otc-1"] = c
+	ex := &fakeExerciseCoordinator{}
+	svc := newContractsSvc(cr, ex)
+
+	if err := svc.ExerciseContract(context.Background(), 7, "otc-1", "111000000000000007"); err != nil {
+		t.Fatalf("ExerciseContract: %v", err)
+	}
+	if !ex.called {
+		t.Fatal("expected coordinator.ExerciseOutbound to be called")
+	}
+	if ex.gotBuyer != 7 || ex.gotAccount != "111000000000000007" {
+		t.Errorf("buyer/account wrong: buyer=%d account=%q", ex.gotBuyer, ex.gotAccount)
+	}
+}
+
+func TestExerciseContract_NotFound(t *testing.T) {
+	svc := newContractsSvc(newFakeContractReader(), &fakeExerciseCoordinator{})
+	err := svc.ExerciseContract(context.Background(), 7, "ghost", "")
+	if !errors.Is(err, ErrNegotiationNotFound) {
+		t.Errorf("expected ErrNegotiationNotFound, got %v", err)
+	}
+}
+
+func TestExerciseContract_NotBuyerSide_Rejected(t *testing.T) {
+	cr := newFakeContractReader()
+	c := activeBuyerContract("otc-1")
+	c.LocalPartyType = store.ContractPartySeller // we host the option → not a buyer-side holding
+	cr.byID["otc-1"] = c
+	ex := &fakeExerciseCoordinator{}
+	svc := newContractsSvc(cr, ex)
+
+	err := svc.ExerciseContract(context.Background(), 7, "otc-1", "")
+	if !errors.Is(err, ErrNegotiationInvalid) {
+		t.Errorf("expected ErrNegotiationInvalid for non-buyer contract, got %v", err)
+	}
+	if ex.called {
+		t.Error("coordinator must NOT be called for a non-buyer contract")
+	}
+}
+
+func TestExerciseContract_NotActive_Rejected(t *testing.T) {
+	cr := newFakeContractReader()
+	c := activeBuyerContract("otc-1")
+	c.Status = store.ContractStatusExercised
+	cr.byID["otc-1"] = c
+	ex := &fakeExerciseCoordinator{}
+	svc := newContractsSvc(cr, ex)
+
+	err := svc.ExerciseContract(context.Background(), 7, "otc-1", "")
+	if !errors.Is(err, ErrNegotiationClosed) {
+		t.Errorf("expected ErrNegotiationClosed for non-ACTIVE contract, got %v", err)
+	}
+	if ex.called {
+		t.Error("coordinator must NOT be called for a non-ACTIVE contract")
+	}
+}
+
+func TestExerciseContract_PastSettlement_Rejected(t *testing.T) {
+	cr := newFakeContractReader()
+	c := activeBuyerContract("otc-1")
+	c.SettlementDate = time.Now().Add(-1 * time.Hour) // expired
+	cr.byID["otc-1"] = c
+	ex := &fakeExerciseCoordinator{}
+	svc := newContractsSvc(cr, ex)
+
+	err := svc.ExerciseContract(context.Background(), 7, "otc-1", "")
+	if !errors.Is(err, ErrNegotiationClosed) {
+		t.Errorf("expected ErrNegotiationClosed for past settlement, got %v", err)
+	}
+	if ex.called {
+		t.Error("coordinator must NOT be called past settlement")
+	}
+}

--- a/interbank-service/internal/service/otc_outbound_test.go
+++ b/interbank-service/internal/service/otc_outbound_test.go
@@ -572,3 +572,170 @@ func TestToView_CounterpartyBankName(t *testing.T) {
 		t.Errorf("expected remoteId=%s, got %v", remoteID, view.RemoteID)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// DeclineContract (buyer "Odbi") + PayOutbound (regular payment) fakes & tests
+// ---------------------------------------------------------------------------
+
+// fakeContractRW implements ContractReader (read + UpdateStatus) for decline tests.
+type fakeContractRW struct {
+	byID     map[string]*store.Contract
+	statuses map[string]string
+}
+
+func newFakeContractRW(cs ...*store.Contract) *fakeContractRW {
+	m := map[string]*store.Contract{}
+	for _, c := range cs {
+		m[c.ID] = c
+	}
+	return &fakeContractRW{byID: m, statuses: map[string]string{}}
+}
+
+func (f *fakeContractRW) FindByID(_ context.Context, id string) (*store.Contract, error) {
+	if c, ok := f.byID[id]; ok {
+		cp := *c
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeContractRW) ListBuyerContracts(_ context.Context, _ string) ([]*store.Contract, error) {
+	return nil, nil
+}
+
+func (f *fakeContractRW) UpdateStatus(_ context.Context, id, status string) error {
+	f.statuses[id] = status
+	return nil
+}
+
+func buyerActiveContract(id string, settlement time.Time, party string) *store.Contract {
+	return &store.Contract{
+		ID:             id,
+		NegotiationID:  "neg-" + id,
+		BuyerRouting:   testOutboundMyRouting,
+		BuyerID:        "C-15",
+		SellerRouting:  testOutboundPartnerRN,
+		SellerID:       "C-2",
+		StockTicker:    "AAPL",
+		Amount:         10,
+		StrikeCurrency: "USD",
+		StrikeAmount:   decimal.NewFromInt(150),
+		SettlementDate: settlement,
+		Status:         store.ContractStatusActive,
+		LocalPartyType: party,
+	}
+}
+
+func TestDeclineContract_BuyerActiveFuture_FlipsDeclined(t *testing.T) {
+	c := buyerActiveContract("otc-dec-1", time.Now().Add(24*time.Hour), store.ContractPartyBuyer)
+	cr := newFakeContractRW(c)
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	svc.SetContractDeps(cr, nil)
+
+	if err := svc.DeclineContract(context.Background(), 15, "otc-dec-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cr.statuses["otc-dec-1"] != store.ContractStatusDeclined {
+		t.Errorf("expected DECLINED, got %q", cr.statuses["otc-dec-1"])
+	}
+}
+
+func TestDeclineContract_NotFound(t *testing.T) {
+	cr := newFakeContractRW()
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	svc.SetContractDeps(cr, nil)
+
+	err := svc.DeclineContract(context.Background(), 15, "ghost")
+	if !errors.Is(err, ErrNegotiationNotFound) {
+		t.Fatalf("expected ErrNegotiationNotFound (404), got %v", err)
+	}
+}
+
+func TestDeclineContract_NotBuyer_Conflict(t *testing.T) {
+	c := buyerActiveContract("otc-dec-sell", time.Now().Add(24*time.Hour), store.ContractPartySeller)
+	cr := newFakeContractRW(c)
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	svc.SetContractDeps(cr, nil)
+
+	err := svc.DeclineContract(context.Background(), 15, "otc-dec-sell")
+	if !errors.Is(err, ErrNegotiationClosed) {
+		t.Fatalf("expected ErrNegotiationClosed (409) for non-buyer, got %v", err)
+	}
+	if _, flipped := cr.statuses["otc-dec-sell"]; flipped {
+		t.Errorf("seller contract must not be DECLINED")
+	}
+}
+
+func TestDeclineContract_NotActive_Conflict(t *testing.T) {
+	c := buyerActiveContract("otc-dec-ex", time.Now().Add(24*time.Hour), store.ContractPartyBuyer)
+	c.Status = store.ContractStatusExercised
+	cr := newFakeContractRW(c)
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	svc.SetContractDeps(cr, nil)
+
+	err := svc.DeclineContract(context.Background(), 15, "otc-dec-ex")
+	if !errors.Is(err, ErrNegotiationClosed) {
+		t.Fatalf("expected ErrNegotiationClosed (409) for non-active, got %v", err)
+	}
+}
+
+func TestDeclineContract_PastSettlement_Conflict(t *testing.T) {
+	c := buyerActiveContract("otc-dec-past", time.Now().Add(-1*time.Hour), store.ContractPartyBuyer)
+	cr := newFakeContractRW(c)
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	svc.SetContractDeps(cr, nil)
+
+	err := svc.DeclineContract(context.Background(), 15, "otc-dec-past")
+	if !errors.Is(err, ErrNegotiationClosed) {
+		t.Fatalf("expected ErrNegotiationClosed (409) past settlement, got %v", err)
+	}
+}
+
+// fakePaymentCoordinator captures the PaymentRequest passed to ExecutePayment.
+type fakePaymentCoordinator struct {
+	called bool
+	got    PaymentRequest
+	err    error
+}
+
+func (f *fakePaymentCoordinator) ExecutePayment(_ context.Context, req PaymentRequest) error {
+	f.called = true
+	f.got = req
+	return f.err
+}
+
+func TestPayOutbound_DelegatesToCoordinator(t *testing.T) {
+	pc := &fakePaymentCoordinator{}
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	svc.SetPaymentCoordinator(pc)
+
+	body := PaymentBody{
+		FromAccount: "111000000000000015",
+		ToRouting:   testOutboundPartnerRN,
+		ToAccount:   "222000000000000099",
+		Amount:      decimal.NewFromInt(500),
+		Currency:    "USD",
+		Purpose:     "rent",
+	}
+	if err := svc.PayOutbound(context.Background(), body); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pc.called || pc.got.FromAccount != "111000000000000015" || pc.got.ToAccount != "222000000000000099" || !pc.got.Amount.Equal(decimal.NewFromInt(500)) {
+		t.Errorf("coordinator not invoked with expected request: %+v", pc.got)
+	}
+}
+
+func TestPayOutbound_RejectsSameBankRouting(t *testing.T) {
+	pc := &fakePaymentCoordinator{}
+	svc := newOutboundSvc(newFakeOutboundNegStore(), &fakeOtcOutboundClient{})
+	svc.SetPaymentCoordinator(pc)
+
+	body := PaymentBody{FromAccount: "111000000000000015", ToRouting: testOutboundMyRouting, ToAccount: "111000000000000099", Amount: decimal.NewFromInt(10), Currency: "USD"}
+	err := svc.PayOutbound(context.Background(), body)
+	if !errors.Is(err, ErrNegotiationInvalid) {
+		t.Fatalf("expected ErrNegotiationInvalid for same-bank routing, got %v", err)
+	}
+	if pc.called {
+		t.Errorf("coordinator must not be called for same-bank routing")
+	}
+}

--- a/interbank-service/internal/service/validator.go
+++ b/interbank-service/internal/service/validator.go
@@ -142,11 +142,19 @@ func (v *Validator) validateRealAccount(ctx context.Context, acc *protocol.RealA
 			}
 			return nil, err
 		}
-		if info.Currency != monas.Currency {
-			return &protocol.NoVoteReason{Reason: protocol.ReasonNoSuchAsset, Posting: &p}, nil
-		}
-		if p.Amount.IsNegative() && info.AvailableBalance.LessThan(p.Amount.Abs()) {
-			return &protocol.NoVoteReason{Reason: protocol.ReasonInsufficientAsset, Posting: &p}, nil
+		// MONAS is always an acceptable asset for a cash account. A currency mismatch
+		// on a DEBIT (positive / recipient) leg is NOT a NO vote — banking-core converts
+		// it on commit via CreditMonas (protocol §2.8.4). Only the CREDIT (negative /
+		// sender) leg requires same-currency funds and the INSUFFICIENT balance check.
+		if p.Amount.IsNegative() {
+			if info.Currency != monas.Currency {
+				// Sender pays from a same-currency account; a foreign-currency sender leg
+				// cannot be debited here without conversion (out of this wave's scope).
+				return &protocol.NoVoteReason{Reason: protocol.ReasonNoSuchAsset, Posting: &p}, nil
+			}
+			if info.AvailableBalance.LessThan(p.Amount.Abs()) {
+				return &protocol.NoVoteReason{Reason: protocol.ReasonInsufficientAsset, Posting: &p}, nil
+			}
 		}
 		return nil, nil
 
@@ -242,14 +250,57 @@ func (v *Validator) validateOption(ctx context.Context, id protocol.ForeignBankI
 	return nil, nil
 }
 
-// accountIsOurs returns true if the 18-digit account number's routing prefix (first 3 digits)
-// matches our routing number.
+// ValidateExerciseTx validates an inbound EXERCISE transaction at the seller bank
+// (we host the OPTION pseudo-account). Per §2.8.6/§2.12.1:
+//   - the negotiation must exist and not be past its settlement date
+//     (else OPTION_USED_OR_EXPIRED);
+//   - the OPTION account must be debited EXACTLY amount×pricePerUnit money and
+//     credited EXACTLY amount stocks (else OPTION_AMOUNT_INCORRECT).
+//
+// moneyDebit is the (positive) money amount on the OPTION account; stockCredit is
+// the (negative) stock amount on the OPTION account. Either may be nil when the
+// corresponding leg is absent — that is itself an OPTION_AMOUNT_INCORRECT.
+//
+// IMPORTANT: this validator deliberately does NOT gate on neg.IsOngoing. After an
+// OTC accept concludes, the negotiation is correctly is_ongoing=false (the deal is
+// done) while the resulting CONTRACT is ACTIVE and exercisable until settlement.
+// !IsOngoing is the WRONG proxy for "option already used" and rejected every
+// legitimate inter-bank exercise. "Already used/expired" is the CONTRACT status,
+// which the per-posting validator cannot reach; that gate lives in the executor
+// (PrepareLocal exercise branch + settleSellerExercise), where e.contracts is wired.
+func (v *Validator) ValidateExerciseTx(ctx context.Context, negID string, moneyDebit, stockCredit *decimal.Decimal) []protocol.NoVoteReason {
+	id := protocol.ForeignBankId{RoutingNumber: v.myRouting, Id: negID}
+	if v.negs == nil {
+		return []protocol.NoVoteReason{{Reason: protocol.ReasonOptionNegotiationNotFound}}
+	}
+	neg, err := v.negs.FindNegotiation(ctx, id)
+	if err != nil || neg == nil {
+		return []protocol.NoVoteReason{{Reason: protocol.ReasonOptionNegotiationNotFound}}
+	}
+	if !neg.SettlementDate.IsZero() && !neg.SettlementDate.After(time.Now()) {
+		return []protocol.NoVoteReason{{Reason: protocol.ReasonOptionUsedOrExpired}}
+	}
+	k := decimal.NewFromInt(int64(neg.Amount))
+	kPi := k.Mul(neg.PricePerUnit)
+	if moneyDebit == nil || stockCredit == nil ||
+		!moneyDebit.Equal(kPi) || !stockCredit.Abs().Equal(k) {
+		return []protocol.NoVoteReason{{Reason: protocol.ReasonOptionAmountIncorrect}}
+	}
+	return nil
+}
+
+// accountIsOurs returns true if the account number's routing prefix (first 3 digits)
+// matches our routing number. Ownership is decided by the prefix (first 3 digits =
+// the bank's routing number), NOT by an exact length: Banka 1 uses 19-digit accounts
+// (e.g. 1110001000000000322), so a hardcoded len != 18 check rejected OUR OWN accounts,
+// meaning an inbound RealAccount recipient/sender leg was never recognised as ours
+// (CreditMonas/ReserveMonas was skipped) → payments never booked. The prefix is
+// sufficient and unique: foreign banks carry a different routing prefix.
 func (v *Validator) accountIsOurs(num string) bool {
-	if len(num) != 18 {
+	if len(num) < 3 {
 		return false
 	}
-	prefix := num[:3]
-	return prefix == fmt.Sprintf("%03d", v.myRouting)
+	return num[:3] == fmt.Sprintf("%03d", v.myRouting)
 }
 
 // parseOwnerID extracts the numeric portion of a prefixed id like "C-7" or "E-42".

--- a/interbank-service/internal/store/contracts.go
+++ b/interbank-service/internal/store/contracts.go
@@ -17,6 +17,16 @@ const (
 	ContractStatusExercised      = "EXERCISED"       // option exercised successfully
 	ContractStatusExpired        = "EXPIRED"         // settlement_date passed without exercise
 	ContractStatusReleased       = "RELEASED"        // cancelled before expiry
+	ContractStatusDeclined       = "DECLINED"        // buyer abandoned the option early ("Odbi")
+)
+
+// Contract local-party-type constants (migration 20260524000006). Distinguishes
+// which side of the option WE hold locally:
+//   - SELLER — we host the option pseudo-account (seller-side accept coordinator).
+//   - BUYER  — our user holds the option right (buyer-side inbound accept).
+const (
+	ContractPartySeller = "SELLER"
+	ContractPartyBuyer  = "BUYER"
 )
 
 // Contract mirrors the interbank_contracts row.
@@ -43,6 +53,7 @@ type Contract struct {
 	Status                 string
 	OptionPseudoOwnerRouting int
 	OptionPseudoOwnerID    string
+	LocalPartyType         string // SELLER | BUYER (migration 20260524000006)
 	Version                int64
 	CreatedAt              time.Time
 	ExercisedAt            *time.Time
@@ -56,7 +67,7 @@ func NewContractStore(pool *pgxpool.Pool) *ContractStore { return &ContractStore
 const contractSelectCols = `
 	id, negotiation_id, buyer_routing_number, buyer_id, seller_routing_number, seller_id,
 	stock_ticker, amount, strike_currency, strike_amount, settlement_date, status,
-	option_pseudo_owner_routing, option_pseudo_owner_id,
+	option_pseudo_owner_routing, option_pseudo_owner_id, local_party_type,
 	version, created_at, exercised_at, expired_at`
 
 func scanContract(row pgx.Row) (*Contract, error) {
@@ -64,7 +75,7 @@ func scanContract(row pgx.Row) (*Contract, error) {
 	err := row.Scan(
 		&c.ID, &c.NegotiationID, &c.BuyerRouting, &c.BuyerID, &c.SellerRouting, &c.SellerID,
 		&c.StockTicker, &c.Amount, &c.StrikeCurrency, &c.StrikeAmount, &c.SettlementDate, &c.Status,
-		&c.OptionPseudoOwnerRouting, &c.OptionPseudoOwnerID,
+		&c.OptionPseudoOwnerRouting, &c.OptionPseudoOwnerID, &c.LocalPartyType,
 		&c.Version, &c.CreatedAt, &c.ExercisedAt, &c.ExpiredAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -76,19 +87,57 @@ func scanContract(row pgx.Row) (*Contract, error) {
 	return &c, nil
 }
 
-// Insert writes a new contract row, populating CreatedAt.
+// Insert writes a new contract row, populating CreatedAt. When LocalPartyType is
+// empty it defaults to SELLER (the historical seller-side accept-coordinator path).
 func (s *ContractStore) Insert(ctx context.Context, c *Contract) error {
+	partyType := c.LocalPartyType
+	if partyType == "" {
+		partyType = ContractPartySeller
+	}
+	c.LocalPartyType = partyType
 	return s.pool.QueryRow(ctx, `
 		INSERT INTO interbank_contracts
 			(id, negotiation_id, buyer_routing_number, buyer_id, seller_routing_number, seller_id,
 			 stock_ticker, amount, strike_currency, strike_amount, settlement_date, status,
-			 option_pseudo_owner_routing, option_pseudo_owner_id, version)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,0)
+			 option_pseudo_owner_routing, option_pseudo_owner_id, local_party_type, version)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,0)
 		RETURNING created_at`,
 		c.ID, c.NegotiationID, c.BuyerRouting, c.BuyerID, c.SellerRouting, c.SellerID,
 		c.StockTicker, c.Amount, c.StrikeCurrency, c.StrikeAmount, c.SettlementDate, c.Status,
-		c.OptionPseudoOwnerRouting, c.OptionPseudoOwnerID,
+		c.OptionPseudoOwnerRouting, c.OptionPseudoOwnerID, partyType,
 	).Scan(&c.CreatedAt)
+}
+
+// ListBuyerContracts returns the buyer-side held option contracts (local_party_type
+// = BUYER) for a given buyer foreign id, newest first. When buyerID is empty
+// (admin/supervisor scope) all buyer-side contracts are returned. Used by
+// GET /api/interbank/otc/contracts so the FE can list & exercise held options.
+func (s *ContractStore) ListBuyerContracts(ctx context.Context, buyerID string) ([]*Contract, error) {
+	var rows pgx.Rows
+	var err error
+	if buyerID == "" {
+		rows, err = s.pool.Query(ctx,
+			`SELECT `+contractSelectCols+` FROM interbank_contracts
+			 WHERE local_party_type = 'BUYER' ORDER BY created_at DESC`)
+	} else {
+		rows, err = s.pool.Query(ctx,
+			`SELECT `+contractSelectCols+` FROM interbank_contracts
+			 WHERE local_party_type = 'BUYER' AND buyer_id = $1 ORDER BY created_at DESC`,
+			buyerID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*Contract
+	for rows.Next() {
+		c, scanErr := scanContract(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
 }
 
 // FindByNegotiationID returns (nil, nil) if not found.
@@ -120,6 +169,31 @@ func (s *ContractStore) SumActiveBySellerAndTicker(ctx context.Context, sellerRo
 		  AND status                = 'ACTIVE'`,
 		sellerRouting, sellerID, ticker).Scan(&sum)
 	return sum, err
+}
+
+// ListExpirable returns every ACTIVE contract whose settlement_date is already in
+// the past — the candidates the expiry sweeper (scheduler/expiry.go) must settle.
+// Ordered oldest-first so a backlog is drained in settlement order. The index
+// idx_interbank_contracts_status_settle (status, settlement_date) backs the
+// status='ACTIVE' predicate.
+func (s *ContractStore) ListExpirable(ctx context.Context) ([]*Contract, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+contractSelectCols+` FROM interbank_contracts
+		 WHERE status = 'ACTIVE' AND settlement_date < now()
+		 ORDER BY settlement_date ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*Contract
+	for rows.Next() {
+		c, scanErr := scanContract(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
 }
 
 // UpdateStatus flips a contract's status (e.g. ACTIVE→EXERCISED or →EXPIRED).

--- a/interbank-service/internal/store/db_test.go
+++ b/interbank-service/internal/store/db_test.go
@@ -205,7 +205,7 @@ func contractRowVals() []any {
 	return []any{
 		"c-1", "neg-1", 222, "C-2", 111, "C-5",
 		"AAPL", 10, "USD", decimal.RequireFromString("200.00"), now, ContractStatusActive,
-		222, "C-2",
+		222, "C-2", ContractPartySeller,
 		int64(0), now, nil, nil,
 	}
 }

--- a/interbank-service/migrations/20260524000006_contract_local_party_type.sql
+++ b/interbank-service/migrations/20260524000006_contract_local_party_type.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- +goose StatementBegin
+-- S4: buyer-side OTC option contract persistence.
+--
+-- interbank_contracts originally held only SELLER-side contracts created by the
+-- accept coordinator (we hosted the option pseudo-account). When we are the BUYER
+-- bank (the partner hosts the option), the inbound accept-COMMIT must also persist
+-- a contract so the buyer can later list & exercise their held options.
+--
+-- local_party_type distinguishes the two:
+--   - 'SELLER' — we host the option pseudo-account (existing rows).
+--   - 'BUYER'  — our user holds the option right (new buyer-side rows).
+--
+-- Existing rows were all created by the seller-side accept coordinator, so the
+-- backfill default of 'SELLER' is correct for historical data.
+ALTER TABLE interbank_contracts
+    ADD COLUMN IF NOT EXISTS local_party_type VARCHAR(8) NOT NULL DEFAULT 'SELLER';
+
+CREATE INDEX IF NOT EXISTS idx_interbank_contracts_party_buyer
+    ON interbank_contracts(local_party_type, buyer_routing_number, buyer_id, status);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_interbank_contracts_party_buyer;
+ALTER TABLE interbank_contracts DROP COLUMN IF EXISTS local_party_type;
+-- +goose StatementEnd

--- a/market-service-go/migrations/026_seed_price_history.sql
+++ b/market-service-go/migrations/026_seed_price_history.sql
@@ -1,4 +1,10 @@
-INSERT INTO listing_daily_price_info (listing_id, date, price, ask, bid, change, volume) VALUES
+-- FIX (lokalni integ + fresh deploy): originalni seed je referencirao listing_id
+-- 101/102/103/201/202 (forex/futures) koji NE postoje — katalog (022) kreira listinge
+-- na sekvencijalnim id-jevima (1-10 akcije, 11+ opcije), nikad 101/201. Na fresh DB
+-- to obara FK fk_listing_daily_price_info_listing i rusi ceo market-service startup.
+-- Wrap u SELECT ... WHERE EXISTS filtrira nepostojece listinge (cosmetic price history).
+INSERT INTO listing_daily_price_info (listing_id, date, price, ask, bid, change, volume)
+SELECT v.listing_id, v.date::date, v.price, v.ask, v.bid, v.change, v.volume FROM (VALUES
   (1, '2026-05-06', 315.59059441, 315.906185, 315.27500382, 4.42169001, 39270903),
   (1, '2026-05-07', 314.89454637, 315.20944092, 314.57965182, -0.69451288, 51642344),
   (1, '2026-05-08', 316.8224777, 317.13930018, 316.50565522, 1.93973502, 43795192),
@@ -389,4 +395,6 @@ INSERT INTO listing_daily_price_info (listing_id, date, price, ask, bid, change,
   (202, '2026-06-02', 74.84600603, 74.92085204, 74.77116002, -1.03276668, 364225),
   (202, '2026-06-03', 76.13837788, 76.21451626, 76.0622395, 1.31468734, 341839),
   (202, '2026-06-04', 77.67744013, 77.75511757, 77.59976269, 1.57017288, 318847)
+) AS v(listing_id, date, price, ask, bid, change, volume)
+WHERE EXISTS (SELECT 1 FROM listing l WHERE l.id = v.listing_id)
 ON CONFLICT (listing_id, date) DO NOTHING;

--- a/trading-service-go/internal/http/interbank_handlers.go
+++ b/trading-service-go/internal/http/interbank_handlers.go
@@ -90,6 +90,21 @@ func (h *Handlers) InterbankReleaseOption(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// InterbankCreditPortfolio ↔ POST /internal/interbank/portfolio/credit (204).
+// Buyer-side stock delivery (p4) of the inter-bank EXERCISE transaction.
+func (h *Handlers) InterbankCreditPortfolio(w http.ResponseWriter, r *http.Request) {
+	var req interbank.CreditPortfolioReq
+	if err := decodeJSONLenient(r, &req); err != nil {
+		writeDomainError(w, r, api.NewOrderError(http.StatusBadRequest, "Malformed JSON request body"))
+		return
+	}
+	if err := h.app.Interbank.CreditPortfolio(r.Context(), req.BuyerUserID, req.Ticker, req.Quantity); err != nil {
+		writeDomainError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // InterbankPublicStocks ↔ GET /internal/interbank/public-stocks (200, list).
 func (h *Handlers) InterbankPublicStocks(w http.ResponseWriter, r *http.Request) {
 	out, err := h.app.Interbank.PublicStocks(r.Context())

--- a/trading-service-go/internal/http/misc_service_handlers_test.go
+++ b/trading-service-go/internal/http/misc_service_handlers_test.go
@@ -162,6 +162,10 @@ func (ibPortStub) UpdateQuantityAndReserved(context.Context, portfolio.Querier, 
 func (ibPortStub) FindAllPublicStocks(context.Context, portfolio.Querier) ([]portfolio.Portfolio, error) {
 	return nil, nil
 }
+func (ibPortStub) UpdateQuantity(context.Context, portfolio.Querier, int64, int) error { return nil }
+func (ibPortStub) Insert(context.Context, portfolio.Querier, int64, int64, string, int, decimal.Decimal) error {
+	return nil
+}
 
 type ibMktStub struct{}
 

--- a/trading-service-go/internal/http/routes.go
+++ b/trading-service-go/internal/http/routes.go
@@ -229,5 +229,6 @@ func registerRoutes(handle func(method, path string, handler http.Handler), app 
 	handle(http.MethodPost, "/internal/interbank/options/{negotiationId}/reserve", orderSecured(jwtService, serviceOnly, handlers.InterbankReserveOption))
 	handle(http.MethodPost, "/internal/interbank/options/{negotiationId}/exercise", orderSecured(jwtService, serviceOnly, handlers.InterbankExerciseOption))
 	handle(http.MethodDelete, "/internal/interbank/options/{negotiationId}/release", orderSecured(jwtService, serviceOnly, handlers.InterbankReleaseOption))
+	handle(http.MethodPost, "/internal/interbank/portfolio/credit", orderSecured(jwtService, serviceOnly, handlers.InterbankCreditPortfolio))
 	handle(http.MethodGet, "/internal/interbank/public-stocks", orderSecured(jwtService, serviceOnly, handlers.InterbankPublicStocks))
 }

--- a/trading-service-go/internal/interbank/creditportfolio_test.go
+++ b/trading-service-go/internal/interbank/creditportfolio_test.go
@@ -1,0 +1,99 @@
+package interbank
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"banka1/trading-service-go/internal/clients"
+	"banka1/trading-service-go/internal/portfolio"
+)
+
+// strptr is a tiny helper for *string fields on clients.StockListing.
+func strptr(s string) *string { return &s }
+
+// ---- CreditPortfolio (S7/S8 buyer-side delivery / S9 settlement leg p4) ----
+
+// Existing buyer lot → increment its quantity by the delivered amount.
+func TestCreditPortfolio_ExistingBuyerLot_Increments(t *testing.T) {
+	port := &stubIBPortfolio{
+		// resolveListingByTicker scans the buyer's positions; this one matches.
+		positions: []portfolio.Portfolio{{ListingID: 5, Quantity: 4}},
+		// FindByUserIDAndListingIDForUpdate returns the existing lot to increment.
+		position: &portfolio.Portfolio{ID: 99, ListingID: 5, Quantity: 4},
+	}
+	mkt := &stubIBMarket{listing: &clients.StockListing{Ticker: strptr("AAPL")}}
+	svc := newIBService(&stubIBRepo{}, port, mkt)
+
+	if err := svc.CreditPortfolio(context.Background(), 7, "AAPL", 3); err != nil {
+		t.Fatalf("CreditPortfolio: %v", err)
+	}
+	if port.updatedID != 99 || port.updatedQuantity != 7 {
+		t.Errorf("expected UpdateQuantity(99, 4+3=7), got id=%d qty=%d", port.updatedID, port.updatedQuantity)
+	}
+	if port.insertedQty != 0 {
+		t.Errorf("expected no Insert for an existing lot, got insertedQty=%d", port.insertedQty)
+	}
+}
+
+// New buyer lot → resolve the listingId from the PUBLIC POOL (buyer holds nothing
+// yet) and Insert a fresh lot. The buyer scan (FindByUserID) is empty; the public
+// pool scan (FindAllPublicStocks) carries the seller's advertised AAPL position.
+func TestCreditPortfolio_NewBuyerLot_InsertsFromPublicListing(t *testing.T) {
+	port := &stubIBPortfolio{
+		positions:       []portfolio.Portfolio{}, // buyer holds nothing → resolveListingByTicker misses
+		position:        nil,                     // FindByUserIDAndListingIDForUpdate → nil → Insert
+		hasPublic:       true,
+		publicPositions: []portfolio.Portfolio{{ListingID: 5, ListingType: "STOCK", PublicQuantity: 10}},
+	}
+	mkt := &stubIBMarket{listing: &clients.StockListing{Ticker: strptr("AAPL")}}
+	svc := newIBService(&stubIBRepo{}, port, mkt)
+
+	if err := svc.CreditPortfolio(context.Background(), 7, "AAPL", 5); err != nil {
+		t.Fatalf("CreditPortfolio: %v", err)
+	}
+	if port.insertedUserID != 7 || port.insertedListingID != 5 || port.insertedQty != 5 {
+		t.Errorf("expected Insert(user=7, listing=5, qty=5), got user=%d listing=%d qty=%d",
+			port.insertedUserID, port.insertedListingID, port.insertedQty)
+	}
+	if port.insertedListingType != "STOCK" {
+		t.Errorf("expected listingType STOCK, got %q", port.insertedListingType)
+	}
+	if port.updatedQuantity != 0 {
+		t.Errorf("expected no UpdateQuantity for a new lot, got %d", port.updatedQuantity)
+	}
+}
+
+func TestCreditPortfolio_ZeroQuantity_Error(t *testing.T) {
+	svc := newIBService(&stubIBRepo{}, &stubIBPortfolio{}, &stubIBMarket{})
+	if err := svc.CreditPortfolio(context.Background(), 7, "AAPL", 0); err == nil {
+		t.Error("expected error for zero quantity")
+	}
+}
+
+func TestCreditPortfolio_BlankTicker_Error(t *testing.T) {
+	svc := newIBService(&stubIBRepo{}, &stubIBPortfolio{}, &stubIBMarket{})
+	if err := svc.CreditPortfolio(context.Background(), 7, "   ", 5); err == nil {
+		t.Error("expected error for blank ticker")
+	}
+}
+
+// No buyer position AND not in the public pool → 404 (cannot resolve listing).
+func TestCreditPortfolio_UnresolvableTicker_Error(t *testing.T) {
+	port := &stubIBPortfolio{positions: []portfolio.Portfolio{}} // empty pool
+	mkt := &stubIBMarket{listing: &clients.StockListing{Ticker: strptr("ZZZ")}}
+	svc := newIBService(&stubIBRepo{}, port, mkt)
+	if err := svc.CreditPortfolio(context.Background(), 7, "AAPL", 5); err == nil {
+		t.Error("expected error for unresolvable ticker")
+	}
+}
+
+// A portfolio read error during listing resolution propagates.
+func TestCreditPortfolio_ListingResolveError_Propagates(t *testing.T) {
+	boom := errors.New("db boom")
+	port := &stubIBPortfolio{posErr: boom}
+	svc := newIBService(&stubIBRepo{}, port, &stubIBMarket{})
+	if err := svc.CreditPortfolio(context.Background(), 7, "AAPL", 5); err == nil {
+		t.Error("expected propagated portfolio read error")
+	}
+}

--- a/trading-service-go/internal/interbank/deps.go
+++ b/trading-service-go/internal/interbank/deps.go
@@ -10,6 +10,7 @@ import (
 	gpdb "banka1/go-platform/db"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
 )
 
 // interbankRepo abstracts *Repository for unit testing.
@@ -31,6 +32,8 @@ type interbankPortfolio interface {
 	FindByIDForUpdate(ctx context.Context, q portfolio.Querier, id int64) (*portfolio.Portfolio, error)
 	UpdateReservedQuantity(ctx context.Context, q portfolio.Querier, id int64, reserved int) error
 	UpdateQuantityAndReserved(ctx context.Context, q portfolio.Querier, id int64, quantity, reserved int) error
+	UpdateQuantity(ctx context.Context, q portfolio.Querier, id int64, quantity int) error
+	Insert(ctx context.Context, q portfolio.Querier, userID, listingID int64, listingType string, quantity int, avg decimal.Decimal) error
 	FindAllPublicStocks(ctx context.Context, q portfolio.Querier) ([]portfolio.Portfolio, error)
 }
 

--- a/trading-service-go/internal/interbank/dtos.go
+++ b/trading-service-go/internal/interbank/dtos.go
@@ -23,6 +23,16 @@ type ReserveStockRes struct {
 	ReservationID string `json:"reservationId"`
 }
 
+// CreditPortfolioReq is the body of POST /internal/interbank/portfolio/credit —
+// the buyer-side stock delivery leg (p4) of the inter-bank EXERCISE transaction.
+// interbank-service calls this when OUR user is the option buyer and the exercise
+// has committed: deliver `quantity` shares of `ticker` into the buyer's portfolio.
+type CreditPortfolioReq struct {
+	BuyerUserID int64  `json:"buyerUserId"`
+	Ticker      string `json:"ticker"`
+	Quantity    int    `json:"quantity"`
+}
+
 // ReserveOptionReq mirrors InterbankOptionController.ReserveOptionReq.
 // sellerForeignId is a pointer so an absent field (Java null →
 // "sellerForeignId must not be null") is distinguishable from a present value

--- a/trading-service-go/internal/interbank/service.go
+++ b/trading-service-go/internal/interbank/service.go
@@ -13,6 +13,7 @@ import (
 	"banka1/trading-service-go/internal/portfolio"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/shopspring/decimal"
 )
 
 // Service exposes the interbank 2PC stock primitives + the option lifecycle +
@@ -294,6 +295,92 @@ func (s *Service) ReleaseOption(ctx context.Context, negotiationID string) error
 		}
 		return s.repo.UpdateOptionReservationStatus(ctx, tx, negotiationID, OptionReleased)
 	})
+}
+
+// CreditPortfolio is the inverse of the reserve-stock path: it delivers `quantity`
+// shares of `ticker` into the BUYER's portfolio. It is the buyer-side leg (p4) of
+// the inter-bank EXERCISE transaction — when our user is the option buyer, the
+// strike has been paid and the seller-bank has released the shares, so we add the
+// shares to the buyer here. One transaction (Java @Transactional).
+//
+// Listing resolution mirrors the rest of this service: there is no global
+// ticker→listingId index, so we scan the buyer's own positions first, then fall
+// back to the public-stock pool (the seller's advertised position carries the same
+// listingId) to discover the listingId for a brand-new buyer lot. If the buyer
+// already holds the listing, we increment its quantity; otherwise we insert a new
+// lot (average price 0 — the strike was settled on the money leg, not capitalised
+// into the cost basis here, matching the simple delivery semantics of the protocol).
+func (s *Service) CreditPortfolio(ctx context.Context, buyerUserID int64, ticker string, quantity int) error {
+	if quantity <= 0 {
+		return api.NewOtcError(http.StatusNotFound, "Quantity must be positive: "+itoa(int64(quantity)))
+	}
+	if strings.TrimSpace(ticker) == "" {
+		return api.NewOtcError(http.StatusNotFound, "Ticker must not be blank")
+	}
+	return s.runTx(ctx, func(tx pgx.Tx) error {
+		// 1. Resolve the listingId for this ticker (buyer positions → public pool).
+		listingID, found, err := s.resolveListingByTicker(ctx, tx, buyerUserID, ticker)
+		if err != nil {
+			return err
+		}
+		listingType := "STOCK"
+		if !found {
+			lid, lt, ok, perr := s.resolveListingFromPublicPool(ctx, tx, ticker)
+			if perr != nil {
+				return perr
+			}
+			if !ok {
+				return api.NewOtcError(http.StatusNotFound,
+					"Cannot resolve listing for ticker="+ticker+" — no buyer position and not in the public pool")
+			}
+			listingID = lid
+			listingType = lt
+		}
+
+		// 2. Upsert the buyer's lot under a write lock.
+		buyer, err := s.portfolio.FindByUserIDAndListingIDForUpdate(ctx, tx, buyerUserID, listingID)
+		if err != nil {
+			return err
+		}
+		if buyer == nil {
+			if err := s.portfolio.Insert(ctx, tx, buyerUserID, listingID, listingType, quantity, decimal.Zero); err != nil {
+				return err
+			}
+			s.logger.Info("interbank creditPortfolio (new lot)", "buyer", buyerUserID, "ticker", ticker,
+				"listing", listingID, "qty", quantity)
+			return nil
+		}
+		if err := s.portfolio.UpdateQuantity(ctx, tx, buyer.ID, buyer.Quantity+quantity); err != nil {
+			return err
+		}
+		s.logger.Info("interbank creditPortfolio (increment)", "buyer", buyerUserID, "ticker", ticker,
+			"listing", listingID, "qty", quantity, "newQuantity", buyer.Quantity+quantity)
+		return nil
+	})
+}
+
+// resolveListingFromPublicPool finds the listingId (and its listing type) for a
+// ticker by scanning the advertised public-stock positions. Used by CreditPortfolio
+// to deliver to a buyer who does not yet hold the foreign stock.
+func (s *Service) resolveListingFromPublicPool(ctx context.Context, q portfolio.Querier, ticker string) (int64, string, bool, error) {
+	positions, err := s.portfolio.FindAllPublicStocks(ctx, q)
+	if err != nil {
+		return 0, "", false, err
+	}
+	for _, p := range positions {
+		listing, lerr := s.market.GetListing(ctx, p.ListingID)
+		if lerr != nil || listing == nil || listing.Ticker == nil {
+			continue
+		}
+		if strings.EqualFold(ticker, *listing.Ticker) {
+			lt := "STOCK"
+			if p.ListingType != "" {
+				lt = p.ListingType
+			}
+			return p.ListingID, lt, true, nil
+		}
+	}
+	return 0, "", false, nil
 }
 
 // ============================== public-stocks =============================

--- a/trading-service-go/internal/interbank/service_stub_test.go
+++ b/trading-service-go/internal/interbank/service_stub_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
 )
 
 // ---- stubs ----
@@ -52,6 +53,21 @@ type stubIBPortfolio struct {
 	position  *portfolio.Portfolio
 	posOneErr error
 	updateErr error
+
+	// publicPositions, when non-nil, is returned by FindAllPublicStocks instead of
+	// positions — letting a test give the buyer scan (FindByUserID) and the public
+	// pool scan (FindAllPublicStocks) distinct contents (CreditPortfolio fallback).
+	publicPositions []portfolio.Portfolio
+	hasPublic       bool
+
+	// CreditPortfolio (S7/S8) bookkeeping.
+	insertErr           error
+	insertedUserID      int64
+	insertedListingID   int64
+	insertedListingType string
+	insertedQty         int
+	updatedID           int64
+	updatedQuantity     int
 }
 
 func (s *stubIBPortfolio) Pool() *pgxpool.Pool { return nil }
@@ -71,7 +87,22 @@ func (s *stubIBPortfolio) UpdateQuantityAndReserved(_ context.Context, _ portfol
 	return s.updateErr
 }
 func (s *stubIBPortfolio) FindAllPublicStocks(_ context.Context, _ portfolio.Querier) ([]portfolio.Portfolio, error) {
+	if s.hasPublic {
+		return s.publicPositions, s.posErr
+	}
 	return s.positions, s.posErr
+}
+func (s *stubIBPortfolio) UpdateQuantity(_ context.Context, _ portfolio.Querier, id int64, quantity int) error {
+	s.updatedID = id
+	s.updatedQuantity = quantity
+	return s.updateErr
+}
+func (s *stubIBPortfolio) Insert(_ context.Context, _ portfolio.Querier, userID, listingID int64, listingType string, quantity int, _ decimal.Decimal) error {
+	s.insertedUserID = userID
+	s.insertedListingID = listingID
+	s.insertedListingType = listingType
+	s.insertedQty = quantity
+	return s.insertErr
 }
 
 type stubIBMarket struct {


### PR DESCRIPTION
Pun cross-bank interop sa Bankom 2 — inter-bank plaćanja (oba smera, FX-aware) + ceo OTC lifecycle (accept / exercise / decline / expiry). Live-testirano kroz Docker sa Bankom 2 (oba stack-a povezana kao na k8s); svaki tok konzervira novac/akcije.

## Plaćanja (temelj)
- Idempotentan FX-aware `POST /internal/interbank/credit-monas` + `interbank_credits` tabela (banking-core)
- Executor `creditPositiveMonasLegs`: kreditira naše recipient/seller MONAS noge na commit-u (2.8.4)
- Validator: cross-ccy DEBIT (recipient) noga se prihvata i konvertuje na commit-u
- `accountIsOurs`: match po prefiksu (ne hardkodiran `len==18`) → prepoznaje sopstvene 19-cifrene račune
- `interbank_credits` + `interbank_reservations.account_number` `VARCHAR(18)` → `34` (IBAN max)
- `ReserveMonas` klijent: `transactionIdRouting` / `transactionIdLocal` (ranije `txId*` → 400)
- Coordinator: premija = `O.premium` (UKUPNA, ne × amount; ranije kršilo 2.8.2 → duplo naplaćivanje)
- market-service `026` seed FK fix (`WHERE EXISTS`) → market više ne crash-loop-uje na fresh DB

## OTC lifecycle (S3–S10, oba smera)
- S3 accept ne skida seller akcije (drži HELD rezervaciju); S4 buyer Contract perzistencija + lista
- S6 settlement/status guard; S7/S8 `ExerciseOutbound` + trading `CreditPortfolio`; S9 inbound seller settlement
- S10 expiry sweep + "Odbi" decline; regularno outbound plaćanje (`ExecutePayment`, RealAccount primalac)
- `ValidateExerciseTx` ne gate-uje na `neg.IsOngoing` (contract-status double-exercise gate u executor-u)
- Buyer contract keyovan na LOKALNI negId (FK) + exercise šalje REMOTE id; `seller_id` iz pregovora (`FindSellerID`)

## Build/test
`go build` + `go vet` + `go test` zeleno (interbank-service, banking-core, trading-service).

> **Napomena za već-pokrenutu bazu:** `ALTER` `interbank_credits` / `interbank_reservations.account_number TYPE varchar(34)`.
