### PR TITLE
feat(monitoring): black-box alerting za sve servise preko Discord bota

### DIFF
--- a/discord-alert-bot/README.md
+++ b/discord-alert-bot/README.md
@@ -3,15 +3,51 @@
 Small Node.js service that receives Alertmanager webhook POSTs and forwards
 each alert as a Discord DM to the developer running this stack.
 
-It is part of the Monitoring / Alerting pipeline:
+It is part of the Monitoring / Alerting pipeline. All backend services are Go and do
+not emit application metrics, so they are monitored **black-box** via exporters:
 
 ```
-service crashes
-  -> Prometheus rule fires (prometheus-rules.yml)
-    -> Alertmanager (setup/alertmanager.yml)
-      -> POST http://discord-alert-bot:9094/alert
-        -> Discord API
-          -> DM to DEVELOPER_DISCORD_ID
+blackbox-exporter  (HTTP health probes)  ─┐
+postgres-exporter  (DB connections)       ├─> Prometheus (setup/prometheus-rules.yml)
+rabbitmq-exporter  (queue depth)          ─┘     -> Alertmanager (setup/alertmanager.yml)
+                                                   -> POST http://discord-alert-bot:9094/alert
+                                                     -> Discord API -> DM to DEVELOPER_DISCORD_ID
+```
+
+## Notifications it sends
+
+The bot forwards every alert defined in `setup/prometheus-rules.yml`, rendered as a
+Discord DM in one of four shapes:
+
+| Shape | Looks like | When |
+|---|---|---|
+| 🔴 critical + Component | `🔴 [FIRING] <name>` + `Component: infrastructure` | an infra component is down |
+| 🔴 critical + Service | `🔴 [FIRING] <name>` + `Service: <svc>` | a service is down |
+| ⚠️ warning + Service | `⚠️ [FIRING] <name>` + `Service: <svc>` | a soft threshold was crossed |
+| ✅ resolved | `✅ [RESOLVED] <name>` … | the condition cleared (any alert) |
+
+### Alert catalogue
+
+| Alert | Severity | Source | Fires when |
+|---|---|---|---|
+| `ServiceDown` | 🔴 critical | blackbox-exporter | a service health probe fails — one per service: `notification`, `user`, `banking-core`, `market`, `trading`, `credit`, `saga-orchestrator`, `interbank` |
+| `OtelCollectorDown` | 🔴 critical | Prometheus `up` | the OTel collector is unreachable |
+| `AlertmanagerDown` | 🔴 critical | Prometheus `up` | Alertmanager is unreachable (self-referential — delivered on recovery) |
+| `ServiceProbeSlow` | ⚠️ warning | blackbox-exporter | a service health probe is slow (> 1.5s) |
+| `PostgresConnectionsHigh` | ⚠️ warning | postgres-exporter | active DB connections > 80% of `max_connections` (200) |
+| `RabbitMQBacklog` | ⚠️ warning | rabbitmq-exporter | a queue has > 1000 unconsumed messages |
+| `RabbitMQNoConsumers` | ⚠️ warning | rabbitmq-exporter | a queue has messages but 0 consumers |
+
+Every alert also sends a ✅ **RESOLVED** DM when its condition clears
+(`send_resolved: true` in `setup/alertmanager.yml`).
+
+### Example DM
+
+```
+🔴 [FIRING] ServiceDown
+credit-service je DOWN
+Health proba ka http://banka_credit_service:8089/health ne uspeva. Servis je verovatno pao ili ne odgovara.
+Service: credit-service
 ```
 
 ## How to set up the Discord bot account (one-time, manual)

--- a/discord-alert-bot/README.md
+++ b/discord-alert-bot/README.md
@@ -143,6 +143,69 @@ curl -X POST http://localhost:9093/api/v2/alerts \
 
 Alertmanager will forward it to the bot, which will DM you on Discord.
 
+## Triggering real alerts (demo mode)
+
+Two helper scripts in `setup/` let you fire each notification on a running stack —
+handy for a demo or a screen recording. They are Windows PowerShell scripts.
+
+### `setup/demo-mode.ps1` — fast-firing thresholds
+
+Production rules use realistic thresholds and multi-minute `for` windows, so warning
+alerts take a while to fire. Demo mode swaps in a copy of the rules with lowered
+thresholds and a short `for` (~15-20s) so everything fires within ~30-60s.
+
+```powershell
+./setup/demo-mode.ps1 on        # apply demo thresholds, reload Prometheus
+./setup/demo-mode.ps1 off       # restore production rules
+./setup/demo-mode.ps1 status    # show which set is active
+```
+
+`on` snapshots the live `prometheus-rules.yml` into a transient
+`prometheus-rules.yml.bak` and swaps in `prometheus-rules.demo.yml`; `off` restores
+the snapshot and deletes it. The standard `prometheus-rules.yml` stays the single
+source of truth (never overwritten permanently).
+
+Trigger / resolve pairs (run `demo-mode.ps1 on` first for the warning alerts):
+
+```powershell
+# ServiceDown — fire / resolve
+docker stop  banka_credit_service
+docker start banka_credit_service
+
+# PostgresConnectionsHigh — fire / resolve
+1..35 | ForEach-Object { Start-Process -WindowStyle Hidden docker -ArgumentList 'exec banka_postgres psql -U postgres -d postgres -c "select pg_sleep(300)"' }
+docker exec banka_postgres psql -U postgres -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ILIKE 'select pg_sleep%' AND pid <> pg_backend_pid();"
+
+# RabbitMQBacklog + RabbitMQNoConsumers — fire / resolve
+$h = @{ Authorization = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("guest:guest")) }
+$body = '{"properties":{},"routing_key":"demo.backlog","payload":"hello","payload_encoding":"string"}'
+irm -Method Put "http://localhost:15672/api/queues/%2F/demo.backlog" -Headers $h -ContentType application/json -Body '{"durable":true}'
+1..20 | ForEach-Object { irm -Method Post "http://localhost:15672/api/exchanges/%2F/amq.default/publish" -Headers $h -ContentType application/json -Body $body | Out-Null }
+irm -Method Delete "http://localhost:15672/api/queues/%2F/demo.backlog/contents" -Headers $h
+irm -Method Delete "http://localhost:15672/api/queues/%2F/demo.backlog" -Headers $h
+```
+
+> The RabbitMQ `Put` (declare queue) must run before publishing — messages sent to a
+> non-existent queue are silently dropped.
+
+### `setup/probe-slow-demo.ps1` — trigger `ServiceProbeSlow`
+
+`ServiceProbeSlow` needs a slow health probe, which won't happen on its own. This
+script injects +1500ms latency on credit-service's health probe via the existing
+`toxiproxy` container and temporarily re-points the blackbox probe through it.
+
+```powershell
+./setup/probe-slow-demo.ps1 on     # inject latency -> ⚠️ ServiceProbeSlow in ~40s
+./setup/probe-slow-demo.ps1 off    # remove latency, revert probe -> ✅ resolved
+```
+
+Run `demo-mode.ps1 on` first: in demo mode the threshold is `> 0.5s`, which the
+injected 1.5s clearly crosses (production threshold is `> 1.5s`, only borderline).
+
+> These scripts call the toxiproxy admin API with a non-browser `User-Agent`
+> (toxiproxy rejects browser-like agents), and a Prometheus reload happens on each
+> toggle.
+
 ## Tests
 
 ```bash

--- a/setup/alertmanager.yml
+++ b/setup/alertmanager.yml
@@ -6,8 +6,8 @@ global:
 route:
   receiver: discord-bot
   group_by: ['alertname', 'service', 'service_name']
-  group_wait: 10s          # wait before sending the first batch of a new group
-  group_interval: 30s      # wait between batches of the same group
+  group_wait: 5s           # wait before sending the first batch of a new group
+  group_interval: 10s      # wait between batches of the same group
   repeat_interval: 4h      # re-send an unresolved alert every 4h
 
 receivers:

--- a/setup/blackbox.yml
+++ b/setup/blackbox.yml
@@ -1,0 +1,11 @@
+# Blackbox exporter probe modules.
+# http_2xx: GET na health endpoint, uspeh = HTTP 2xx odgovor.
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      valid_status_codes: []        # prazno = podrazumevano 2xx
+      preferred_ip_protocol: ip4
+      fail_if_not_ssl: false

--- a/setup/demo-mode.ps1
+++ b/setup/demo-mode.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+  Privremeni DEMO režim Prometheus pravila (kratki `for`, spušteni pragovi) da warning
+  alarmi okidaju brzo za testiranje/snimak. Vraća na produkciju sa `off`.
+
+  prometheus-rules.yml je JEDINI standardni fajl. `on` napravi privremeni
+  prometheus-rules.yml.bak (kopija produkcije) i ubaci demo; `off` vrati .bak i obriše ga.
+
+.EXAMPLE
+  ./setup/demo-mode.ps1 on       # aktiviraj demo pragove + reload Prometheus
+  ./setup/demo-mode.ps1 off      # vrati produkcione pragove
+  ./setup/demo-mode.ps1 status   # koja je verzija trenutno aktivna
+#>
+param(
+  [Parameter(Mandatory)][ValidateSet('on','off','status')]$Mode
+)
+$ErrorActionPreference = 'Stop'
+$dir    = $PSScriptRoot
+$active = Join-Path $dir 'prometheus-rules.yml'
+$demo   = Join-Path $dir 'prometheus-rules.demo.yml'
+$bak    = Join-Path $dir 'prometheus-rules.yml.bak'
+
+function IsDemo { (Get-Content $active -Raw) -like '*DEMO MODE*' }
+
+switch ($Mode) {
+  'status' {
+    if (IsDemo) { Write-Host 'Aktivno: DEMO' -ForegroundColor Yellow }
+    else        { Write-Host 'Aktivno: PRODUKCIJA (prometheus-rules.yml)' -ForegroundColor Green }
+    return
+  }
+  'on' {
+    if (IsDemo) { Write-Host 'Vec je DEMO režim.' -ForegroundColor Yellow; return }
+    if (-not (Test-Path $demo)) { throw "Nedostaje $demo" }
+    Copy-Item $active $bak -Force        # privremena kopija produkcije
+    Copy-Item $demo $active -Force
+  }
+  'off' {
+    if (Test-Path $bak) {
+      Copy-Item $bak $active -Force
+      Remove-Item $bak -Force
+    } elseif (-not (IsDemo)) {
+      Write-Host 'Vec je PRODUKCIJA.' -ForegroundColor Green; return
+    } else {
+      Write-Host 'Demo je aktivan ali nema .bak — vrati rucno iz git-a (git checkout setup/prometheus-rules.yml).' -ForegroundColor Red; return
+    }
+  }
+}
+docker compose -f (Join-Path $dir 'docker-compose.yml') restart prometheus | Out-Null
+for ($i=0; $i -lt 12; $i++) { Start-Sleep -Seconds 2; try { $null = Invoke-RestMethod 'http://localhost:9090/-/ready' -TimeoutSec 3; break } catch {} }
+Write-Host ("Demo režim: {0}  (Prometheus reload-ovan)" -f $Mode.ToUpper()) -ForegroundColor Cyan

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -277,6 +277,65 @@ services:
         reservations:
           memory: 64M
 
+  # =========================================================================
+  # Black-box monitoring exporters — mere servise SPOLJA, kod servisa se NE dira.
+  # blackbox: health probe (down + latencija) | postgres/rabbitmq: infra metрике
+  # cadvisor: memorija/CPU/restart po kontejneru.
+  # =========================================================================
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.25.0
+    container_name: banka_blackbox_exporter
+    restart: unless-stopped
+    volumes:
+      - ./blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    expose:
+      - "9115"
+    networks:
+      - banka-network
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+    container_name: banka_postgres_exporter
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@banka_postgres:5432/postgres?sslmode=disable"
+    expose:
+      - "9187"
+    depends_on:
+      - postgres
+    networks:
+      - banka-network
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+
+  # Cita postojeci RabbitMQ management API (15672) — NE dira rabbitmq kontejner.
+  # NOTE: tag :latest radi pouzdano; pin-uj na konkretan RC posle verifikacije.
+  rabbitmq-exporter:
+    image: kbudde/rabbitmq-exporter:latest
+    container_name: banka_rabbitmq_exporter
+    restart: unless-stopped
+    environment:
+      RABBIT_URL: "http://rabbitmq:15672"
+      RABBIT_USER: "${RABBITMQ_USERNAME:-guest}"
+      RABBIT_PASSWORD: "${RABBITMQ_PASSWORD:-guest}"
+      PUBLISH_PORT: "9419"
+    expose:
+      - "9419"
+    depends_on:
+      - rabbitmq
+    networks:
+      - banka-network
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+
   loki:
     image: grafana/loki:3.1.1
     container_name: banka_loki

--- a/setup/probe-slow-demo.ps1
+++ b/setup/probe-slow-demo.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+  Okida ServiceProbeSlow tako što ubaci +1500ms latencije na health probu credit-service-a
+  preko toxiproxy-ja i privremeno preusmeri Prometheus probe kroz proxy.
+
+.EXAMPLE
+  ./setup/probe-slow-demo.ps1 on    # ubaci latenciju -> za ~30s stigne ⚠️ ServiceProbeSlow
+  ./setup/probe-slow-demo.ps1 off   # ukloni latenciju, vrati direktnu probu
+#>
+param([Parameter(Mandatory)][ValidateSet('on','off')]$Mode)
+$ErrorActionPreference = 'Stop'
+$dir    = $PSScriptRoot
+$promyml = Join-Path $dir 'prometheus.yml'
+$tox    = 'http://localhost:8474'
+$direct = 'http://banka_credit_service:8089/health'
+$viaTox = 'http://toxiproxy:8666/health'
+# toxiproxy admin API odbija "browser" User-Agent (PowerShell default sadrzi Mozilla) -> postavi ne-browser UA.
+$ua = 'toxiproxy-client'
+
+function Save([string]$path,[string]$content){ [IO.File]::WriteAllText($path,$content,(New-Object Text.UTF8Encoding($false))) }
+
+if ($Mode -eq 'on') {
+  try { Invoke-RestMethod -Method Delete "$tox/proxies/credit-slow" -UserAgent $ua -TimeoutSec 5 | Out-Null } catch {}
+  Invoke-RestMethod -Method Post "$tox/proxies" -UserAgent $ua -ContentType application/json -Body '{"name":"credit-slow","listen":"0.0.0.0:8666","upstream":"banka_credit_service:8089"}' | Out-Null
+  Invoke-RestMethod -Method Post "$tox/proxies/credit-slow/toxics" -UserAgent $ua -ContentType application/json -Body '{"type":"latency","attributes":{"latency":1500}}' | Out-Null
+  Save $promyml ((Get-Content $promyml -Raw).Replace($direct, $viaTox))
+  Write-Host "ProbeSlow ON: credit-service probe ide kroz toxiproxy (+1500ms)." -ForegroundColor Yellow
+} else {
+  try { Invoke-RestMethod -Method Delete "$tox/proxies/credit-slow" -UserAgent $ua -TimeoutSec 5 | Out-Null } catch {}
+  Save $promyml ((Get-Content $promyml -Raw).Replace($viaTox, $direct))
+  Write-Host "ProbeSlow OFF: vraćena direktna proba." -ForegroundColor Green
+}
+docker compose -f (Join-Path $dir 'docker-compose.yml') restart prometheus | Out-Null
+for ($i=0; $i -lt 12; $i++) { Start-Sleep -Seconds 2; try { $null = Invoke-RestMethod 'http://localhost:9090/-/ready' -TimeoutSec 3; break } catch {} }
+Write-Host "Prometheus reload-ovan."

--- a/setup/prometheus-rules.demo.yml
+++ b/setup/prometheus-rules.demo.yml
@@ -1,38 +1,32 @@
-# Prometheus alerting rules za Banka-1 backend (black-box monitoring).
-#
-# Svi servisi su Go i ne emituju aplikacione metrike; zato se mere SPOLJA:
-#   - blackbox-exporter  -> probe_success / probe_duration_seconds (po servisu)
-#   - postgres-exporter  -> pg_stat_database_numbackends
-#   - rabbitmq-exporter  -> rabbitmq_queue_messages_ready, rabbitmq_queue_consumers
+# DEMO MODE pravila - kratki for i spusteni pragovi da warning alarmi okidaju brzo.
+# NE koristiti u produkciji. Aktivacija: ./setup/demo-mode.ps1 on   (vrati: ./setup/demo-mode.ps1 off)
 groups:
   - name: infrastructure
-    interval: 30s
+    interval: 15s
     rules:
       - alert: OtelCollectorDown
         expr: up{job="otel-collector"} == 0
-        for: 1m
+        for: 15s
         labels:
           severity: critical
           component: infrastructure
         annotations:
           summary: "OTel Collector is down"
-          description: "Prometheus ne moze da skrejpuje OTel collector - trace pipeline je blokiran."
+          description: "Prometheus ne moze da skrejpuje OTel collector — trace pipeline je blokiran."
 
       - alert: AlertmanagerDown
         expr: up{job="alertmanager"} == 0
-        for: 1m
+        for: 15s
         labels:
           severity: critical
           component: infrastructure
         annotations:
           summary: "Alertmanager is down"
-          description: "Prometheus ne moze da skrejpuje Alertmanager - alarmi se mozda ne isporucuju."
+          description: "Prometheus ne moze da skrejpuje Alertmanager — alarmi se mozda ne isporucuju."
 
   - name: service-availability
     interval: 10s
     rules:
-      # Jedno pravilo pokriva svih 8 servisa; service_name dolazi sa probe metrike.
-      # for: 15s = brza detekcija (~30s do DM). Za stroziju produkciju vrati na ~1m (manje flapping-a).
       - alert: ServiceDown
         expr: probe_success == 0
         for: 15s
@@ -43,54 +37,56 @@ groups:
           description: "Health proba ka {{ $labels.instance }} ne uspeva. Servis je verovatno pao ili ne odgovara."
 
   - name: http-health
-    interval: 30s
+    interval: 15s
     rules:
+      # DEMO: prag 0.5s (umesto 1.5s) — toxiproxy +1500ms lako pređe. for: 20s.
       - alert: ServiceProbeSlow
-        expr: probe_duration_seconds > 1.5
-        for: 3m
+        expr: probe_duration_seconds > 0.5
+        for: 20s
         labels:
           severity: warning
           category: http
         annotations:
           summary: "Spor health odgovor na {{ $labels.service_name }}"
-          description: "Health proba ka {{ $labels.instance }} traje {{ $value }}s (>1.5s) 3+ minuta."
+          description: "Health proba ka {{ $labels.instance }} traje {{ $value }}s (>0.5s demo prag)."
 
   - name: database
-    interval: 30s
+    interval: 15s
     rules:
-      # max_connections=200 je fiksiran u docker-compose.yml (postgres command).
+      # DEMO: prag >30 konekcija (0.15*200) umesto >160. for: 15s.
       - alert: PostgresConnectionsHigh
-        expr: sum(pg_stat_database_numbackends) / 200 > 0.8
-        for: 2m
+        expr: sum(pg_stat_database_numbackends) / 200 > 0.15
+        for: 15s
         labels:
           severity: warning
           service: postgres
           category: database
         annotations:
-          summary: "Postgres konekcije pri vrhu"
-          description: "Aktivnih backend-ova je >80% od max_connections (200) 2+ minuta. Nove DB konekcije ce cekati/timeout-ovati."
+          summary: "Postgres konekcije pri vrhu (demo)"
+          description: "Aktivnih backend-ova je preko demo praga (>30 od 200)."
 
   - name: messaging
-    interval: 30s
+    interval: 15s
     rules:
+      # DEMO: prag >10 poruka umesto >1000. for: 20s.
       - alert: RabbitMQBacklog
-        expr: rabbitmq_queue_messages_ready > 1000
-        for: 5m
+        expr: rabbitmq_queue_messages_ready > 10
+        for: 20s
         labels:
           severity: warning
           service: rabbitmq
           category: messaging
         annotations:
-          summary: "RabbitMQ zaostatak u redu {{ $labels.queue }}"
-          description: "{{ $value }} neobradjenih poruka u redu {{ $labels.queue }} 5+ minuta - consumer ne stize ili je pao."
+          summary: "RabbitMQ zaostatak u redu {{ $labels.queue }} (demo)"
+          description: "{{ $value }} neobradjenih poruka u redu {{ $labels.queue }} (>10 demo prag)."
 
       - alert: RabbitMQNoConsumers
         expr: rabbitmq_queue_consumers == 0 and rabbitmq_queue_messages_ready > 0
-        for: 5m
+        for: 20s
         labels:
           severity: warning
           service: rabbitmq
           category: messaging
         annotations:
           summary: "Nema consumer-a na redu {{ $labels.queue }}"
-          description: "Red {{ $labels.queue }} ima poruke ali 0 consumer-a 5+ minuta."
+          description: "Red {{ $labels.queue }} ima poruke ali 0 consumer-a."

--- a/setup/prometheus.yml
+++ b/setup/prometheus.yml
@@ -1,6 +1,6 @@
 global:
   scrape_interval: 15s
-  evaluation_interval: 15s
+  evaluation_interval: 10s
 
 rule_files:
   - /etc/prometheus/prometheus-rules.yml
@@ -23,3 +23,44 @@ scrape_configs:
   - job_name: alertmanager
     static_configs:
       - targets: ["alertmanager:9093"]
+
+  # Black-box HTTP probe svakog servisa (servisi se ne diraju).
+  # service_name label se postavlja po targetu; relabel preusmerava scrape na
+  # blackbox-exporter a stvarni URL ide kao ?target=.
+  - job_name: blackbox-http
+    scrape_interval: 10s
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets: ["http://notification-service:8006/health"]
+        labels: { service_name: notification-service }
+      - targets: ["http://banka_user_service:8081/actuator/health"]
+        labels: { service_name: user-service }
+      - targets: ["http://banka_banking_core_service:8084/actuator/health"]
+        labels: { service_name: banking-core-service }
+      - targets: ["http://banka_market_service:8085/actuator/health"]
+        labels: { service_name: market-service }
+      - targets: ["http://banka_trading_service:8088/actuator/health"]
+        labels: { service_name: trading-service }
+      - targets: ["http://banka_credit_service:8089/health"]
+        labels: { service_name: credit-service }
+      - targets: ["http://saga-orchestrator-service:8095/health"]
+        labels: { service_name: saga-orchestrator-service }
+      - targets: ["http://banka_interbank_service:8091/health"]
+        labels: { service_name: interbank-service }
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
+  - job_name: postgres
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  - job_name: rabbitmq
+    static_configs:
+      - targets: ["rabbitmq-exporter:9419"]


### PR DESCRIPTION
Servisi su Go i ne emituju aplikacione metrike, pa se monitoring radi spolja preko blackbox/postgres/rabbitmq exportera. Prepisana prometheus-rules.yml (ServiceDown, ServiceProbeSlow, PostgresConnectionsHigh, RabbitMQBacklog, RabbitMQNoConsumers; uklonjeni mrtvi jvm/hikari alarmi), dodati exporteri + scrape job-ovi, ubrzani Alertmanager timing-i, demo-mode skripte za testiranje, i azuriran README bota.