### PR TITLE
Cross-bank OTC exercise (oba smera) + asset/money conservation + idempotency; RSD-only placanja

### DIFF
--- a/banking-core-service-go/internal/http/handler.go
+++ b/banking-core-service-go/internal/http/handler.go
@@ -231,6 +231,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.accountByOwner(w, r)
 	case r.Method == http.MethodGet && path == "/internal/interbank/account-resolve":
 		h.resolveInterbankAccount(w, r)
+	case r.Method == http.MethodPost && path == "/internal/interbank/record-payment":
+		h.recordInterbankPayment(w, r)
 
 	case r.Method == http.MethodPost && path == "/internal/accounts/transaction":
 		h.internalTransaction(w, r, false)
@@ -518,6 +520,17 @@ func (h *Handler) resolveInterbankAccount(w http.ResponseWriter, r *http.Request
 	respond(w, resp, http.StatusOK, err)
 }
 
+func (h *Handler) recordInterbankPayment(w http.ResponseWriter, r *http.Request) {
+	if !h.requireServiceRole(w, r) {
+		return
+	}
+	var req service.RecordInterbankPaymentRequest
+	if !decode(w, r, &req) {
+		return
+	}
+	respondEmptyOK(w, h.services.Interbank.RecordInterbankPayment(r.Context(), req))
+}
+
 type creditDebitRequest struct {
 	AccountNumber string `json:"accountNumber"`
 	Amount        any    `json:"amount"`
@@ -691,6 +704,7 @@ func isKnownPath(path string) bool {
 		"/transactions/stockBuyMarginTransaction", "/transactions/stockSellMarginTransaction",
 		"/transactions/internal/reserve-funds", "/transactions/internal/transfer",
 		"/internal/interbank/reserve-monas", "/internal/interbank/account-by-owner", "/internal/interbank/account-resolve",
+		"/internal/interbank/record-payment",
 		"/internal/accounts/transaction", "/internal/accounts/exchange/buy", "/internal/accounts/exchange/sell",
 		"/internal/accounts/transactionFromBank", "/internal/accounts/debit", "/internal/accounts/credit",
 		"/internal/accounts/creditBank", "/internal/accounts/debitBank",

--- a/banking-core-service-go/internal/service/interbank.go
+++ b/banking-core-service-go/internal/service/interbank.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 
 	"banka1/banking-core-service-go/internal/decimal"
 	"banka1/banking-core-service-go/internal/uuid"
@@ -14,6 +15,24 @@ const (
 	InterbankCommitted = "COMMITTED"
 	InterbankReleased  = "RELEASED"
 )
+
+// interbankExternalSender is the sentinel stored in payment_table.from_account_number
+// when a cross-bank credit arrives from a foreign Person-only counterparty that has no
+// real 18-digit account number on the wire (e.g. an inbound OTC premium). The column is
+// VARCHAR(255) NOT NULL, so an empty fromAccount cannot be persisted as NULL/blank — the
+// sentinel keeps the audit row insertable while clearly marking the foreign origin.
+const interbankExternalSender = "INTERBANK-EXTERNAL"
+
+// normalizeInterbankFromAccount returns the account string to persist as the sender of a
+// recorded inter-bank payment. A blank fromAccount (foreign Person-only sender) collapses
+// to the interbankExternalSender sentinel; any non-blank value is passed through trimmed.
+func normalizeInterbankFromAccount(fromAccount string) string {
+	trimmed := strings.TrimSpace(fromAccount)
+	if trimmed == "" {
+		return interbankExternalSender
+	}
+	return trimmed
+}
 
 type InterbankService struct {
 	db       *sql.DB
@@ -43,8 +62,87 @@ type AccountByOwnerResponse struct {
 	AccountNumber string `json:"accountNumber"`
 }
 
+// RecordInterbankPaymentRequest is the body for POST /internal/interbank/record-payment.
+// It is posted by interbank-service after a cross-bank 2PC money leg commits, so the
+// movement shows up in this bank's transaction history (payment_table). The counterparty
+// account may be foreign (belonging to another bank); in that case its client id is left
+// as 0 because we have no local owner for it.
+type RecordInterbankPaymentRequest struct {
+	OrderNumber    string          `json:"orderNumber"`    // idempotency key (UNIQUE on payment_table.order_number)
+	FromAccount    string          `json:"fromAccount"`    // sender 18-digit account (local on outbound, foreign on inbound)
+	ToAccount      string          `json:"toAccount"`      // recipient 18-digit account (foreign on outbound, local on inbound)
+	Amount         decimal.Decimal `json:"amount"`         // moved amount (initial = final, same-currency interbank)
+	Currency       string          `json:"currency"`       // ISO currency code (from = to)
+	RecipientName  string          `json:"recipientName"`  // optional display name
+	PaymentPurpose string          `json:"paymentPurpose"` // optional purpose text
+}
+
 func NewInterbankService(db *sql.DB, accounts *AccountService) *InterbankService {
 	return &InterbankService{db: db, accounts: accounts}
+}
+
+// RecordInterbankPayment inserts a COMPLETED payment_table row for a cross-bank money
+// movement so it appears in transaction history. Idempotent on order_number
+// (ON CONFLICT DO NOTHING), matching the InternalService transfer audit style.
+//
+// sender_client_id / recipient_client_id are resolved from the local account when the
+// account belongs to this bank; the foreign counterparty has no local owner so its id
+// is left as 0 (the column is NOT NULL, so a sentinel 0 is used rather than NULL).
+func (s *InterbankService) RecordInterbankPayment(ctx context.Context, req RecordInterbankPaymentRequest) error {
+	// fromAccount is NO LONGER required: an inbound cross-bank credit from a foreign
+	// Person-only counterparty (e.g. an OTC premium) carries no real sender account on
+	// the wire, so it arrives blank. Collapsing it to a sentinel keeps the audit row
+	// insertable (from_account_number is VARCHAR(255) NOT NULL) instead of 400-ing and
+	// dropping the received money out of transaction history. orderNumber/toAccount stay
+	// mandatory.
+	if req.OrderNumber == "" || req.ToAccount == "" {
+		return BadRequest("orderNumber i toAccount su obavezni")
+	}
+	if req.Amount.Sign() <= 0 {
+		return BadRequest("Amount must be positive")
+	}
+	currency := strings.ToUpper(strings.TrimSpace(req.Currency))
+	if currency == "" {
+		return BadRequest("currency je obavezan")
+	}
+
+	fromAccount := normalizeInterbankFromAccount(req.FromAccount)
+	senderClientID := s.resolveLocalOwner(ctx, fromAccount)
+	recipientClientID := s.resolveLocalOwner(ctx, req.ToAccount)
+
+	recipientName := strings.TrimSpace(req.RecipientName)
+	if recipientName == "" {
+		recipientName = "Account " + req.ToAccount
+	}
+	purpose := strings.TrimSpace(req.PaymentPurpose)
+	if purpose == "" {
+		purpose = "Interbank payment"
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO payment_table (
+    from_account_number, to_account_number, initial_amount, final_amount, commission,
+    sender_client_id, recipient_client_id, recipient_name,
+    payment_code, reference_number, payment_purpose, status,
+    from_currency, to_currency, exchange_rate, order_number, created_at, updated_at, version
+) VALUES ($1, $2, $3, $3, 0, $4, $5, $6, '289', NULL, $7, 'COMPLETED',
+          $8, $8, 1, $9, NOW(), NOW(), 0)
+ON CONFLICT (order_number) DO NOTHING
+`, fromAccount, req.ToAccount, req.Amount,
+		senderClientID, recipientClientID, recipientName,
+		purpose, currency, req.OrderNumber)
+	return err
+}
+
+// resolveLocalOwner returns the owner (vlasnik) id of a local account, or 0 when the
+// account is not found locally (e.g. it belongs to a foreign bank). Best-effort:
+// resolution failures degrade to 0 rather than failing the audit record.
+func (s *InterbankService) resolveLocalOwner(ctx context.Context, accountNumber string) int64 {
+	acc, err := s.accounts.getByNumber(ctx, s.db, accountNumber, false)
+	if err != nil {
+		return 0
+	}
+	return acc.OwnerID
 }
 
 func (s *InterbankService) ReserveMonas(ctx context.Context, req ReserveMonasRequest) (string, error) {

--- a/banking-core-service-go/internal/service/interbank_test.go
+++ b/banking-core-service-go/internal/service/interbank_test.go
@@ -1,0 +1,27 @@
+package service
+
+import "testing"
+
+// TestNormalizeInterbankFromAccount covers FIX 6: a blank fromAccount (foreign
+// Person-only sender, e.g. an inbound OTC premium) must collapse to the
+// INTERBANK-EXTERNAL sentinel so the audit row stays insertable (from_account_number
+// is VARCHAR(255) NOT NULL) instead of being rejected and vanishing from history.
+func TestNormalizeInterbankFromAccount(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty -> sentinel", "", interbankExternalSender},
+		{"whitespace-only -> sentinel", "   ", interbankExternalSender},
+		{"real account passes through", "111000000000000123", "111000000000000123"},
+		{"trims surrounding space", "  222000000000000999  ", "222000000000000999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeInterbankFromAccount(tc.in); got != tc.want {
+				t.Fatalf("normalizeInterbankFromAccount(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/interbank-service/cmd/interbank-service/main.go
+++ b/interbank-service/cmd/interbank-service/main.go
@@ -158,7 +158,10 @@ func run() error {
 	// NegotiationStore → OptionNegotiationLookup adapter.
 	// NewNegotiationSellerLookup is provided by the service package; it also
 	// implements NegotiationReader for Validator use (used inside NewExecutor).
-	negLookup := service.NewNegotiationSellerLookup(negStore)
+	// The contract store is wired in so the Validator can tell an exercisable accepted
+	// option (closed negotiation + ACTIVE contract) apart from a dead one — without it,
+	// every accepted cross-bank option would fail its exercise 2PC with OPTION_USED_OR_EXPIRED.
+	negLookup := service.NewNegotiationSellerLookupWithContracts(negStore, contractStore)
 
 	executor := service.NewExecutor(
 		cfg.Interbank.MyRoutingNumber,
@@ -168,6 +171,11 @@ func run() error {
 		negLookup,
 		logger,
 	)
+	// FIX B — per-contract exercise idempotency: gate the (non-idempotent) exercise
+	// settlement legs (seller strike CreditMonas, buyer CreditStock) on the contract status
+	// so a retry with a NEW txId for an already-EXERCISED contract is a no-op (no double
+	// credit). The claim is an atomic ACTIVE→EXERCISED CAS on interbank_contracts.
+	executor.SetContractGate(&contractGateAdapter{contractStore})
 
 	// -------------------------------------------------------------------------
 	// OTC negotiation service — needs a CoordinatorIface.
@@ -184,14 +192,20 @@ func run() error {
 		logger,
 	)
 
-	// Coordinator uses BankingCoreClient for MONAS account resolution.
+	// Coordinator uses BankingCoreClient for MONAS account resolution. The
+	// sellerNegResolver maps a buyer-side contract's LOCAL negotiation id to the
+	// SELLER bank's authoritative id (the option pseudo-account key on exercise);
+	// bcReserver doubles as the off-wire buyer-strike reserver (LocalMonasReserver).
+	sellerNegResolver := &sellerNegAdapter{negStore}
 	coordinator := service.NewCoordinator(
 		cfg.Interbank.MyRoutingNumber,
 		executor,
 		outboundClient,
 		negStore,
-		contractStore, // *store.ContractStore satisfies service.ContractStoreIface
-		bcReserver,    // satisfies service.BankingCoreAccountResolver
+		contractStore,     // *store.ContractStore satisfies service.ContractStoreIface
+		bcReserver,        // satisfies service.BankingCoreAccountResolver
+		sellerNegResolver, // satisfies service.SellerNegResolver
+		bcReserver,        // satisfies service.LocalMonasReserver (Reserve/Commit/ReleaseMonas)
 		logger,
 	)
 	// Fill shim now that coordinator is ready.
@@ -202,7 +216,7 @@ func run() error {
 	// -------------------------------------------------------------------------
 	otcOutbound := service.NewOtcOutboundService(
 		cfg.Interbank.MyRoutingNumber,
-		negStore,      // satisfies NegotiationStoreForOutbound
+		negStore, // satisfies NegotiationStoreForOutbound
 		outboundClient,
 		otcSvc,
 		registry, // satisfies service.PartnerNameResolver
@@ -210,9 +224,32 @@ func run() error {
 	)
 
 	// -------------------------------------------------------------------------
+	// OTC contracts service (FE-facing buyer-side option contracts) — list +
+	// exercise. The exerciser is the same Coordinator used by OTC accept/payment.
+	// -------------------------------------------------------------------------
+	otcContracts := service.NewOtcContractsService(
+		cfg.Interbank.MyRoutingNumber,
+		contractStore, // *store.ContractStore satisfies ContractStoreForService
+		coordinator,   // *service.Coordinator satisfies service.ContractExerciser
+		logger,
+	)
+
+	// BuyerContractRecorder records the buyer's local option contract on a
+	// successful inbound COMMIT_TX (cross-bank OTC option buy). It reads back the
+	// committed tx postings, maps the partner negotiation id → our local mirror,
+	// and inserts an ACTIVE contract (idempotent).
+	buyerContractRecorder := service.NewBuyerContractRecorder(
+		cfg.Interbank.MyRoutingNumber,
+		execStore,     // *txStoreAdapter satisfies RecorderExecutorStore (FindTx)
+		contractStore, // satisfies RecorderContractStore
+		negStore,      // satisfies RecorderNegotiationStore
+		logger,
+	)
+
+	// -------------------------------------------------------------------------
 	// API handlers
 	// -------------------------------------------------------------------------
-	inboundHandler := api.NewInboundHandler(executor, msgStore, logger)
+	inboundHandler := api.NewInboundHandler(executor, msgStore, buyerContractRecorder, logger)
 	otcHandler := api.NewOtcHandler(otcSvc, logger)
 
 	// PublicStockHandler needs a PublicStockService; TradingClient satisfies it
@@ -229,18 +266,26 @@ func run() error {
 	)
 
 	otcOutboundHandler := api.NewOtcOutboundHandler(otcOutbound, logger)
+	otcContractsHandler := api.NewOtcContractsHandler(otcContracts, logger)
+
+	// PaymentHandler reuses the same Coordinator instance as OTC accept; it
+	// validates the sender account via banking-core (bcReserver satisfies
+	// service.BankingCoreReader) before running the outbound payment 2PC.
+	paymentHandler := api.NewPaymentHandler(coordinator, bcReserver, logger)
 
 	// -------------------------------------------------------------------------
 	// HTTP router
 	// -------------------------------------------------------------------------
 	deps := api.ServerDeps{
-		Partners:        registry, // satisfies auth.PartnerStore
-		InboundHandler:  inboundHandler,
-		OtcHandler:      otcHandler,
-		PublicStock:     pubStockHandler,
-		UserDisplay:     userDisplayHandler,
-		OtcOutbound:     otcOutboundHandler,
-		JWTSecret:       cfg.JWT.Secret,
+		Partners:       registry, // satisfies auth.PartnerStore
+		InboundHandler: inboundHandler,
+		OtcHandler:     otcHandler,
+		PublicStock:    pubStockHandler,
+		UserDisplay:    userDisplayHandler,
+		OtcOutbound:    otcOutboundHandler,
+		OtcContracts:   otcContractsHandler,
+		Payments:       paymentHandler,
+		JWTSecret:      cfg.JWT.Secret,
 	}
 	router := api.NewRouter(deps)
 
@@ -438,6 +483,46 @@ func (a *txStoreAdapter) UpdateTxStatus(ctx context.Context, routing int, id, st
 }
 
 // ---------------------------------------------------------------------------
+// contractGateAdapter — adapts *store.ContractStore to service.ContractGate
+// ---------------------------------------------------------------------------
+
+// contractGateAdapter bridges the per-contract exercise idempotency gate (FIX B) to the
+// contract store's atomic ACTIVE→EXERCISED claim. The method names differ only to keep the
+// service-side interface name short.
+type contractGateAdapter struct{ s *store.ContractStore }
+
+func (a *contractGateAdapter) ClaimExercise(ctx context.Context, negotiationID string) (bool, bool, error) {
+	return a.s.ClaimExerciseByNegotiation(ctx, negotiationID)
+}
+
+func (a *contractGateAdapter) ReleaseClaim(ctx context.Context, negotiationID string) error {
+	return a.s.ReleaseExerciseClaimByNegotiation(ctx, negotiationID)
+}
+
+// ---------------------------------------------------------------------------
+// sellerNegAdapter — adapts *store.NegotiationStore to service.SellerNegResolver
+// ---------------------------------------------------------------------------
+
+// sellerNegAdapter maps a buyer-side contract's LOCAL negotiation id to the SELLER
+// bank's AUTHORITATIVE negotiation id (the option pseudo-account key on a cross-bank
+// exercise). It reads our mirror negotiation row: when we are NOT authoritative we hold
+// a non-authoritative mirror whose remote_negotiation_id is the seller-bank id. When we
+// ARE authoritative (the option was issued here) there is no remote id; returning ""
+// makes the Coordinator fall back to the local id (correct — we host the pseudo-account).
+type sellerNegAdapter struct{ s *store.NegotiationStore }
+
+func (a *sellerNegAdapter) SellerNegotiationID(ctx context.Context, localNegotiationID string) string {
+	neg, err := a.s.FindByID(ctx, localNegotiationID)
+	if err != nil || neg == nil {
+		return ""
+	}
+	if neg.RemoteNegotiationID != nil && *neg.RemoteNegotiationID != "" {
+		return *neg.RemoteNegotiationID
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
 // bcAdapter — adapts *client.BankingCoreClient to service.BankingCoreReserver
 // ---------------------------------------------------------------------------
 
@@ -471,8 +556,16 @@ func (a *bcAdapter) CommitMonas(ctx context.Context, reservationID string) error
 	return a.c.CommitMonas(ctx, reservationID)
 }
 
+func (a *bcAdapter) CreditMonas(ctx context.Context, accountNum string, amount decimal.Decimal, clientID int64) error {
+	return a.c.CreditMonas(ctx, accountNum, amount, clientID)
+}
+
 func (a *bcAdapter) ReleaseMonas(ctx context.Context, reservationID string) error {
 	return a.c.ReleaseMonas(ctx, reservationID)
+}
+
+func (a *bcAdapter) RecordInterbankPayment(ctx context.Context, orderNumber, fromAccount, toAccount string, amount decimal.Decimal, currency, recipientName, paymentPurpose string) error {
+	return a.c.RecordInterbankPayment(ctx, orderNumber, fromAccount, toAccount, amount, currency, recipientName, paymentPurpose)
 }
 
 // ---------------------------------------------------------------------------

--- a/interbank-service/internal/api/coverage_extra_test.go
+++ b/interbank-service/internal/api/coverage_extra_test.go
@@ -406,7 +406,7 @@ func fullTestDeps() ServerDeps {
 			Routing:      testTheirRouting,
 			InboundToken: testApiKey,
 		}}},
-		InboundHandler: NewInboundHandler(&fakeInboundExecutor{prepareVote: protocol.TransactionVote{Vote: protocol.VoteYes}}, newFakeInboundMessageStore(), nil),
+		InboundHandler: NewInboundHandler(&fakeInboundExecutor{prepareVote: protocol.TransactionVote{Vote: protocol.VoteYes}}, newFakeInboundMessageStore(), nil, nil),
 		OtcHandler:     NewOtcHandler(&fakeOtcService{}, nil),
 		PublicStock:    NewPublicStockHandler(&fakePublicStockService{}, nil),
 		UserDisplay:    NewUserDisplayHandler(testMyRouting, "Banka 1", &fakeUserResolver{info: &UserDisplayInfo{DisplayName: "X"}}, nil),

--- a/interbank-service/internal/api/handlers_test.go
+++ b/interbank-service/internal/api/handlers_test.go
@@ -214,7 +214,7 @@ func TestUserDisplay_NoAuth_401(t *testing.T) {
 func TestHealthEndpoint(t *testing.T) {
 	deps := ServerDeps{
 		Partners:       &staticPartnerStore{},
-		InboundHandler: NewInboundHandler(&fakeInboundExecutor{}, newFakeInboundMessageStore(), nil),
+		InboundHandler: NewInboundHandler(&fakeInboundExecutor{}, newFakeInboundMessageStore(), nil, nil),
 		OtcHandler:     NewOtcHandler(&fakeOtcService{}, nil),
 		PublicStock:    NewPublicStockHandler(&fakePublicStockService{}, nil),
 		UserDisplay:    NewUserDisplayHandler(testMyRouting, "Banka 1", &fakeUserResolver{}, nil),

--- a/interbank-service/internal/api/inbound.go
+++ b/interbank-service/internal/api/inbound.go
@@ -28,6 +28,14 @@ type InboundMessageStore interface {
 	Insert(ctx context.Context, m *store.Message) error
 }
 
+// BuyerContractRecorder records the buyer's local option contract after a
+// successful inbound COMMIT_TX (cross-bank OTC option buy). Optional — when nil,
+// the inbound path behaves exactly as before. Implemented by
+// *service.BuyerContractRecorder.
+type BuyerContractRecorder interface {
+	RecordOnCommit(ctx context.Context, txID protocol.ForeignBankId)
+}
+
 // ---------------------------------------------------------------------------
 // InboundHandler
 // ---------------------------------------------------------------------------
@@ -37,15 +45,18 @@ type InboundMessageStore interface {
 type InboundHandler struct {
 	executor InboundExecutor
 	messages InboundMessageStore
+	recorder BuyerContractRecorder // optional — records buyer-side option contracts on commit
 	log      *slog.Logger
 }
 
-// NewInboundHandler constructs the handler.
-func NewInboundHandler(executor InboundExecutor, messages InboundMessageStore, log *slog.Logger) *InboundHandler {
+// NewInboundHandler constructs the handler. recorder may be nil; when set, it is
+// invoked after a successful inbound COMMIT_TX to record the buyer's local
+// option contract for a cross-bank OTC option buy.
+func NewInboundHandler(executor InboundExecutor, messages InboundMessageStore, recorder BuyerContractRecorder, log *slog.Logger) *InboundHandler {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &InboundHandler{executor: executor, messages: messages, log: log}
+	return &InboundHandler{executor: executor, messages: messages, recorder: recorder, log: log}
 }
 
 // PostMessage handles POST /interbank.
@@ -166,6 +177,15 @@ func (h *InboundHandler) handleCommitTx(w http.ResponseWriter, r *http.Request, 
 	if err := h.executor.CommitLocal(r.Context(), body.TransactionId); err != nil {
 		h.persistAndReturnError(w, r.Context(), msg, senderRouting, http.StatusInternalServerError, err.Error())
 		return
+	}
+
+	// Buyer-side option contract recording: when this committed tx carried an
+	// option receipt for one of our persons (we BOUGHT a cross-bank option),
+	// record a local ACTIVE contract so the buyer can see/exercise it. Best-effort
+	// and idempotent — the 2PC commit has already succeeded, so a recording
+	// failure must not turn this COMMIT_TX into a 5xx.
+	if h.recorder != nil {
+		h.recorder.RecordOnCommit(r.Context(), body.TransactionId)
 	}
 
 	h.persistCache(r.Context(), msg, senderRouting, http.StatusNoContent, "")

--- a/interbank-service/internal/api/inbound_test.go
+++ b/interbank-service/internal/api/inbound_test.go
@@ -89,7 +89,7 @@ func buildTestRouter(exec InboundExecutor, msgs InboundMessageStore) http.Handle
 		Routing:      testTheirRouting,
 		InboundToken: testApiKey,
 	}}}
-	h := NewInboundHandler(exec, msgs, nil)
+	h := NewInboundHandler(exec, msgs, nil, nil)
 	r := chi.NewRouter()
 	r.Group(func(r chi.Router) {
 		r.Use(auth.RequireXApiKey(partners))

--- a/interbank-service/internal/api/otc_contracts.go
+++ b/interbank-service/internal/api/otc_contracts.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/service"
+)
+
+// ---------------------------------------------------------------------------
+// OtcContractsHandler
+// ---------------------------------------------------------------------------
+
+// OtcContractsHandler handles the FE-facing JWT-authed interbank option-contract
+// routes:
+//
+//	GET  /api/interbank/otc/contracts/my          — list the caller's contracts
+//	POST /api/interbank/otc/contracts/{id}/exercise — buyer exercises a contract
+//
+// These complete the BUYER side of the cross-bank OTC option lifecycle: a Banka 1
+// user who bought an option from a partner bank can now see and exercise it.
+type OtcContractsHandler struct {
+	svc *service.OtcContractsService
+	log *slog.Logger
+}
+
+// NewOtcContractsHandler constructs the handler.
+func NewOtcContractsHandler(svc *service.OtcContractsService, log *slog.Logger) *OtcContractsHandler {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &OtcContractsHandler{svc: svc, log: log}
+}
+
+// List handles GET /api/interbank/otc/contracts/my.
+// Admin/supervisor callers may pass ?all=true to see every contract.
+func (h *OtcContractsHandler) List(w http.ResponseWriter, r *http.Request) {
+	principalID := extractPrincipalID(r)
+	isAdmin := hasAdminOrSupervisor(r) && r.URL.Query().Get("all") == "true"
+
+	views, err := h.svc.ListForUser(r.Context(), principalID, isAdmin)
+	if err != nil {
+		h.handleContractError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, views)
+}
+
+// Exercise handles POST /api/interbank/otc/contracts/{id}/exercise.
+func (h *OtcContractsHandler) Exercise(w http.ResponseWriter, r *http.Request) {
+	principalID := extractPrincipalID(r)
+	isAdmin := hasAdminOrSupervisor(r)
+	id := chi.URLParam(r, "id")
+
+	view, err := h.svc.Exercise(r.Context(), principalID, isAdmin, id)
+	if err != nil {
+		h.handleContractError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, view)
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+func (h *OtcContractsHandler) handleContractError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, service.ErrContractNotFound):
+		writeError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, service.ErrContractForbidden):
+		writeError(w, http.StatusForbidden, err.Error())
+	case errors.Is(err, service.ErrContractNotExercisable):
+		writeError(w, http.StatusConflict, err.Error())
+	case errors.Is(err, service.ErrContractAlreadyExercising):
+		// Lost the concurrent-exercise entry claim — another exercise is in flight.
+		writeError(w, http.StatusConflict, err.Error())
+	case errors.Is(err, service.ErrInterbankProtocol):
+		// Partner rejected / 2PC could not complete — treat as a conflict.
+		writeError(w, http.StatusConflict, err.Error())
+	default:
+		h.log.ErrorContext(r.Context(), "contracts: unexpected error", "err", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+	}
+}

--- a/interbank-service/internal/api/payment_outbound.go
+++ b/interbank-service/internal/api/payment_outbound.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/client"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/service"
+)
+
+// ---------------------------------------------------------------------------
+// PaymentHandler
+// ---------------------------------------------------------------------------
+
+// PaymentHandler handles the FE-facing POST /api/interbank/payments route.
+// It lets a Banka 1 user initiate a plain cross-bank money payment to an
+// account at a partner bank (e.g. Banka 2, routing 222). The handler runs the
+// inter-bank 2PC as coordinator via Coordinator.SendOutboundPayment.
+//
+// Like OtcOutboundHandler this route uses JWT auth (not X-Api-Key) so Angular
+// clients can call it directly without exposing the inter-bank token.
+type PaymentHandler struct {
+	coord *service.Coordinator
+	bc    service.BankingCoreReader
+	log   *slog.Logger
+}
+
+// NewPaymentHandler constructs the handler. bc resolves the sender account so we
+// can verify ownership and currency before initiating the 2PC.
+func NewPaymentHandler(coord *service.Coordinator, bc service.BankingCoreReader, log *slog.Logger) *PaymentHandler {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &PaymentHandler{coord: coord, bc: bc, log: log}
+}
+
+// outboundPaymentRequest is the FE request body for POST /api/interbank/payments.
+// Amount accepts both a JSON string ("100.50") and a bare number per the
+// shopspring/decimal unmarshaller used across the protocol DTOs.
+type outboundPaymentRequest struct {
+	FromAccount string          `json:"fromAccount"`
+	ToAccount   string          `json:"toAccount"`
+	Amount      decimal.Decimal `json:"amount"`
+	Currency    string          `json:"currency"`
+	Message     string          `json:"message,omitempty"`
+}
+
+// outboundPaymentResponse is returned on a successful 2PC commit.
+type outboundPaymentResponse struct {
+	TransactionID string `json:"transactionId"`
+	Status        string `json:"status"`
+}
+
+// Send handles POST /api/interbank/payments.
+func (h *PaymentHandler) Send(w http.ResponseWriter, r *http.Request) {
+	principalID := extractPrincipalID(r)
+	if principalID == 0 {
+		writeError(w, http.StatusUnauthorized, "missing or invalid principal id claim")
+		return
+	}
+
+	var req outboundPaymentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid body: "+err.Error())
+		return
+	}
+
+	// Basic validation.
+	if req.FromAccount == "" || req.ToAccount == "" {
+		writeError(w, http.StatusBadRequest, "fromAccount and toAccount are required")
+		return
+	}
+	if req.Currency == "" {
+		writeError(w, http.StatusBadRequest, "currency is required")
+		return
+	}
+	if !req.Amount.IsPositive() {
+		writeError(w, http.StatusBadRequest, "amount must be greater than zero")
+		return
+	}
+
+	// Validate the sender account against banking-core: it must exist, belong to
+	// the JWT principal (unless admin/supervisor), and be in the requested currency.
+	info, err := h.bc.ResolveAccount(r.Context(), req.FromAccount)
+	if err != nil {
+		if errors.Is(err, service.ErrAccountNotFound) || errors.Is(err, client.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "sender account not found")
+			return
+		}
+		h.log.ErrorContext(r.Context(), "payment: resolve sender account failed", "account", req.FromAccount, "err", err)
+		writeError(w, http.StatusInternalServerError, "failed to resolve sender account")
+		return
+	}
+	if info == nil {
+		writeError(w, http.StatusNotFound, "sender account not found")
+		return
+	}
+	if !hasAdminOrSupervisor(r) && info.OwnerID != principalID {
+		writeError(w, http.StatusForbidden, "sender account does not belong to the authenticated user")
+		return
+	}
+	if info.Currency != req.Currency {
+		writeError(w, http.StatusBadRequest, "currency does not match the sender account currency")
+		return
+	}
+
+	txID, err := h.coord.SendOutboundPayment(r.Context(), req.FromAccount, req.ToAccount, req.Amount, req.Currency, req.Message)
+	if err != nil {
+		h.handlePaymentError(w, r, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, outboundPaymentResponse{
+		TransactionID: fmt.Sprintf("%d:%s", txID.RoutingNumber, txID.Id),
+		Status:        "COMPLETED",
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+func (h *PaymentHandler) handlePaymentError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, service.ErrPaymentInvalid):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, service.ErrAccountNotFound), errors.Is(err, client.ErrNotFound):
+		writeError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, service.ErrInterbankProtocol):
+		// Partner rejected / 2PC could not complete — treat as a conflict.
+		writeError(w, http.StatusConflict, err.Error())
+	default:
+		h.log.ErrorContext(r.Context(), "payment: unexpected error", "err", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+	}
+}

--- a/interbank-service/internal/api/server.go
+++ b/interbank-service/internal/api/server.go
@@ -17,6 +17,8 @@ type ServerDeps struct {
 	PublicStock     *PublicStockHandler
 	UserDisplay     *UserDisplayHandler
 	OtcOutbound     *OtcOutboundHandler
+	OtcContracts    *OtcContractsHandler
+	Payments        *PaymentHandler
 	JWTSecret       string
 }
 
@@ -96,7 +98,23 @@ func NewRouter(d ServerDeps) http.Handler {
 				r.Post("/negotiations/{id}/accept", d.OtcOutbound.Accept)
 				r.Delete("/negotiations/{id}", d.OtcOutbound.Delete)
 				r.Get("/public-stock", d.OtcOutbound.PartnerPublicStock)
+
+				// Buyer-side option contracts (cross-bank OTC option buy lifecycle).
+				if d.OtcContracts != nil {
+					r.Get("/contracts/my", d.OtcContracts.List)
+					r.Post("/contracts/{id}/exercise", d.OtcContracts.Exercise)
+				}
 			})
+		})
+	}
+
+	// FE-facing JWT-authenticated outbound cross-bank payment route.
+	// Same permissions as the OTC outbound routes.
+	if d.Payments != nil {
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireJWT(d.JWTSecret))
+			r.Use(auth.RequirePermission("OTC_TRADE", "CLIENT_OTC_TRADE", "ROLE_ADMIN", "ROLE_SUPERVISOR"))
+			r.Post("/api/interbank/payments", d.Payments.Send)
 		})
 	}
 
@@ -143,7 +161,21 @@ func NewRouterWithMock(d ServerDeps, mountMock func(chi.Router)) http.Handler {
 				r.Post("/negotiations/{id}/accept", d.OtcOutbound.Accept)
 				r.Delete("/negotiations/{id}", d.OtcOutbound.Delete)
 				r.Get("/public-stock", d.OtcOutbound.PartnerPublicStock)
+
+				// Buyer-side option contracts (cross-bank OTC option buy lifecycle).
+				if d.OtcContracts != nil {
+					r.Get("/contracts/my", d.OtcContracts.List)
+					r.Post("/contracts/{id}/exercise", d.OtcContracts.Exercise)
+				}
 			})
+		})
+	}
+
+	if d.Payments != nil {
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireJWT(d.JWTSecret))
+			r.Use(auth.RequirePermission("OTC_TRADE", "CLIENT_OTC_TRADE", "ROLE_ADMIN", "ROLE_SUPERVISOR"))
+			r.Post("/api/interbank/payments", d.Payments.Send)
 		})
 	}
 

--- a/interbank-service/internal/client/banking_core.go
+++ b/interbank-service/internal/client/banking_core.go
@@ -78,12 +78,17 @@ func (c *BankingCoreClient) FindAccountByOwnerAndCurrency(ctx context.Context, o
 // ReserveMonas places a reservation for the given amount on the account.
 // Returns the reservation UUID. Idempotent per (txIDRouting, txIDLocal) on the server.
 func (c *BankingCoreClient) ReserveMonas(ctx context.Context, accountNum, currency string, amount decimal.Decimal, txIDRouting int, txIDLocal string) (string, error) {
+	// NOTE: field names MUST match banking-core's ReserveMonasRequest json tags
+	// (transactionIdRouting / transactionIdLocal). A previous mismatch
+	// (txIdRouting / txIdLocal) left TransactionIdLocal empty server-side, so every
+	// outbound MONAS reservation failed with "transactionIdLocal je obavezan" (400) —
+	// breaking the sender-debit leg of cross-bank payments and OTC buyer premiums.
 	body := map[string]any{
-		"accountNum":  accountNum,
-		"currency":    currency,
-		"amount":      amount.String(),
-		"txIdRouting": txIDRouting,
-		"txIdLocal":   txIDLocal,
+		"accountNum":           accountNum,
+		"currency":             currency,
+		"amount":               amount.String(),
+		"transactionIdRouting": txIDRouting,
+		"transactionIdLocal":   txIDLocal,
 	}
 	var resp struct {
 		ReservationID string `json:"reservationId"`
@@ -92,6 +97,39 @@ func (c *BankingCoreClient) ReserveMonas(ctx context.Context, accountNum, curren
 		return "", err
 	}
 	return resp.ReservationID, nil
+}
+
+// CreditMonas credits an account for an INCOMING inter-bank transfer (money arriving
+// at one of our accounts). Unlike CommitMonas — which finalizes a prior reservation
+// (a debit) — this directly increases the recipient's balance via banking-core's
+// POST /internal/accounts/credit. clientID MUST be the account owner: banking-core
+// validates ownership (validateMutable) and rejects a mismatch unless the owner is the
+// bank (-1). Returns nil on 2xx.
+func (c *BankingCoreClient) CreditMonas(ctx context.Context, accountNum string, amount decimal.Decimal, clientID int64) error {
+	body := map[string]any{
+		"accountNumber": accountNum,
+		"amount":        amount.String(),
+		"clientId":      clientID,
+	}
+	return c.do(ctx, http.MethodPost, c.baseURL+"/internal/accounts/credit", body, nil)
+}
+
+// RecordInterbankPayment asks banking-core to insert a COMPLETED payment_table row for a
+// cross-bank money movement so it shows up in this bank's transaction history. orderNumber
+// is the idempotency key (banking-core does ON CONFLICT DO NOTHING). Best-effort by
+// contract: callers log and continue on failure — it must never roll back a settled
+// transfer. Returns nil on 2xx.
+func (c *BankingCoreClient) RecordInterbankPayment(ctx context.Context, orderNumber, fromAccount, toAccount string, amount decimal.Decimal, currency, recipientName, paymentPurpose string) error {
+	body := map[string]any{
+		"orderNumber":    orderNumber,
+		"fromAccount":    fromAccount,
+		"toAccount":      toAccount,
+		"amount":         amount.String(),
+		"currency":       currency,
+		"recipientName":  recipientName,
+		"paymentPurpose": paymentPurpose,
+	}
+	return c.do(ctx, http.MethodPost, c.baseURL+"/internal/interbank/record-payment", body, nil)
 }
 
 // CommitMonas permanently debits the reserved amount. Returns nil on 204.

--- a/interbank-service/internal/client/trading.go
+++ b/interbank-service/internal/client/trading.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
 	"github.com/raf-si-2025/banka-1-go/shared/auth"
 )
@@ -86,6 +88,21 @@ func (c *TradingClient) ReserveStock(ctx context.Context, sellerUserID int64, ti
 		return "", err
 	}
 	return resp.ReservationID, nil
+}
+
+// CreditStock credits an incoming stock delivery to a LOCAL buyer's portfolio (the
+// buyer-side STOCK leg of a cross-bank OTC option exercise). Idempotency is provided by
+// the 2PC commit being single-shot per local tx. Returns nil on 204 (FIX 1).
+func (c *TradingClient) CreditStock(ctx context.Context, buyerUserID int64, ticker string, quantity int, txIDRouting int, txIDLocal string, strike decimal.Decimal) error {
+	body := map[string]any{
+		"buyerUserId":          buyerUserID,
+		"ticker":               ticker,
+		"quantity":             quantity,
+		"transactionIdRouting": txIDRouting,
+		"transactionIdLocal":   txIDLocal,
+		"strikePrice":          strike,
+	}
+	return c.do(ctx, http.MethodPost, c.baseURL+"/internal/interbank/credit-stock", body, nil)
 }
 
 // CommitStock permanently transfers the reserved stock. Returns nil on 204.

--- a/interbank-service/internal/service/contract_recorder.go
+++ b/interbank-service/internal/service/contract_recorder.go
@@ -1,0 +1,299 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// BuyerContractRecorder — records the BUYER's local option contract on commit
+// ---------------------------------------------------------------------------
+//
+// Closes the buyer-side gap in the cross-bank OTC option lifecycle. When a
+// Banka 1 user BUYS an option from a partner bank, the partner is the 2PC
+// coordinator: it creates the SELLER-side contract (see coordinator.go
+// AcceptNegotiation → contractSt.Insert), and B1 only processes the inbound
+// NEW_TX / COMMIT_TX. The buyer pays the premium correctly, but no local
+// contract was ever recorded for the option B1 received — so the buyer could
+// neither see nor exercise it.
+//
+// This recorder runs on the inbound COMMIT path: it scans the committed
+// transaction's stored postings for a buyer-side OPTION receipt (a
+// PersonAccount on OUR routing, positive amount, OptionAsset) and inserts a
+// matching interbank_contracts row in status ACTIVE.
+//
+// Idempotency: keyed by the negotiation. A second COMMIT (idempotent replay)
+// must not duplicate the contract — we check FindByNegotiationID before insert
+// and also tolerate a unique-violation from a concurrent insert.
+
+// RecorderContractStore is the persistence seam BuyerContractRecorder needs from
+// *store.ContractStore: look up an existing contract (idempotency), insert a new one,
+// and flip a contract's status (used to mark the SELLER's contract EXERCISED on an
+// inbound cross-bank exercise commit).
+type RecorderContractStore interface {
+	FindByNegotiationID(ctx context.Context, negotiationID string) (*store.Contract, error)
+	Insert(ctx context.Context, c *store.Contract) error
+	UpdateStatus(ctx context.Context, id, status string) error
+}
+
+// RecorderNegotiationStore is the lookup seam BuyerContractRecorder needs to map
+// the partner's negotiation id (carried in the option posting) to OUR local
+// mirror negotiation. The interbank_contracts.negotiation_id column has a FK to
+// interbank_negotiations(id), so the contract must reference the LOCAL id, not
+// the partner's. *store.NegotiationStore satisfies this.
+type RecorderNegotiationStore interface {
+	// FindByID returns (nil, nil) when not found. Matches when the partner's
+	// negotiation id happens to equal one of our local ids (rare).
+	FindByID(ctx context.Context, id string) (*store.Negotiation, error)
+	// FindByAuthoritativeRef matches a mirror row by remote_negotiation_id (the
+	// usual buyer case: we hold a non-authoritative mirror of the seller's neg).
+	FindByAuthoritativeRef(ctx context.Context, routing int, id string) (*store.Negotiation, error)
+}
+
+// RecorderExecutorStore is the seam used to read back the committed transaction's
+// stored postings. *store.TransactionStore is adapted to this in main.go (same
+// FindTx rename adapter as ExecutorStore).
+type RecorderExecutorStore interface {
+	FindTx(ctx context.Context, routing int, id string) (*store.Transaction, error)
+}
+
+// BuyerContractRecorder records the buyer's local option contract on commit.
+type BuyerContractRecorder struct {
+	myRouting int
+	txStore   RecorderExecutorStore
+	contracts RecorderContractStore
+	negs      RecorderNegotiationStore
+	log       *slog.Logger
+}
+
+// NewBuyerContractRecorder constructs the recorder.
+func NewBuyerContractRecorder(
+	myRouting int,
+	txStore RecorderExecutorStore,
+	contracts RecorderContractStore,
+	negs RecorderNegotiationStore,
+	log *slog.Logger,
+) *BuyerContractRecorder {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &BuyerContractRecorder{
+		myRouting: myRouting,
+		txStore:   txStore,
+		contracts: contracts,
+		negs:      negs,
+		log:       log,
+	}
+}
+
+// RecordOnCommit scans the committed transaction's postings for a buyer-side
+// OPTION receipt and, if found, inserts a local ACTIVE contract for it.
+//
+// It is best-effort and idempotent: it never returns an error (the 2PC commit
+// has already succeeded by the time this runs, so a recording failure must not
+// turn the inbound COMMIT_TX into a 5xx). Failures are logged.
+func (r *BuyerContractRecorder) RecordOnCommit(ctx context.Context, txID protocol.ForeignBankId) {
+	tx, err := r.txStore.FindTx(ctx, txID.RoutingNumber, txID.Id)
+	if err != nil {
+		r.log.WarnContext(ctx, "buyer-contract: find tx for recording failed", "txID", txID, "err", err)
+		return
+	}
+	if tx == nil || tx.PostingsJSON == "" {
+		return
+	}
+
+	var postings []protocol.Posting
+	if err := json.Unmarshal([]byte(tx.PostingsJSON), &postings); err != nil {
+		r.log.WarnContext(ctx, "buyer-contract: unmarshal postings failed", "txID", txID, "err", err)
+		return
+	}
+
+	// SELLER-side exercise: an inbound cross-bank exercise of an option WE issued. The
+	// committed tx delivered our seller's stock and credited the strike (executor); here we
+	// flip our local seller contract ACTIVE→EXERCISED so the seller's view matches reality.
+	// Mutually exclusive with the buyer-receipt path below (an exercise tx carries no
+	// buyer-side OPTION receipt, only STOCK/MONAS legs), so handle it and return.
+	if negID, ok := r.exerciseNegotiationID(postings); ok {
+		r.markSellerContractExercised(ctx, txID, negID)
+		return
+	}
+
+	// Locate the buyer-side OPTION receipt and the option's pseudo-account
+	// (the latter carries the seller bank's routing for the seller side).
+	receipt, optDesc, ok := r.findBuyerOptionReceipt(postings)
+	if !ok {
+		return // not a buyer-side option transaction — nothing to record
+	}
+	sellerRouting := r.sellerRoutingFrom(postings, optDesc)
+
+	if err := r.insertContract(ctx, receipt, optDesc, sellerRouting); err != nil {
+		r.log.ErrorContext(ctx, "buyer-contract: insert failed", "txID", txID, "neg", optDesc.NegotiationId, "err", err)
+	}
+}
+
+// exerciseNegotiationID returns the negotiation id of the option pseudo-account when the
+// committed tx is a cross-bank EXERCISE we host as the seller bank: an OptionPseudoAccount
+// leg carrying a (negative) StockAsset ("Credit option pseudo-account for k stocks",
+// §2.7.2). The pseudo-account's id IS the (our local) negotiation id.
+func (r *BuyerContractRecorder) exerciseNegotiationID(postings []protocol.Posting) (string, bool) {
+	for i := range postings {
+		pseudo, isPseudo := postings[i].Account.(*protocol.OptionPseudoAccount)
+		if !isPseudo {
+			continue
+		}
+		if _, isStock := postings[i].Asset.(*protocol.StockAsset); !isStock {
+			continue
+		}
+		if pseudo.Id.RoutingNumber != r.myRouting {
+			continue // the option is hosted by a partner bank — not our seller contract
+		}
+		return pseudo.Id.Id, true
+	}
+	return "", false
+}
+
+// markSellerContractExercised flips our local seller contract for negID to EXERCISED.
+// Best-effort and idempotent: a missing contract or an already-EXERCISED one is a no-op,
+// and any error is logged (the 2PC commit and settlement already succeeded — this is only
+// the contract-status view). The pseudo-account id is OUR local negotiation id, so the
+// contract is found directly via FindByNegotiationID.
+func (r *BuyerContractRecorder) markSellerContractExercised(ctx context.Context, txID protocol.ForeignBankId, negID string) {
+	contract, err := r.contracts.FindByNegotiationID(ctx, negID)
+	if err != nil {
+		r.log.WarnContext(ctx, "seller-contract: lookup for exercise flip failed", "txID", txID, "neg", negID, "err", err)
+		return
+	}
+	if contract == nil {
+		r.log.WarnContext(ctx, "seller-contract: no local contract for exercised negotiation — skipping flip", "txID", txID, "neg", negID)
+		return
+	}
+	if contract.Status == store.ContractStatusExercised {
+		return // idempotent: already exercised (duplicate COMMIT_TX §2.9)
+	}
+	if err := r.contracts.UpdateStatus(ctx, contract.ID, store.ContractStatusExercised); err != nil {
+		r.log.ErrorContext(ctx, "seller-contract: UpdateStatus EXERCISED failed", "txID", txID, "contract", contract.ID, "err", err)
+		return
+	}
+	r.log.InfoContext(ctx, "seller-side option contract EXERCISED", "txID", txID, "contract", contract.ID, "neg", negID)
+}
+
+// findBuyerOptionReceipt returns the buyer's option-receipt posting (PersonAccount
+// on our routing, positive amount, OptionAsset) and its OptionDescription.
+func (r *BuyerContractRecorder) findBuyerOptionReceipt(postings []protocol.Posting) (*protocol.PersonAccount, protocol.OptionDescription, bool) {
+	for i := range postings {
+		p := postings[i]
+		opt, isOpt := p.Asset.(*protocol.OptionAsset)
+		if !isOpt {
+			continue
+		}
+		person, isPerson := p.Account.(*protocol.PersonAccount)
+		if !isPerson {
+			continue
+		}
+		if person.Id.RoutingNumber != r.myRouting {
+			continue // option received by a partner person, not ours
+		}
+		if !p.Amount.IsPositive() {
+			continue // the buyer RECEIVES the option (+1); negatives are debits
+		}
+		return person, opt.OptionDescription, true
+	}
+	return nil, protocol.OptionDescription{}, false
+}
+
+// sellerRoutingFrom derives the seller bank's routing number. The OptionPseudoAccount
+// posting (the option-issuing side) carries the seller-bank routing in its id; we
+// fall back to the negotiation id's routing on the OptionDescription.
+func (r *BuyerContractRecorder) sellerRoutingFrom(postings []protocol.Posting, optDesc protocol.OptionDescription) int {
+	for i := range postings {
+		if pseudo, ok := postings[i].Account.(*protocol.OptionPseudoAccount); ok {
+			return pseudo.Id.RoutingNumber
+		}
+	}
+	return optDesc.NegotiationId.RoutingNumber
+}
+
+// insertContract resolves the local mirror negotiation (for the FK + idempotency
+// key) and inserts a buyer-side ACTIVE contract, skipping if one already exists.
+func (r *BuyerContractRecorder) insertContract(
+	ctx context.Context,
+	buyer *protocol.PersonAccount,
+	optDesc protocol.OptionDescription,
+	sellerRouting int,
+) error {
+	// Map the partner's negotiation id → our local mirror negotiation id. The
+	// interbank_contracts.negotiation_id FK references interbank_negotiations(id),
+	// which on the buyer side is OUR local id, not the partner's.
+	remoteNegID := optDesc.NegotiationId.Id
+	localNeg := r.resolveLocalNegotiation(ctx, remoteNegID)
+	if localNeg == nil {
+		// Without a local negotiation row we cannot satisfy the FK. Skip rather
+		// than insert an orphan (the seller bank still holds the authoritative
+		// contract; the buyer view simply won't show it).
+		r.log.WarnContext(ctx, "buyer-contract: no local mirror negotiation — skipping contract record",
+			"remoteNeg", remoteNegID, "sellerRouting", sellerRouting)
+		return nil
+	}
+
+	// Idempotency: a contract for this (local) negotiation already exists → no-op.
+	existing, err := r.contracts.FindByNegotiationID(ctx, localNeg.ID)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+
+	// Derive the seller foreign-id: prefer the local mirror's recorded seller.
+	sellerID := localNeg.SellerID
+	if sellerRouting == 0 {
+		sellerRouting = localNeg.SellerRouting
+	}
+
+	contract := &store.Contract{
+		ID:             generateContractID(),
+		NegotiationID:  localNeg.ID,
+		BuyerRouting:   buyer.Id.RoutingNumber,
+		BuyerID:        buyer.Id.Id,
+		SellerRouting:  sellerRouting,
+		SellerID:       sellerID,
+		StockTicker:    optDesc.Stock.Ticker,
+		Amount:         optDesc.Amount,
+		StrikeCurrency: optDesc.PricePerUnit.Currency,
+		StrikeAmount:   optDesc.PricePerUnit.Amount,
+		SettlementDate: localNeg.SettlementDate,
+		Status:         store.ContractStatusActive,
+		// The buyer conceptually owns (holds the right to) the option.
+		OptionPseudoOwnerRouting: buyer.Id.RoutingNumber,
+		OptionPseudoOwnerID:      buyer.Id.Id,
+	}
+	if err := r.contracts.Insert(ctx, contract); err != nil {
+		if store.IsUniqueViolation(err) {
+			// Concurrent commit recorded it first — idempotent success.
+			return nil
+		}
+		return err
+	}
+
+	r.log.InfoContext(ctx, "recorded buyer-side option contract — ACTIVE",
+		"contract", contract.ID, "neg", localNeg.ID, "ticker", contract.StockTicker,
+		"buyer", contract.BuyerID, "sellerRouting", sellerRouting)
+	return nil
+}
+
+// resolveLocalNegotiation finds OUR local negotiation row for the partner's
+// negotiation id: first by remote_negotiation_id (the usual buyer mirror), then
+// by direct id match (defensive — in case the ids coincide).
+func (r *BuyerContractRecorder) resolveLocalNegotiation(ctx context.Context, remoteNegID string) *store.Negotiation {
+	if n, err := r.negs.FindByAuthoritativeRef(ctx, 0, remoteNegID); err == nil && n != nil {
+		return n
+	}
+	if n, err := r.negs.FindByID(ctx, remoteNegID); err == nil && n != nil {
+		return n
+	}
+	return nil
+}

--- a/interbank-service/internal/service/contract_recorder_test.go
+++ b/interbank-service/internal/service/contract_recorder_test.go
@@ -1,0 +1,314 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes for BuyerContractRecorder
+// ---------------------------------------------------------------------------
+
+// recorderTxStore is a minimal RecorderExecutorStore returning a fixed tx.
+type recorderTxStore struct {
+	tx *store.Transaction
+}
+
+func (f *recorderTxStore) FindTx(_ context.Context, _ int, _ string) (*store.Transaction, error) {
+	return f.tx, nil
+}
+
+// recorderContractStore is a richer fake than coordinator_test.go's fakeContractStore:
+// it supports FindByNegotiationID + Insert for idempotency testing, plus UpdateStatus for
+// the seller-side EXERCISED flip.
+type recorderContractStore struct {
+	byNeg         map[string]*store.Contract
+	byID          map[string]*store.Contract
+	inserted      []*store.Contract
+	statusUpdates map[string]string // contract id → last status set
+}
+
+func newRecorderContractStore() *recorderContractStore {
+	return &recorderContractStore{
+		byNeg:         map[string]*store.Contract{},
+		byID:          map[string]*store.Contract{},
+		statusUpdates: map[string]string{},
+	}
+}
+
+func (f *recorderContractStore) FindByNegotiationID(_ context.Context, negID string) (*store.Contract, error) {
+	if c, ok := f.byNeg[negID]; ok {
+		return c, nil
+	}
+	return nil, nil
+}
+
+func (f *recorderContractStore) Insert(_ context.Context, c *store.Contract) error {
+	cp := *c
+	f.inserted = append(f.inserted, &cp)
+	f.byNeg[c.NegotiationID] = &cp
+	if c.ID != "" {
+		f.byID[c.ID] = &cp
+	}
+	return nil
+}
+
+func (f *recorderContractStore) UpdateStatus(_ context.Context, id, status string) error {
+	f.statusUpdates[id] = status
+	if c, ok := f.byID[id]; ok {
+		c.Status = status
+	}
+	return nil
+}
+
+// recorderNegStore is a minimal RecorderNegotiationStore. It matches the partner's
+// remote negotiation id to a local mirror via FindByAuthoritativeRef.
+type recorderNegStore struct {
+	byRemote map[string]*store.Negotiation // remote_negotiation_id → local mirror
+	byID     map[string]*store.Negotiation // local id → row
+}
+
+func (f *recorderNegStore) FindByID(_ context.Context, id string) (*store.Negotiation, error) {
+	if f.byID == nil {
+		return nil, nil
+	}
+	return f.byID[id], nil
+}
+
+func (f *recorderNegStore) FindByAuthoritativeRef(_ context.Context, _ int, id string) (*store.Negotiation, error) {
+	if f.byRemote == nil {
+		return nil, nil
+	}
+	return f.byRemote[id], nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// buyerOptionReceiptTx builds a committed-transaction row whose postings include
+// a buyer-side OPTION receipt (PersonAccount on our routing, +1, OptionAsset),
+// plus the seller OptionPseudoAccount debit — exactly the shape the partner
+// coordinator sends to us when we BUY the option.
+func buyerOptionReceiptTx(t *testing.T, sellerRouting int, remoteNegID, ticker string, amount int, strike decimal.Decimal) *store.Transaction {
+	t.Helper()
+	optDesc := protocol.OptionDescription{
+		NegotiationId:  protocol.ForeignBankId{RoutingNumber: sellerRouting, Id: remoteNegID},
+		Stock:          protocol.StockDescription{Ticker: ticker},
+		PricePerUnit:   protocol.MonetaryValue{Currency: "USD", Amount: strike},
+		SettlementDate: time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339),
+		Amount:         amount,
+	}
+	postings := []protocol.Posting{
+		// Seller option pseudo-account credit (-1) — option-issuing side (seller bank).
+		{
+			Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: sellerRouting, Id: remoteNegID}},
+			Amount:  decimal.NewFromInt(-1),
+			Asset:   &protocol.OptionAsset{OptionDescription: optDesc},
+		},
+		// Buyer person option receipt (+1) — OUR client receives the option.
+		{
+			Account: &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: myRouting, Id: "C-15"}},
+			Amount:  decimal.NewFromInt(1),
+			Asset:   &protocol.OptionAsset{OptionDescription: optDesc},
+		},
+	}
+	pj, err := json.Marshal(postings)
+	if err != nil {
+		t.Fatalf("marshal postings: %v", err)
+	}
+	return &store.Transaction{
+		TransactionIdRouting: sellerRouting,
+		TransactionIdLocal:   "tx-buy-opt",
+		Status:               store.TxStatusCommitted,
+		PostingsJSON:         string(pj),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestBuyerContractRecorder_RecordsBuyerContract(t *testing.T) {
+	tx := buyerOptionReceiptTx(t, theirRouting, "neg-remote-1", "AAPL", 10, decimal.NewFromInt(150))
+	txStore := &recorderTxStore{tx: tx}
+	cs := newRecorderContractStore()
+	localNeg := &store.Negotiation{
+		ID:             "neg-local-1",
+		BuyerRouting:   myRouting,
+		BuyerID:        "C-15",
+		SellerRouting:  theirRouting,
+		SellerID:       "C-2",
+		StockTicker:    "AAPL",
+		Amount:         10,
+		PriceCurrency:  "USD",
+		PriceAmount:    decimal.NewFromInt(150),
+		SettlementDate: time.Now().Add(48 * time.Hour),
+	}
+	ns := &recorderNegStore{byRemote: map[string]*store.Negotiation{"neg-remote-1": localNeg}}
+
+	rec := NewBuyerContractRecorder(myRouting, txStore, cs, ns, discardLogger())
+	rec.RecordOnCommit(context.Background(), protocol.ForeignBankId{RoutingNumber: theirRouting, Id: "tx-buy-opt"})
+
+	if len(cs.inserted) != 1 {
+		t.Fatalf("expected exactly one contract inserted, got %d", len(cs.inserted))
+	}
+	c := cs.inserted[0]
+	if c.NegotiationID != "neg-local-1" {
+		t.Errorf("expected FK to local negotiation id, got %q", c.NegotiationID)
+	}
+	if c.BuyerRouting != myRouting || c.BuyerID != "C-15" {
+		t.Errorf("unexpected buyer %d/%s", c.BuyerRouting, c.BuyerID)
+	}
+	if c.SellerRouting != theirRouting {
+		t.Errorf("expected seller routing %d, got %d", theirRouting, c.SellerRouting)
+	}
+	if c.StockTicker != "AAPL" || c.Amount != 10 {
+		t.Errorf("unexpected ticker/amount %s/%d", c.StockTicker, c.Amount)
+	}
+	if c.StrikeCurrency != "USD" || !c.StrikeAmount.Equal(decimal.NewFromInt(150)) {
+		t.Errorf("unexpected strike %s/%s", c.StrikeCurrency, c.StrikeAmount)
+	}
+	if c.Status != store.ContractStatusActive {
+		t.Errorf("expected ACTIVE, got %q", c.Status)
+	}
+	if c.OptionPseudoOwnerRouting != myRouting || c.OptionPseudoOwnerID != "C-15" {
+		t.Errorf("buyer should hold the option, got %d/%s", c.OptionPseudoOwnerRouting, c.OptionPseudoOwnerID)
+	}
+}
+
+func TestBuyerContractRecorder_IdempotentOnSecondCommit(t *testing.T) {
+	tx := buyerOptionReceiptTx(t, theirRouting, "neg-remote-2", "MSFT", 5, decimal.NewFromInt(300))
+	txStore := &recorderTxStore{tx: tx}
+	cs := newRecorderContractStore()
+	localNeg := &store.Negotiation{
+		ID:             "neg-local-2",
+		BuyerRouting:   myRouting,
+		BuyerID:        "C-15",
+		SellerRouting:  theirRouting,
+		SellerID:       "C-2",
+		StockTicker:    "MSFT",
+		Amount:         5,
+		PriceCurrency:  "USD",
+		PriceAmount:    decimal.NewFromInt(300),
+		SettlementDate: time.Now().Add(48 * time.Hour),
+	}
+	ns := &recorderNegStore{byRemote: map[string]*store.Negotiation{"neg-remote-2": localNeg}}
+
+	rec := NewBuyerContractRecorder(myRouting, txStore, cs, ns, discardLogger())
+	ctx := context.Background()
+	txID := protocol.ForeignBankId{RoutingNumber: theirRouting, Id: "tx-buy-opt"}
+
+	rec.RecordOnCommit(ctx, txID)
+	rec.RecordOnCommit(ctx, txID) // idempotent replay
+
+	if len(cs.inserted) != 1 {
+		t.Fatalf("expected exactly one contract after duplicate commits, got %d", len(cs.inserted))
+	}
+}
+
+func TestBuyerContractRecorder_NonOptionTx_NoContract(t *testing.T) {
+	// A plain MONAS-only transaction must not produce a contract.
+	postings := balancedMonasPosting("222000000000000099", "111000000000000001", 100, "USD")
+	pj, _ := json.Marshal(postings)
+	txStore := &recorderTxStore{tx: &store.Transaction{
+		TransactionIdRouting: theirRouting,
+		TransactionIdLocal:   "tx-money",
+		Status:               store.TxStatusCommitted,
+		PostingsJSON:         string(pj),
+	}}
+	cs := newRecorderContractStore()
+	ns := &recorderNegStore{}
+
+	rec := NewBuyerContractRecorder(myRouting, txStore, cs, ns, discardLogger())
+	rec.RecordOnCommit(context.Background(), protocol.ForeignBankId{RoutingNumber: theirRouting, Id: "tx-money"})
+
+	if len(cs.inserted) != 0 {
+		t.Fatalf("expected no contract for a money-only tx, got %d", len(cs.inserted))
+	}
+}
+
+func TestBuyerContractRecorder_NoLocalNegotiation_Skips(t *testing.T) {
+	// No local mirror negotiation → cannot satisfy FK → skip (no insert, no panic).
+	tx := buyerOptionReceiptTx(t, theirRouting, "neg-missing", "TSLA", 3, decimal.NewFromInt(200))
+	txStore := &recorderTxStore{tx: tx}
+	cs := newRecorderContractStore()
+	ns := &recorderNegStore{} // empty — nothing resolves
+
+	rec := NewBuyerContractRecorder(myRouting, txStore, cs, ns, discardLogger())
+	rec.RecordOnCommit(context.Background(), protocol.ForeignBankId{RoutingNumber: theirRouting, Id: "tx-buy-opt"})
+
+	if len(cs.inserted) != 0 {
+		t.Fatalf("expected no contract when local negotiation is missing, got %d", len(cs.inserted))
+	}
+}
+
+// sellerExerciseCommitTx builds the committed exercise tx that B1 (seller, myRouting)
+// receives from the buyer's bank: our OPTION pseudo-account (id = our local negotiation id)
+// is credited -k stocks and +k·π monas, the buyer (partner) receives the stock. This is the
+// shape the seller-side EXERCISED flip keys off.
+func sellerExerciseCommitTx(t *testing.T, localNegID, ticker string) *store.Transaction {
+	t.Helper()
+	neg := protocol.ForeignBankId{RoutingNumber: myRouting, Id: localNegID}
+	seller := protocol.ForeignBankId{RoutingNumber: myRouting, Id: "C-5"}
+	buyer := protocol.ForeignBankId{RoutingNumber: theirRouting, Id: "C-8"}
+	postings := []protocol.Posting{
+		{Account: &protocol.OptionPseudoAccount{Id: neg}, Amount: decimal.NewFromInt(200), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		{Account: &protocol.PersonAccount{Id: seller}, Amount: decimal.NewFromInt(-200), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		{Account: &protocol.OptionPseudoAccount{Id: neg}, Amount: decimal.NewFromInt(-1), Asset: &protocol.StockAsset{Ticker: ticker}},
+		{Account: &protocol.PersonAccount{Id: buyer}, Amount: decimal.NewFromInt(1), Asset: &protocol.StockAsset{Ticker: ticker}},
+	}
+	pj, err := json.Marshal(postings)
+	if err != nil {
+		t.Fatalf("marshal postings: %v", err)
+	}
+	return &store.Transaction{
+		TransactionIdRouting: theirRouting,
+		TransactionIdLocal:   "tx-ex-seller",
+		Status:               store.TxStatusCommitted,
+		PostingsJSON:         string(pj),
+	}
+}
+
+// On an inbound exercise commit, the seller's local contract is flipped ACTIVE→EXERCISED,
+// and no buyer contract is inserted.
+func TestBuyerContractRecorder_SellerExercise_FlipsContractExercised(t *testing.T) {
+	tx := sellerExerciseCommitTx(t, "neg-local-ex", "AAPL")
+	txStore := &recorderTxStore{tx: tx}
+	cs := newRecorderContractStore()
+	cs.byNeg["neg-local-ex"] = &store.Contract{ID: "ctr-1", NegotiationID: "neg-local-ex", Status: store.ContractStatusActive}
+	ns := &recorderNegStore{}
+
+	rec := NewBuyerContractRecorder(myRouting, txStore, cs, ns, discardLogger())
+	rec.RecordOnCommit(context.Background(), protocol.ForeignBankId{RoutingNumber: theirRouting, Id: "tx-ex-seller"})
+
+	if got := cs.statusUpdates["ctr-1"]; got != store.ContractStatusExercised {
+		t.Fatalf("expected seller contract flipped to EXERCISED, got %q", got)
+	}
+	if len(cs.inserted) != 0 {
+		t.Fatalf("exercise must not insert a buyer contract, got %d", len(cs.inserted))
+	}
+}
+
+// Idempotent: a duplicate exercise COMMIT_TX (already EXERCISED) does not re-update.
+func TestBuyerContractRecorder_SellerExercise_IdempotentWhenAlreadyExercised(t *testing.T) {
+	tx := sellerExerciseCommitTx(t, "neg-local-ex2", "AAPL")
+	txStore := &recorderTxStore{tx: tx}
+	cs := newRecorderContractStore()
+	cs.byNeg["neg-local-ex2"] = &store.Contract{ID: "ctr-2", NegotiationID: "neg-local-ex2", Status: store.ContractStatusExercised}
+	ns := &recorderNegStore{}
+
+	rec := NewBuyerContractRecorder(myRouting, txStore, cs, ns, discardLogger())
+	rec.RecordOnCommit(context.Background(), protocol.ForeignBankId{RoutingNumber: theirRouting, Id: "tx-ex-seller"})
+
+	if _, updated := cs.statusUpdates["ctr-2"]; updated {
+		t.Fatalf("already-EXERCISED contract must not be re-updated")
+	}
+}

--- a/interbank-service/internal/service/coordinator.go
+++ b/interbank-service/internal/service/coordinator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -46,9 +47,50 @@ type ContractStoreIface interface {
 // ---------------------------------------------------------------------------
 
 // BankingCoreAccountResolver is a subset of BankingCoreReserver used by Coordinator
-// to look up real account numbers for local parties.
+// to look up real account numbers for local parties and to record the transaction-history
+// row for an outbound cross-bank money leg.
 type BankingCoreAccountResolver interface {
 	FindAccountByOwnerAndCurrency(ctx context.Context, ownerID int64, currency string) (string, error)
+	// RecordInterbankPayment records a COMPLETED payment_table row so the outbound
+	// money shows in transaction history. Best-effort: callers log and continue on failure.
+	RecordInterbankPayment(ctx context.Context, orderNumber, fromAccount, toAccount string, amount decimal.Decimal, currency, recipientName, paymentPurpose string) error
+}
+
+// SellerNegResolver resolves the SELLER bank's AUTHORITATIVE negotiation id for a
+// contract we (the buyer) hold. The cross-bank OTC option pseudo-account is keyed by the
+// negotiation id AT THE BANK THAT ISSUED THE OPTION (the seller). When we are the buyer we
+// hold only a NON-authoritative mirror of the seller's negotiation, so contract.NegotiationID
+// is our LOCAL mirror id, not the seller's — exercising with the local id would address an
+// option pseudo-account the seller bank cannot resolve. This seam maps our local negotiation
+// id to the seller bank's authoritative id (the mirror row's remote_negotiation_id).
+//
+// Optional: when nil, or when no mirror/remote id is found, the Coordinator falls back to
+// contract.NegotiationID (correct when we ARE the authoritative side, i.e. an intra-issued
+// negotiation, or in tests with a single id space).
+type SellerNegResolver interface {
+	// SellerNegotiationID returns the seller-bank authoritative negotiation id for the
+	// given LOCAL negotiation id. It returns "" (no error) when there is no mapping, so
+	// the caller can fall back to the local id.
+	SellerNegotiationID(ctx context.Context, localNegotiationID string) string
+}
+
+// LocalMonasReserver lets the Coordinator reserve and commit a LOCAL money debit
+// OUTSIDE the inter-bank wire postings. The buyer-side exercise strike debit is NOT
+// carried on the wire (it would unbalance the canonical MONAS group: OPTION +strike +
+// seller −strike already nets to zero). Instead — mirroring how the SELLER side's bank
+// consumes the buyer cash from its own reservation, and how the partner does
+// reservationApplier.commitMonas AFTER a successful 2PC — we reserve the buyer's strike
+// locally at prepare time and commit it only after the partner has voted YES and we have
+// committed locally. On any abort we release it (no money moved).
+//
+// Optional: when nil (e.g. tests, or a deployment without a banking-core reserver) the
+// buyer strike is not reserved here; conservation then relies on the buyer already having
+// been debited upstream. Production always wires the banking-core reserver.
+type LocalMonasReserver interface {
+	FindAccountByOwnerAndCurrency(ctx context.Context, ownerID int64, currency string) (string, error)
+	ReserveMonas(ctx context.Context, accountNum, currency string, amount decimal.Decimal, txIDRouting int, txIDLocal string) (string, error)
+	CommitMonas(ctx context.Context, reservationID string) error
+	ReleaseMonas(ctx context.Context, reservationID string) error
 }
 
 // ---------------------------------------------------------------------------
@@ -74,11 +116,16 @@ type Coordinator struct {
 	negStore    NegotiationStoreIface
 	contractSt  ContractStoreIface
 	bcResolver  BankingCoreAccountResolver
+	sellerNeg   SellerNegResolver  // optional — resolves the seller bank's authoritative negId for buyer-side exercise
+	monasResv   LocalMonasReserver // optional — reserves/commits the buyer strike debit off-wire on exercise
 	log         *slog.Logger
 }
 
 // NewCoordinator constructs a Coordinator. bcResolver may be nil — in that case
 // MONAS account resolution falls back to TxAccount.Person (partner resolves).
+// sellerNeg may be nil — in that case buyer-side ExerciseContract addresses the
+// option pseudo-account with contract.NegotiationID directly (correct when we are
+// the authoritative side; partner-mirror cases supply a resolver in production).
 func NewCoordinator(
 	myRouting int,
 	executor *Executor,
@@ -86,6 +133,8 @@ func NewCoordinator(
 	negStore NegotiationStoreIface,
 	contractSt ContractStoreIface,
 	bcResolver BankingCoreAccountResolver,
+	sellerNeg SellerNegResolver,
+	monasResv LocalMonasReserver,
 	log *slog.Logger,
 ) *Coordinator {
 	if log == nil {
@@ -98,6 +147,8 @@ func NewCoordinator(
 		negStore:   negStore,
 		contractSt: contractSt,
 		bcResolver: bcResolver,
+		sellerNeg:  sellerNeg,
+		monasResv:  monasResv,
 		log:        log,
 	}
 }
@@ -232,6 +283,325 @@ func (c *Coordinator) AcceptNegotiation(ctx context.Context, neg *store.Negotiat
 	return nil
 }
 
+// SendOutboundPayment runs the inter-bank 2PC as coordinator for a plain
+// cross-bank money payment: Banka 1 user → an account at a partner bank.
+//
+// This is the money-only sibling of AcceptNegotiation — same 2PC sequence, no
+// option/contract. The transaction carries two MONAS postings (sender debit on
+// our side, recipient credit on the partner's side); our PrepareLocal reserves
+// only the sender debit (the credit lands at the partner), and CommitLocal
+// finalizes that debit. The partner performs the recipient credit.
+//
+// Flow (mirrors AcceptNegotiation):
+//  1. PrepareLocal (reserve sender debit).
+//  2. OutboundClient.SendNewTx (partner prepare).
+//  3. On partner NO or error: rollback local (+ rollback partner); return error.
+//  4. CommitLocal (finalize sender debit).
+//  5. OutboundClient.SendCommitTx (best-effort; retry scheduler covers failures).
+//
+// Returns the freshly generated transaction id on success.
+func (c *Coordinator) SendOutboundPayment(ctx context.Context, fromAccount, toAccount string, amount decimal.Decimal, currency, message string) (protocol.ForeignBankId, error) {
+	// FIX 5: cross-bank PLAIN payments are RSD-only by product decision — foreign
+	// currencies are blocked (no FX on the inter-bank money rail) BEFORE any 2PC begins.
+	// OTC settlement (AcceptNegotiation / ExerciseContract) is unaffected and stays USD.
+	if !strings.EqualFold(strings.TrimSpace(currency), "RSD") {
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: medjubankarska placanja su podrzana samo u RSD (currency=%q)", ErrPaymentInvalid, currency)
+	}
+
+	// Derive the partner routing from the recipient account's 3-digit prefix.
+	if len(toAccount) < 3 {
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: recipient account too short: %q", ErrPaymentInvalid, toAccount)
+	}
+	partnerRouting, err := parseBigInt(toAccount[:3])
+	if err != nil {
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: recipient routing prefix not numeric: %q", ErrPaymentInvalid, toAccount[:3])
+	}
+	if int(partnerRouting) == c.myRouting {
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: recipient routing equals ours (%d) — use intra-bank transfer", ErrPaymentInvalid, c.myRouting)
+	}
+
+	postings := []protocol.Posting{
+		// a) Sender debit (-amount): money leaves our local account.
+		{
+			Account: &protocol.RealAccount{Num: fromAccount},
+			Amount:  amount.Neg(),
+			Asset:   &protocol.MonasAsset{Currency: currency},
+		},
+		// b) Recipient credit (+amount): money arrives at the partner account.
+		{
+			Account: &protocol.RealAccount{Num: toAccount},
+			Amount:  amount,
+			Asset:   &protocol.MonasAsset{Currency: currency},
+		},
+	}
+
+	txID := protocol.ForeignBankId{RoutingNumber: c.myRouting, Id: generateTxID()}
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId:  txID,
+		Postings:       postings,
+		Message:        message,
+		PaymentCode:    "289",
+		PaymentPurpose: message,
+	}
+
+	// 1. PrepareLocal.
+	localVote, err := c.executor.PrepareLocal(ctx, tx)
+	if err != nil {
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: local prepare infra failure: %v", ErrInterbankProtocol, err)
+	}
+	if localVote.Vote != protocol.VoteYes {
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: local prepare rejected: %v", ErrInterbankProtocol, localVote.Reasons)
+	}
+
+	// 2. Partner prepare.
+	partnerVote, err := c.outbound.SendNewTx(ctx, int(partnerRouting), tx)
+	if err != nil {
+		c.safeRollbackLocal(ctx, txID)
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: partner prepare exception: %v", ErrInterbankProtocol, err)
+	}
+	if partnerVote.Vote != protocol.VoteYes {
+		c.safeRollbackLocal(ctx, txID)
+		c.safeRollbackPartner(ctx, int(partnerRouting), txID)
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: partner rejected: %v", ErrInterbankProtocol, partnerVote.Reasons)
+	}
+
+	// 3. CommitLocal.
+	if err := c.executor.CommitLocal(ctx, txID); err != nil {
+		// Catastrophic: we committed locally but might fail to tell partner.
+		c.safeRollbackPartner(ctx, int(partnerRouting), txID)
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: catastrophic commitLocal failure: %v", ErrInterbankProtocol, err)
+	}
+
+	// 3b. Record the outbound money in our transaction history. Best-effort: a
+	// recording failure must NOT fail the (already committed) payment — log & continue.
+	// Idempotent via deterministic order_number (ON CONFLICT DO NOTHING server-side).
+	c.recordOutboundPayment(ctx, txID, fromAccount, toAccount, amount, currency, message)
+
+	// 4. Partner commit — best-effort (retry scheduler covers failures).
+	if err := c.outbound.SendCommitTx(ctx, int(partnerRouting), txID); err != nil {
+		c.log.WarnContext(ctx, "coordinator: payment sendCommitTx to partner failed — retry scheduler will pick it up",
+			"partnerRouting", partnerRouting, "txID", txID, "err", err)
+	}
+
+	c.log.InfoContext(ctx, "sent outbound cross-bank payment",
+		"from", fromAccount, "to", toAccount, "amount", amount, "currency", currency,
+		"partnerRouting", partnerRouting, "tx", txID)
+	return txID, nil
+}
+
+// ExerciseContract runs the inter-bank 2PC as coordinator for the BUYER
+// exercising a cross-bank OTC option before/at settlement.
+//
+// This is the buyer-side counterpart of the seller-centric exercise path. The
+// option holder (our buyer) pays the strike (price × amount) to the seller and
+// receives `amount` shares of the underlying.
+//
+// Wire shape — CANONICAL §2.7.2 exercise (mirror of the already-working
+// B2-buyer / B1-seller tx, with the routings swapped). All four legs carry the
+// SELLER bank's routing for the option pseudo-account; the seller's stock-delivery
+// and strike-credit legs sit on the seller-bank OPTION pseudo-account / PERSON so the
+// seller bank recognises the exercise from the SHAPE (Stock+Option signature) and
+// settles its seller internally:
+//
+//	p1  OPTION{sellerRouting, sellerNegId}  +strike   MONAS{strikeCcy}  (option pseudo receives money)
+//	p2  PERSON{sellerRouting, sellerId}     −strike   MONAS{strikeCcy}  (seller is CREDITED — negative)
+//	p3  OPTION{sellerRouting, sellerNegId}  −k        STOCK{ticker}     (seller DELIVERS — exercise signature)
+//	p4  PERSON{buyerRouting,  buyerId}      +k        STOCK{ticker}     (our buyer receives the shares)
+//
+// MONAS group nets to zero (p1 +strike, p2 −strike); STOCK group nets to zero
+// (p3 −k, p4 +k) — the tx is balanced on both banks.
+//
+// The buyer's strike debit is NOT a wire posting (adding it would unbalance the MONAS
+// group). It is reserved LOCALLY before the 2PC and committed only after a successful
+// SendCommitTx — exactly as the partner consumes the buyer cash from its own
+// reservation in the mirror direction (reservationApplier.commitMonas AFTER 2PC). On any
+// abort the reservation is released and no money moves.
+//
+// Flow (mirrors AcceptNegotiation): reserve buyer strike → SendNewTx →
+// (release+rollback on NO/err) → SendCommitTx → commit buyer strike. The seller bank's
+// PrepareLocal validates the canonical legs; its CommitLocal delivers the seller stock and
+// credits the seller strike (settleSellerOnInboundExercise). The caller
+// (OtcContractsService) flips OUR buyer contract to EXERCISED after this returns nil.
+// Returns the generated tx id.
+func (c *Coordinator) ExerciseContract(ctx context.Context, contract *store.Contract) (protocol.ForeignBankId, error) {
+	// The seller is the partner; the buyer is us.
+	partnerRouting := contract.SellerRouting
+	strikeCurrency := contract.StrikeCurrency
+	totalStrike := contract.StrikeAmount.Mul(decimal.NewFromInt(int64(contract.Amount)))
+	qty := decimal.NewFromInt(int64(contract.Amount))
+
+	buyerParty := protocol.ForeignBankId{RoutingNumber: contract.BuyerRouting, Id: contract.BuyerID}
+	sellerParty := protocol.ForeignBankId{RoutingNumber: contract.SellerRouting, Id: contract.SellerID}
+
+	// The OPTION pseudo-account is keyed by the SELLER bank's AUTHORITATIVE negotiation id
+	// (the bank that ISSUED the option resolves the pseudo-account → its seller contract).
+	// We hold only a non-authoritative mirror, so contract.NegotiationID is our LOCAL id;
+	// map it to the seller-bank id when a resolver is wired, else fall back to the local id.
+	sellerNegID := contract.NegotiationID
+	if c.sellerNeg != nil {
+		if remote := c.sellerNeg.SellerNegotiationID(ctx, contract.NegotiationID); remote != "" {
+			sellerNegID = remote
+		}
+	}
+	optionPseudo := &protocol.OptionPseudoAccount{
+		Id: protocol.ForeignBankId{RoutingNumber: contract.SellerRouting, Id: sellerNegID},
+	}
+
+	postings := []protocol.Posting{
+		// p1) OPTION pseudo-account debit (+strike): the pseudo-account receives the money.
+		{
+			Account: optionPseudo,
+			Amount:  totalStrike,
+			Asset:   &protocol.MonasAsset{Currency: strikeCurrency},
+		},
+		// p2) Seller strike credit (−strike): the seller RECEIVES the strike. NEGATIVE is
+		// the protocol "credit seller" sign — the seller bank credits its seller from the
+		// swept pseudo-account; a positive amount would be read as a seller DEBIT (drain).
+		{
+			Account: &protocol.PersonAccount{Id: sellerParty},
+			Amount:  totalStrike.Neg(),
+			Asset:   &protocol.MonasAsset{Currency: strikeCurrency},
+		},
+		// p3) OPTION pseudo-account credit (−k STOCK): the seller delivers the shares. The
+		// NEGATIVE STOCK leg on the OPTION pseudo-account is the EXERCISE signature the
+		// seller bank keys on (isExercise = Stock+Option).
+		{
+			Account: optionPseudo,
+			Amount:  qty.Neg(),
+			Asset:   &protocol.StockAsset{Ticker: contract.StockTicker},
+		},
+		// p4) Buyer stock credit (+k STOCK): our buyer receives the shares (applied on our
+		// CommitLocal via the trading-service option-exercise / stock-credit path).
+		{
+			Account: &protocol.PersonAccount{Id: buyerParty},
+			Amount:  qty,
+			Asset:   &protocol.StockAsset{Ticker: contract.StockTicker},
+		},
+	}
+
+	txID := protocol.ForeignBankId{RoutingNumber: c.myRouting, Id: generateTxID()}
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId:  txID,
+		Postings:       postings,
+		Message:        "OTC exercise for contract " + contract.ID,
+		PaymentCode:    "289",
+		PaymentPurpose: "OTC option exercise — strike + stock delivery",
+	}
+
+	// 0. Reserve the buyer's strike OFF-WIRE (not a wire posting — it would unbalance the
+	// MONAS group). Released on any abort, committed only after a successful 2PC.
+	buyerStrikeResID, err := c.reserveBuyerStrike(ctx, contract, strikeCurrency, totalStrike, txID)
+	if err != nil {
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: buyer strike reservation failed: %v", ErrInterbankProtocol, err)
+	}
+
+	// 1. PrepareLocal (records the buyer's incoming STOCK credit; the strike legs ride the
+	// seller-bank OPTION pseudo-account and are validated as balance-only on our side).
+	localVote, err := c.executor.PrepareLocal(ctx, tx)
+	if err != nil {
+		c.releaseBuyerStrike(ctx, buyerStrikeResID)
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: local prepare infra failure: %v", ErrInterbankProtocol, err)
+	}
+	if localVote.Vote != protocol.VoteYes {
+		c.releaseBuyerStrike(ctx, buyerStrikeResID)
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: local prepare rejected: %v", ErrInterbankProtocol, localVote.Reasons)
+	}
+
+	// 2. Partner prepare.
+	partnerVote, err := c.outbound.SendNewTx(ctx, partnerRouting, tx)
+	if err != nil {
+		c.safeRollbackLocal(ctx, txID)
+		c.releaseBuyerStrike(ctx, buyerStrikeResID)
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: partner prepare exception: %v", ErrInterbankProtocol, err)
+	}
+	if partnerVote.Vote != protocol.VoteYes {
+		c.safeRollbackLocal(ctx, txID)
+		c.safeRollbackPartner(ctx, partnerRouting, txID)
+		c.releaseBuyerStrike(ctx, buyerStrikeResID)
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: partner rejected: %v", ErrInterbankProtocol, partnerVote.Reasons)
+	}
+
+	// 3. CommitLocal.
+	if err := c.executor.CommitLocal(ctx, txID); err != nil {
+		c.safeRollbackPartner(ctx, partnerRouting, txID)
+		c.releaseBuyerStrike(ctx, buyerStrikeResID)
+		return protocol.ForeignBankId{}, fmt.Errorf("%w: catastrophic commitLocal failure: %v", ErrInterbankProtocol, err)
+	}
+
+	// 3b. Commit the buyer strike — the 2PC is now durable (partner prepared YES, our
+	// stock credit committed). The buyer's reserved strike is permanently debited. Mirrors
+	// the partner doing reservationApplier.commitMonas AFTER its own successful 2PC.
+	c.commitBuyerStrike(ctx, buyerStrikeResID)
+
+	// 4. Partner commit — best-effort (retry scheduler covers failures).
+	if err := c.outbound.SendCommitTx(ctx, partnerRouting, txID); err != nil {
+		c.log.WarnContext(ctx, "coordinator: exercise sendCommitTx to partner failed — retry scheduler will pick it up",
+			"partnerRouting", partnerRouting, "txID", txID, "err", err)
+	}
+
+	c.log.InfoContext(ctx, "exercised cross-bank option contract",
+		"contract", contract.ID, "ticker", contract.StockTicker, "amount", contract.Amount,
+		"partnerRouting", partnerRouting, "tx", txID)
+	return txID, nil
+}
+
+// reserveBuyerStrike places an off-wire reservation on the buyer's strike account for the
+// buyer-side exercise. Returns "" (no error) when no reserver is wired or the account
+// cannot be resolved as ours — conservation then relies on an upstream debit, and the
+// commit/release helpers no-op on an empty id. A reservation failure (insufficient funds)
+// IS surfaced so the exercise aborts before any cross-bank movement.
+func (c *Coordinator) reserveBuyerStrike(ctx context.Context, contract *store.Contract, currency string, amount decimal.Decimal, txID protocol.ForeignBankId) (string, error) {
+	if c.monasResv == nil || contract.BuyerRouting != c.myRouting {
+		return "", nil
+	}
+	ownerID, err := parseBuyerOwnerID(contract.BuyerID)
+	if err != nil {
+		// A non-numeric buyer id is unexpected for our own party; surface it so the
+		// exercise aborts rather than silently skipping the buyer debit.
+		return "", fmt.Errorf("parse buyer owner id %q: %w", contract.BuyerID, err)
+	}
+	accountNum, err := c.monasResv.FindAccountByOwnerAndCurrency(ctx, ownerID, currency)
+	if err != nil || accountNum == "" {
+		return "", fmt.Errorf("resolve buyer %d %s account: %w", ownerID, currency, err)
+	}
+	resID, err := c.monasResv.ReserveMonas(ctx, accountNum, currency, amount.Abs(), txID.RoutingNumber, txID.Id)
+	if err != nil {
+		return "", fmt.Errorf("reserve buyer strike on %s: %w", accountNum, err)
+	}
+	return resID, nil
+}
+
+// commitBuyerStrike permanently debits a previously reserved buyer strike. No-op on an
+// empty id. Best-effort: a commit failure is logged (the 2PC is already durable).
+func (c *Coordinator) commitBuyerStrike(ctx context.Context, reservationID string) {
+	if c.monasResv == nil || reservationID == "" {
+		return
+	}
+	if err := c.monasResv.CommitMonas(ctx, reservationID); err != nil {
+		c.log.ErrorContext(ctx, "coordinator: commit buyer strike failed — 2PC committed, manual reconciliation needed",
+			"reservationID", reservationID, "err", err)
+	}
+}
+
+// releaseBuyerStrike frees a buyer strike reservation on abort. No-op on an empty id.
+func (c *Coordinator) releaseBuyerStrike(ctx context.Context, reservationID string) {
+	if c.monasResv == nil || reservationID == "" {
+		return
+	}
+	if err := c.monasResv.ReleaseMonas(ctx, reservationID); err != nil {
+		c.log.WarnContext(ctx, "coordinator: release buyer strike failed", "reservationID", reservationID, "err", err)
+	}
+}
+
+// parseBuyerOwnerID strips a C-/E- prefix and parses the numeric owner id.
+func parseBuyerOwnerID(buyerID string) (int64, error) {
+	numericPart := buyerID
+	if len(buyerID) > 2 && (buyerID[:2] == "C-" || buyerID[:2] == "E-") {
+		numericPart = buyerID[2:]
+	}
+	return parseBigInt(numericPart)
+}
+
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
@@ -258,6 +628,25 @@ func (c *Coordinator) resolveMonasAccount(ctx context.Context, userRouting int, 
 		return &protocol.PersonAccount{Id: protocol.ForeignBankId{RoutingNumber: userRouting, Id: userID}}
 	}
 	return &protocol.RealAccount{Num: accountNum}
+}
+
+// recordOutboundPayment writes a transaction-history row for an outbound cross-bank
+// payment (money leaving one of our accounts). Best-effort: failures are logged and
+// swallowed so they never affect the already-committed transfer. No-op when no resolver
+// is wired (e.g. tests that pass a nil bcResolver).
+func (c *Coordinator) recordOutboundPayment(ctx context.Context, txID protocol.ForeignBankId, fromAccount, toAccount string, amount decimal.Decimal, currency, message string) {
+	if c.bcResolver == nil {
+		return
+	}
+	purpose := message
+	if purpose == "" {
+		purpose = "Interbank outbound payment"
+	}
+	orderNumber := interbankOrderNumber(txID, "OUT", "")
+	if err := c.bcResolver.RecordInterbankPayment(ctx, orderNumber, fromAccount, toAccount, amount, currency, "", purpose); err != nil {
+		c.log.WarnContext(ctx, "coordinator: record outbound interbank payment failed — transfer already committed, continuing",
+			"txID", txID, "from", fromAccount, "to", toAccount, "err", err)
+	}
 }
 
 func (c *Coordinator) safeRollbackLocal(ctx context.Context, txID protocol.ForeignBankId) {

--- a/interbank-service/internal/service/coordinator_test.go
+++ b/interbank-service/internal/service/coordinator_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -123,6 +124,9 @@ type fakeTDReserver struct{}
 func (fakeTDReserver) ReserveStock(_ context.Context, _ int64, _ string, _ int, _ int, _ string) (string, error) {
 	return "res-stock-01", nil
 }
+func (fakeTDReserver) CreditStock(_ context.Context, _ int64, _ string, _ int, _ int, _ string, _ decimal.Decimal) error {
+	return nil
+}
 func (fakeTDReserver) CommitStock(_ context.Context, _ string) error  { return nil }
 func (fakeTDReserver) ReleaseStock(_ context.Context, _ string) error { return nil }
 func (fakeTDReserver) ReserveOption(_ context.Context, _ protocol.ForeignBankId, _, _ string, _ int) error {
@@ -147,7 +151,13 @@ func (f fakeBCReserverFull) ReserveMonas(ctx context.Context, accountNum, curren
 }
 
 func (f fakeBCReserverFull) CommitMonas(ctx context.Context, reservationID string) error { return nil }
+func (f fakeBCReserverFull) CreditMonas(ctx context.Context, accountNum string, amount decimal.Decimal, clientID int64) error {
+	return nil
+}
 func (f fakeBCReserverFull) ReleaseMonas(ctx context.Context, reservationID string) error { return nil }
+func (f fakeBCReserverFull) RecordInterbankPayment(ctx context.Context, orderNumber, fromAccount, toAccount string, amount decimal.Decimal, currency, recipientName, paymentPurpose string) error {
+	return nil
+}
 
 // ---------------------------------------------------------------------------
 // build helpers
@@ -183,7 +193,28 @@ func buildCoordinator(outbound OutboundClient, negStore NegotiationStoreIface, c
 	// Wire NegotiationSellerLookup so the Validator can resolve option negotiations.
 	negLookup := NewNegotiationSellerLookup(negStore)
 	exec := NewExecutor(myRouting, es, fakeBCReserverFull{}, fakeTDReserver{}, negLookup, nil)
-	return NewCoordinator(myRouting, exec, outbound, negStore, contractSt, fakeBCReserverFull{}, nil)
+	return NewCoordinator(myRouting, exec, outbound, negStore, contractSt, fakeBCReserverFull{}, nil, nil, nil)
+}
+
+// buildCoordinatorWithBC builds a Coordinator backed by the supplied
+// *fakeBankingCoreReserver so reservation/commit tracking can be asserted. The same
+// reserver doubles as the off-wire buyer-strike LocalMonasReserver.
+func buildCoordinatorWithBC(outbound OutboundClient, negStore NegotiationStoreIface, contractSt ContractStoreIface, bc *fakeBankingCoreReserver) *Coordinator {
+	es := newCoordExecStore()
+	negLookup := NewNegotiationSellerLookup(negStore)
+	exec := NewExecutor(myRouting, es, bc, fakeTDReserver{}, negLookup, nil)
+	return NewCoordinator(myRouting, exec, outbound, negStore, contractSt, bc, nil, bc, nil)
+}
+
+// buildCoordinatorForExercise builds a Coordinator wired for a buyer-side reverse
+// exercise: the supplied BC reserver tracks the off-wire buyer-strike reservation, and
+// sellerNeg maps the local negotiation id to the seller-bank authoritative id (so the
+// emitted OPTION pseudo-account carries the seller-bank negId).
+func buildCoordinatorForExercise(outbound OutboundClient, negStore NegotiationStoreIface, contractSt ContractStoreIface, bc *fakeBankingCoreReserver, sellerNeg SellerNegResolver, td TradingReserver) *Coordinator {
+	es := newCoordExecStore()
+	negLookup := NewNegotiationSellerLookup(negStore)
+	exec := NewExecutor(myRouting, es, bc, td, negLookup, nil)
+	return NewCoordinator(myRouting, exec, outbound, negStore, contractSt, bc, sellerNeg, bc, nil)
 }
 
 // ---------------------------------------------------------------------------
@@ -280,5 +311,253 @@ func TestCoordinator_CommitTxSendFailure_NonFatal(t *testing.T) {
 	}
 	if len(cs.inserted) == 0 {
 		t.Error("contract must be inserted even if SendCommitTx fails")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// capturingOutboundClient — records the last NEW_TX so payment tests can
+// assert the postings sent to the partner.
+// ---------------------------------------------------------------------------
+
+type capturingOutboundClient struct {
+	vote           protocol.TransactionVote
+	sendErr        error
+	lastTx         protocol.InterbankTransactionPayload
+	sentRouting    int
+	committed      bool
+	rolledBack     bool
+}
+
+func (f *capturingOutboundClient) SendNewTx(_ context.Context, routing int, tx protocol.InterbankTransactionPayload) (protocol.TransactionVote, error) {
+	f.sentRouting = routing
+	f.lastTx = tx
+	return f.vote, f.sendErr
+}
+
+func (f *capturingOutboundClient) SendCommitTx(_ context.Context, _ int, _ protocol.ForeignBankId) error {
+	f.committed = true
+	return nil
+}
+
+func (f *capturingOutboundClient) SendRollbackTx(_ context.Context, _ int, _ protocol.ForeignBankId) error {
+	f.rolledBack = true
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// SendOutboundPayment tests
+// ---------------------------------------------------------------------------
+
+func TestCoordinator_SendOutboundPayment_HappyPath(t *testing.T) {
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	// Sender account is ours (routing 111, prefix matches); recipient is at the
+	// partner (routing 222, prefix 222) so PrepareLocal only reserves the debit.
+	// FIX 5: plain cross-bank payments are RSD-only, so both the account and the
+	// payment currency are RSD here.
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000001": {OwnerID: 7, Currency: "RSD", AvailableBalance: decimal.NewFromInt(1000)},
+	})
+	outbound := &capturingOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildCoordinatorWithBC(outbound, ns, cs, bc)
+
+	txID, err := coord.SendOutboundPayment(
+		context.Background(),
+		"111000000000000001",
+		"222000000000000099",
+		decimal.NewFromInt(250),
+		"RSD",
+		"rent",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if txID.RoutingNumber != myRouting || txID.Id == "" {
+		t.Errorf("expected our-routing tx id, got %+v", txID)
+	}
+	// Sender debit must be reserved then committed (recipient credit is partner-side).
+	if len(bc.reserved) != 1 {
+		t.Errorf("expected exactly 1 reservation (sender debit), got %d", len(bc.reserved))
+	}
+	if len(bc.committed) != 1 {
+		t.Errorf("expected exactly 1 commit (sender debit), got %d", len(bc.committed))
+	}
+	// Partner must have been prepared and committed.
+	if !outbound.committed {
+		t.Error("expected SendCommitTx to be called")
+	}
+	if outbound.sentRouting != theirRouting {
+		t.Errorf("expected partner routing %d, got %d", theirRouting, outbound.sentRouting)
+	}
+	// The NEW_TX must carry exactly 2 balanced MONAS postings.
+	if got := len(outbound.lastTx.Postings); got != 2 {
+		t.Fatalf("expected 2 postings sent to partner, got %d", got)
+	}
+	sum := decimal.Zero
+	for _, p := range outbound.lastTx.Postings {
+		sum = sum.Add(p.Amount)
+		if _, ok := p.Asset.(*protocol.MonasAsset); !ok {
+			t.Errorf("expected MONAS asset, got %T", p.Asset)
+		}
+	}
+	if !sum.IsZero() {
+		t.Errorf("expected balanced postings (sum 0), got %s", sum)
+	}
+}
+
+func TestCoordinator_SendOutboundPayment_IntraBankRejected(t *testing.T) {
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000001": {OwnerID: 7, Currency: "RSD", AvailableBalance: decimal.NewFromInt(1000)},
+	})
+	outbound := &capturingOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildCoordinatorWithBC(outbound, ns, cs, bc)
+
+	// Recipient routing 111 == ours → must be rejected as an intra-bank transfer.
+	// (RSD currency so the FIX 5 RSD-only gate passes and the routing rule is reached.)
+	_, err := coord.SendOutboundPayment(
+		context.Background(),
+		"111000000000000001",
+		"111000000000000002",
+		decimal.NewFromInt(50),
+		"RSD",
+		"oops",
+	)
+	if err == nil {
+		t.Fatal("expected error for intra-bank recipient routing")
+	}
+	if !errors.Is(err, ErrPaymentInvalid) {
+		t.Errorf("expected ErrPaymentInvalid, got %v", err)
+	}
+	// Nothing should have been reserved or sent.
+	if len(bc.reserved) != 0 {
+		t.Errorf("expected no reservations, got %d", len(bc.reserved))
+	}
+}
+
+func TestCoordinator_SendOutboundPayment_PartnerRejects(t *testing.T) {
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000001": {OwnerID: 7, Currency: "RSD", AvailableBalance: decimal.NewFromInt(1000)},
+	})
+	outbound := &capturingOutboundClient{
+		vote: protocol.TransactionVote{
+			Vote:    protocol.VoteNo,
+			Reasons: []protocol.NoVoteReason{{Reason: protocol.ReasonNoSuchAccount}},
+		},
+	}
+	coord := buildCoordinatorWithBC(outbound, ns, cs, bc)
+
+	_, err := coord.SendOutboundPayment(
+		context.Background(),
+		"111000000000000001",
+		"222000000000000099",
+		decimal.NewFromInt(250),
+		"RSD",
+		"rent",
+	)
+	if err == nil {
+		t.Fatal("expected error when partner rejects")
+	}
+	if !errors.Is(err, ErrInterbankProtocol) {
+		t.Errorf("expected ErrInterbankProtocol, got %v", err)
+	}
+	// Local reservation must be released; partner rollback must be sent.
+	if len(bc.released) != 1 {
+		t.Errorf("expected sender reservation to be released, got %d releases", len(bc.released))
+	}
+	if len(bc.committed) != 0 {
+		t.Errorf("expected no commit on partner reject, got %d", len(bc.committed))
+	}
+	if !outbound.rolledBack {
+		t.Error("expected SendRollbackTx to be called on partner reject")
+	}
+}
+
+// FIX 5: plain cross-bank payments in a non-RSD currency are blocked BEFORE any 2PC —
+// no reservation, no partner NEW_TX. (OTC settlement, which uses a different entry
+// point, is unaffected.)
+func TestCoordinator_SendOutboundPayment_NonRSD_Blocked(t *testing.T) {
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000001": {OwnerID: 7, Currency: "USD", AvailableBalance: decimal.NewFromInt(1000)},
+	})
+	outbound := &capturingOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildCoordinatorWithBC(outbound, ns, cs, bc)
+
+	for _, ccy := range []string{"USD", "EUR", "eur", ""} {
+		_, err := coord.SendOutboundPayment(
+			context.Background(),
+			"111000000000000001",
+			"222000000000000099",
+			decimal.NewFromInt(250),
+			ccy,
+			"rent",
+		)
+		if err == nil {
+			t.Fatalf("expected non-RSD currency %q to be blocked", ccy)
+		}
+		if !errors.Is(err, ErrPaymentInvalid) {
+			t.Errorf("ccy=%q: expected ErrPaymentInvalid, got %v", ccy, err)
+		}
+	}
+	// Nothing should have been reserved or sent to the partner.
+	if len(bc.reserved) != 0 {
+		t.Errorf("expected no reservations for blocked non-RSD payments, got %d", len(bc.reserved))
+	}
+	if outbound.lastTx.TransactionId.Id != "" {
+		t.Errorf("expected no NEW_TX sent to partner, got %+v", outbound.lastTx.TransactionId)
+	}
+}
+
+// FIX 5: an RSD plain cross-bank payment passes the currency gate (regression guard for
+// the RSD-only rule actually allowing RSD).
+func TestCoordinator_SendOutboundPayment_RSD_Allowed(t *testing.T) {
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000001": {OwnerID: 7, Currency: "RSD", AvailableBalance: decimal.NewFromInt(1000)},
+	})
+	outbound := &capturingOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildCoordinatorWithBC(outbound, ns, cs, bc)
+
+	if _, err := coord.SendOutboundPayment(
+		context.Background(),
+		"111000000000000001",
+		"222000000000000099",
+		decimal.NewFromInt(250),
+		"RSD",
+		"rent",
+	); err != nil {
+		t.Fatalf("expected RSD payment to be allowed, got %v", err)
+	}
+}
+
+// FIX 5: the RSD-only gate is case-insensitive (a "rsd"/" RSD " input is accepted by the
+// gate even though downstream currency matching is case-sensitive — the gate must not be
+// the thing that rejects a legitimately-RSD payment).
+func TestCoordinator_SendOutboundPayment_RSD_GateCaseInsensitive(t *testing.T) {
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	bc := newFakeBC(map[string]*AccountInfo{})
+	outbound := &capturingOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildCoordinatorWithBC(outbound, ns, cs, bc)
+
+	// " rsd " passes the gate, then fails LATER (no such account) — NOT with the
+	// RSD-only ErrPaymentInvalid message. We only assert the gate itself didn't reject it.
+	_, err := coord.SendOutboundPayment(
+		context.Background(),
+		"111000000000000001",
+		"222000000000000099",
+		decimal.NewFromInt(250),
+		"  rsd  ",
+		"rent",
+	)
+	if err != nil && errors.Is(err, ErrPaymentInvalid) && strings.Contains(err.Error(), "samo u RSD") {
+		t.Fatalf("RSD gate must accept ' rsd ' case/space-insensitively, got %v", err)
 	}
 }

--- a/interbank-service/internal/service/errors.go
+++ b/interbank-service/internal/service/errors.go
@@ -35,4 +35,28 @@ var (
 	// ErrInterbankProtocol signals a protocol-level failure during 2PC
 	// (e.g. local prepare failed, partner rejected, catastrophic commit).
 	ErrInterbankProtocol = errors.New("service: inter-bank protocol failure")
+
+	// ErrPaymentInvalid is returned for malformed outbound cross-bank payment
+	// requests (e.g. the recipient routing equals our own — that is an intra-bank
+	// transfer which banking-core handles, not this inter-bank coordinator).
+	ErrPaymentInvalid = errors.New("service: outbound payment request invalid")
+
+	// ErrContractNotFound is returned when an interbank option contract cannot be
+	// located by id. Handlers map it to 404.
+	ErrContractNotFound = errors.New("service: contract not found")
+
+	// ErrContractNotExercisable is returned when an exercise is attempted on a
+	// contract that is not ACTIVE (already exercised / expired / released) or whose
+	// settlement date has passed. Handlers map it to 409.
+	ErrContractNotExercisable = errors.New("service: contract not exercisable")
+
+	// ErrContractForbidden is returned when the caller is neither the buyer nor an
+	// admin/supervisor and therefore may not exercise the contract. Maps to 403.
+	ErrContractForbidden = errors.New("service: contract operation forbidden")
+
+	// ErrContractAlreadyExercising is returned when an exercise loses the entry-level
+	// ACTIVE→EXERCISING claim because a concurrent exercise of the same contract already
+	// holds it (or the contract is past ACTIVE). It guarantees the loser performs NO strike
+	// reserve/commit, so the buyer is never double-charged. Handlers map it to 409.
+	ErrContractAlreadyExercising = errors.New("service: contract exercise already in progress")
 )

--- a/interbank-service/internal/service/executor.go
+++ b/interbank-service/internal/service/executor.go
@@ -44,8 +44,15 @@ type BankingCoreReserver interface {
 	ReserveMonas(ctx context.Context, accountNum, currency string, amount decimal.Decimal, txIDRouting int, txIDLocal string) (string, error)
 	// CommitMonas permanently debits a previously reserved amount.
 	CommitMonas(ctx context.Context, reservationID string) error
+	// CreditMonas credits an account for an incoming inter-bank transfer (money
+	// arriving at one of our accounts). clientID must be the recipient account owner.
+	CreditMonas(ctx context.Context, accountNum string, amount decimal.Decimal, clientID int64) error
 	// ReleaseMonas frees a previously reserved amount back to available balance.
 	ReleaseMonas(ctx context.Context, reservationID string) error
+	// RecordInterbankPayment records a COMPLETED payment_table row for a cross-bank
+	// money movement so it shows in this bank's transaction history. orderNumber is the
+	// idempotency key. Best-effort: callers log and continue on failure.
+	RecordInterbankPayment(ctx context.Context, orderNumber, fromAccount, toAccount string, amount decimal.Decimal, currency, recipientName, paymentPurpose string) error
 }
 
 // TradingReserver provides stock and option reservation actions toward
@@ -54,6 +61,12 @@ type TradingReserver interface {
 	// ReserveStock creates a stock reservation for a pending inter-bank transaction.
 	// Returns the reservation UUID on success.
 	ReserveStock(ctx context.Context, sellerUserID int64, ticker string, quantity int, txIDRouting int, txIDLocal string) (string, error)
+	// CreditStock credits an incoming stock delivery to a LOCAL buyer's portfolio
+	// (the buyer-side STOCK leg of a cross-bank OTC option exercise). Like an incoming
+	// MONAS credit it is applied on commit only — no reservation at prepare. strike is
+	// the contract strike used as the average-purchase-price fallback when no live
+	// market price exists for the ticker (FIX 1: asset-conservation).
+	CreditStock(ctx context.Context, buyerUserID int64, ticker string, quantity int, txIDRouting int, txIDLocal string, strike decimal.Decimal) error
 	// CommitStock permanently transfers the reserved stock.
 	CommitStock(ctx context.Context, reservationID string) error
 	// ReleaseStock frees the stock reservation.
@@ -75,6 +88,35 @@ type OptionNegotiationLookup interface {
 	FindSellerID(ctx context.Context, negID string) (string, error)
 }
 
+// ContractGate provides per-CONTRACT idempotency for cross-bank OTC option exercise
+// settlement (FIX B). The desync it closes: B1's exercise settlement (seller strike
+// CreditMonas, seller stock delivery via ExerciseOption, and — when we are the buyer —
+// the buyer STOCK CreditStock) is keyed per-txId / per-negotiation, NOT per-contract.
+// A coordinator retry with a NEW txId for the SAME contract re-runs CommitLocal and
+// re-applies the non-idempotent legs (a second strike credit creates money; a second
+// stock credit creates assets). ExerciseOption alone is per-negotiation idempotent, but
+// CreditMonas/CreditStock are not.
+//
+// ClaimExercise serializes different-txId exercises of the same contract: it atomically
+// transitions the contract from ACTIVE to EXERCISED (single conditional UPDATE — the
+// WHERE status='ACTIVE' guard is the serialization point) and reports whether THIS call
+// won the claim. The settlement runs ONLY when claimed; a contract already EXERCISED
+// (or absent / terminal) yields claimed=false so the whole exercise settlement is a no-op.
+// On a settlement failure AFTER a successful claim, ReleaseClaim flips the contract back
+// to ACTIVE so a retransmit (§2.9) can re-settle — preserving conservation under partial
+// failure. Optional: when nil, CommitLocal behaves exactly as before (per-txId only).
+type ContractGate interface {
+	// ClaimExercise atomically transitions the contract identified by negotiationID from
+	// ACTIVE to EXERCISED. claimed=true means THIS call won the transition and must run
+	// settlement; claimed=false means it is already settled (or not exercisable) and the
+	// caller must skip settlement. exists=false means there is no local contract for the
+	// negotiation (defensive — proceed without gating, e.g. a partner-hosted option).
+	ClaimExercise(ctx context.Context, negotiationID string) (exists bool, claimed bool, err error)
+	// ReleaseClaim reverts a contract previously claimed by ClaimExercise back to ACTIVE
+	// (settlement failed after the claim). Best-effort and idempotent.
+	ReleaseClaim(ctx context.Context, negotiationID string) error
+}
+
 // ---------------------------------------------------------------------------
 // Executor struct
 // ---------------------------------------------------------------------------
@@ -91,9 +133,15 @@ type Executor struct {
 	bc        BankingCoreReserver
 	td        TradingReserver
 	negLookup OptionNegotiationLookup
+	gate      ContractGate // optional — per-contract exercise idempotency (FIX B); nil = per-txId only
 	validator *Validator
 	log       *slog.Logger
 }
+
+// SetContractGate wires the per-contract exercise idempotency gate (FIX B). Kept as a
+// setter rather than a constructor parameter so the many existing NewExecutor call sites
+// (production + tests) are unaffected; production wires it in main.go.
+func (e *Executor) SetContractGate(g ContractGate) { e.gate = g }
 
 // NewExecutor constructs an Executor. negLookup is used only during
 // reservePosting for the OPTION branch (looking up the seller's foreign-id).
@@ -152,9 +200,24 @@ func (e *Executor) PrepareLocal(ctx context.Context, tx protocol.InterbankTransa
 		}
 	}
 
+	// Detect the cross-bank EXERCISE shape: an OPTION pseudo-account leg on OUR routing
+	// carrying a negative STOCK asset ("Credit option pseudo-account for k stocks", §2.7.2).
+	// In an exercise, our option pseudo-account is swept internally (stock delivered +
+	// seller credited the strike via the option lifecycle), so the wire MONAS legs are
+	// balance-only and the seller's PERSON+MONAS leg is a CREDIT to the seller, not a debit.
+	exercise := e.isExerciseTx(ours)
+
 	// 3. Validate each of our postings (no side effects; NO vote on any failure).
 	var reasons []protocol.NoVoteReason
 	for _, p := range ours {
+		// In an exercise, the seller's PERSON+MONAS leg is the strike the seller RECEIVES
+		// (the option pseudo-account is swept on our side). It is not a debit, so it must
+		// not be balance-checked against the seller's available funds — doing so wrongly
+		// rejected the legitimate exercise with INSUFFICIENT_ASSET. Existence is still
+		// implied by the credit applied on commit.
+		if exercise && e.isExerciseSellerCashLeg(p) {
+			continue
+		}
 		r, err := e.validator.ValidatePosting(ctx, p)
 		if err != nil {
 			return protocol.TransactionVote{}, fmt.Errorf("executor: validate posting: %w", err)
@@ -167,19 +230,83 @@ func (e *Executor) PrepareLocal(ctx context.Context, tx protocol.InterbankTransa
 		return protocol.TransactionVote{Vote: protocol.VoteNo, Reasons: reasons}, nil
 	}
 
-	// 4. Reserve — saga-style, LIFO compensation on failure.
+	// 4. Reserve outgoing (debit) postings + record incoming (credit) postings —
+	// saga-style, LIFO compensation on failure. Debits are reserved now and
+	// committed/released later; incoming MONAS credits are applied on commit only
+	// (incoming money needs no reservation), so we just record a credit ref here.
 	var refs []store.ReservationRef
 	for _, p := range ours {
-		if !p.Amount.IsNegative() {
-			// Only outgoing (debit) postings need reservation.
+		// EXERCISE delivery leg (cross-bank §2.7.2, B2-buyer / B1-seller): the buyer's bank
+		// places the seller's stock-delivery on the OPTION pseudo-account as a NEGATIVE
+		// StockAsset leg ("Credit option pseudo-account for k stocks"). Unlike the accept-shape
+		// side legs, this one MUST settle on our side: the seller's k reserved shares have to
+		// be delivered. We record a RefKindOption so commit drives ExerciseOption (which
+		// commits the seller's stock reservation: quantity & reserved_quantity decrement, option
+		// flips EXERCISED). Without this the seller's shares stayed reserved forever — broken
+		// asset conservation. The seller's strike CREDIT is handled by the exercise seller-cash
+		// branch below (creditSellerExerciseStrike); the OPTION-pseudo MONAS leg stays a no-op skip.
+		if ref, ok := e.optionExerciseDeliveryRef(p); ok {
+			refs = append(refs, ref)
 			continue
 		}
-		ref, err := e.reservePosting(ctx, p, tx.TransactionId)
+		// FIX 3: a MONAS/STOCK leg riding the OPTION pseudo-account (the premium/share
+		// legs a partner-coordinated accept hangs off the pseudo-account) carries no raw
+		// money/stock movement on our side — the seller's stock is delivered through the
+		// OPTION reservation lifecycle (the OPTION-unit leg), and the premium lands on the
+		// seller's real PERSON/ACCOUNT leg. Skip it here so it is not (wrongly) reserved or
+		// credited as a standalone money/stock posting. The validator has already accepted
+		// it against the live negotiation.
+		if isOptionPseudoSideLeg(p) {
+			continue
+		}
+		// EXERCISE seller-cash leg: the seller RECEIVES the strike (k·π). On B2's wire the
+		// leg is signed negative (their "credit seller" convention), but per the exercise
+		// settlement the seller's bank credits the seller from the swept option pseudo-account.
+		// Record a MONAS_CREDIT for the ABSOLUTE strike amount so the seller is paid on commit
+		// — never reserved/debited. This is what conserves money on the seller side (seller
+		// +k·π, buyer −k·π at the other bank).
+		if exercise && e.isExerciseSellerCashLeg(p) {
+			ref, ok, err := e.creditSellerExerciseStrike(ctx, p, tx.Postings)
+			if err != nil {
+				e.compensate(ctx, refs)
+				return protocol.TransactionVote{}, fmt.Errorf("executor: prepare exercise seller credit: %w", err)
+			}
+			if ok {
+				refs = append(refs, ref)
+			}
+			continue
+		}
+		if p.Amount.IsNegative() {
+			ref, err := e.reservePosting(ctx, p, tx.TransactionId)
+			if err != nil {
+				e.compensate(ctx, refs)
+				return protocol.TransactionVote{}, fmt.Errorf("executor: reserve posting: %w", err)
+			}
+			refs = append(refs, ref)
+			continue
+		}
+		// Incoming (credit) posting. Two kinds land here:
+		//   - MONAS credit → recorded as a MONAS_CREDIT ref (recipient credited on commit).
+		//   - STOCK credit to a local buyer (the buyer-side leg of a cross-bank OTC
+		//     option exercise) → recorded as a STOCK_CREDIT ref (shares delivered on
+		//     commit via trading-service). Without this the buyer's strike cash was
+		//     debited but the shares never arrived (FIX 1).
+		// Option-receipt postings are recorded as contracts elsewhere, not credited.
+		if ref, ok, err := e.creditStockPosting(p, tx.Postings); err != nil {
+			e.compensate(ctx, refs)
+			return protocol.TransactionVote{}, fmt.Errorf("executor: prepare stock credit posting: %w", err)
+		} else if ok {
+			refs = append(refs, ref)
+			continue
+		}
+		ref, ok, err := e.creditMonasPosting(ctx, p, tx.Postings)
 		if err != nil {
 			e.compensate(ctx, refs)
-			return protocol.TransactionVote{}, fmt.Errorf("executor: reserve posting: %w", err)
+			return protocol.TransactionVote{}, fmt.Errorf("executor: prepare credit posting: %w", err)
 		}
-		refs = append(refs, ref)
+		if ok {
+			refs = append(refs, ref)
+		}
 	}
 
 	// 5. Build message meta JSON.
@@ -239,8 +366,51 @@ func (e *Executor) CommitLocal(ctx context.Context, txID protocol.ForeignBankId)
 		return fmt.Errorf("%w: status=%s txID=%v", ErrAlreadyTerminal, tx.Status, txID)
 	}
 
+	// FIX B — per-CONTRACT exercise idempotency. The per-txId COMMITTED guard above makes a
+	// re-commit of the SAME txId a no-op, but a coordinator retry with a NEW txId for the
+	// SAME contract would otherwise re-run the non-idempotent exercise settlement legs
+	// (a second seller-strike CreditMonas creates money; a second buyer CreditStock creates
+	// assets). We claim the contract ONCE: when this tx is an exercise and the contract is
+	// already EXERCISED (claimed=false), the exercise settlement refs are skipped; only the
+	// claiming tx applies them. The negotiation id is read from the tx's OPTION pseudo-account
+	// leg, present in both directions (seller hosts OPTION@ours; buyer addresses OPTION@seller).
+	exerciseNegID := exerciseNegotiationIDFromPostings(tx.PostingsJSON)
+	skipExercise := false
+	claimedNegID := ""
+	if exerciseNegID != "" && e.gate != nil {
+		exists, claimed, gerr := e.gate.ClaimExercise(ctx, exerciseNegID)
+		if gerr != nil {
+			if updateErr := e.store.UpdateTxStatus(ctx, txID.RoutingNumber, txID.Id, store.TxStatusFailed); updateErr != nil {
+				e.log.ErrorContext(ctx, "commitLocal: failed to flip status to FAILED after gate error",
+					"txID", txID, "err", updateErr)
+			}
+			return fmt.Errorf("executor: claim exercise contract neg=%s: %w", exerciseNegID, gerr)
+		}
+		if exists && !claimed {
+			// Contract already EXERCISED (or terminal): a prior/concurrent tx settled it.
+			// Skip ALL exercise settlement refs — exactly-once per contract. Plain refs
+			// (none expected on an exercise tx) still run.
+			skipExercise = true
+			e.log.InfoContext(ctx, "commitLocal: exercise already settled for contract — skipping settlement (idempotent)",
+				"txID", txID, "neg", exerciseNegID)
+		} else if exists && claimed {
+			claimedNegID = exerciseNegID // we own the claim; revert on settlement failure
+		}
+	}
+
 	for _, ref := range tx.ReservationRefs {
-		if err := e.commitRef(ctx, ref); err != nil {
+		if skipExercise && isExerciseSettlementRef(ref) {
+			continue
+		}
+		if err := e.commitRef(ctx, ref, txID); err != nil {
+			// Settlement failed AFTER claiming the contract — revert the claim so a §2.9
+			// retransmit can re-settle (preserves conservation under partial failure).
+			if claimedNegID != "" {
+				if relErr := e.gate.ReleaseClaim(ctx, claimedNegID); relErr != nil {
+					e.log.ErrorContext(ctx, "commitLocal: failed to release exercise claim after settlement failure",
+						"txID", txID, "neg", claimedNegID, "err", relErr)
+				}
+			}
 			// Best-effort status flip to FAILED; log and propagate.
 			if updateErr := e.store.UpdateTxStatus(ctx, txID.RoutingNumber, txID.Id, store.TxStatusFailed); updateErr != nil {
 				e.log.ErrorContext(ctx, "commitLocal: failed to flip status to FAILED",
@@ -251,6 +421,48 @@ func (e *Executor) CommitLocal(ctx context.Context, txID protocol.ForeignBankId)
 	}
 
 	return e.store.UpdateTxStatus(ctx, txID.RoutingNumber, txID.Id, store.TxStatusCommitted)
+}
+
+// isExerciseSettlementRef reports whether a reservation ref is part of the cross-bank OTC
+// option EXERCISE settlement that must be gated per-contract (FIX B): the seller stock
+// delivery (RefKindOptionExercise), the buyer stock credit (RefKindStockCredit), and the
+// seller strike credit (RefKindMonasCredit). On an exercise-shaped tx every credit/exercise
+// ref belongs to that exercise; plain MONAS/STOCK/OPTION reservation refs do not appear on
+// an exercise tx, so this gate never suppresses an unrelated leg.
+func isExerciseSettlementRef(ref store.ReservationRef) bool {
+	switch ref.Kind {
+	case store.RefKindOptionExercise, store.RefKindStockCredit, store.RefKindMonasCredit:
+		return true
+	default:
+		return false
+	}
+}
+
+// exerciseNegotiationIDFromPostings extracts the option negotiation id from a committed
+// transaction's stored postings when the tx is an exercise (a STOCK asset riding an OPTION
+// pseudo-account — the §2.7.2 "Credit option pseudo-account for k stocks" signature). The
+// pseudo-account id IS the negotiation id (keyed at the bank that issued the option). Works
+// in both exercise directions: seller-host (OPTION@ours) and buyer (OPTION@seller). Returns
+// "" when the tx is not an exercise or the postings cannot be parsed (gate then no-ops).
+func exerciseNegotiationIDFromPostings(postingsJSON string) string {
+	if postingsJSON == "" {
+		return ""
+	}
+	var postings []protocol.Posting
+	if err := json.Unmarshal([]byte(postingsJSON), &postings); err != nil {
+		return ""
+	}
+	for i := range postings {
+		pseudo, isPseudo := postings[i].Account.(*protocol.OptionPseudoAccount)
+		if !isPseudo {
+			continue
+		}
+		if _, isStock := postings[i].Asset.(*protocol.StockAsset); !isStock {
+			continue
+		}
+		return pseudo.Id.Id
+	}
+	return ""
 }
 
 // ---------------------------------------------------------------------------
@@ -301,6 +513,124 @@ func (e *Executor) isOurs(p protocol.Posting) bool {
 		return acc.Id.RoutingNumber == e.myRouting
 	}
 	return false
+}
+
+// isOptionPseudoSideLeg reports whether a posting is a MONAS/STOCK leg sitting on an
+// OPTION pseudo-account — the premium/share legs a partner-coordinated accept hangs off
+// the option pseudo-account (FIX 3). Such legs are settled via the OPTION reservation
+// lifecycle (the OPTION-unit leg) and the seller's real-account postings, not as
+// standalone money/stock movements, so PrepareLocal skips them. The OPTION-unit leg
+// itself (OptionAsset on the pseudo-account) is NOT a side leg — it is the reservation.
+func isOptionPseudoSideLeg(p protocol.Posting) bool {
+	if _, ok := p.Account.(*protocol.OptionPseudoAccount); !ok {
+		return false
+	}
+	switch p.Asset.(type) {
+	case *protocol.MonasAsset, *protocol.StockAsset:
+		return true
+	default:
+		return false
+	}
+}
+
+// optionExerciseDeliveryRef recognises the cross-bank EXERCISE delivery leg and, when it
+// targets one of OUR option pseudo-accounts, returns a RefKindOptionExercise reservation ref
+// that drives ExerciseOption on commit (delivering the seller's k reserved shares).
+//
+// Shape (B2-buyer / B1-seller, §2.7.2 "Credit option pseudo-account for k stocks"):
+//
+//	{Account: OPTION{ours, negId}, Amount: -k, Asset: STOCK{ticker}}
+//
+// This is distinct from the accept-shape pseudo side legs (which are MONAS premium legs or
+// the OPTION-unit reservation), and from the strike-into-option MONAS leg of the same
+// exercise tx (which is settled via the seller's real PERSON/MONAS credit leg). Only the
+// negative STOCK leg on our pseudo-account represents the seller's stock delivery, so only
+// it produces an exercise ref. Returns ok=false for anything else.
+func (e *Executor) optionExerciseDeliveryRef(p protocol.Posting) (store.ReservationRef, bool) {
+	pseudo, ok := p.Account.(*protocol.OptionPseudoAccount)
+	if !ok || pseudo.Id.RoutingNumber != e.myRouting {
+		return store.ReservationRef{}, false
+	}
+	if _, ok := p.Asset.(*protocol.StockAsset); !ok {
+		return store.ReservationRef{}, false
+	}
+	// The seller DELIVERS shares: the option pseudo-account is CREDITED (negative amount).
+	// A positive STOCK leg on the pseudo-account is not a delivery and is left to the
+	// skip path (defensive — the protocol does not emit one).
+	if !p.Amount.IsNegative() {
+		return store.ReservationRef{}, false
+	}
+	negRouting := pseudo.Id.RoutingNumber
+	negID := pseudo.Id.Id
+	return store.ReservationRef{
+		Kind:               store.RefKindOptionExercise,
+		NegotiationRouting: &negRouting,
+		NegotiationID:      &negID,
+	}, true
+}
+
+// isExerciseTx reports whether any of OUR postings is the exercise delivery leg (an OPTION
+// pseudo-account on our routing carrying a negative STOCK asset). When true, the tx is a
+// cross-bank OTC option exercise where WE are the seller bank: our option pseudo-account is
+// swept internally (stock delivered + seller credited), and the wire MONAS legs are
+// balance-only. `ours` is the already-filtered slice of postings on our side.
+func (e *Executor) isExerciseTx(ours []protocol.Posting) bool {
+	for _, p := range ours {
+		if _, ok := e.optionExerciseDeliveryRef(p); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// isExerciseSellerCashLeg reports whether a posting is the seller's strike-cash leg of an
+// exercise tx: a MONAS asset on a PERSON account belonging to OUR routing. (The buyer cash
+// leg lives at the buyer's bank and never reaches us; the option pseudo MONAS leg is an
+// OptionPseudoAccount, not a PersonAccount, so it is excluded here and skipped separately.)
+func (e *Executor) isExerciseSellerCashLeg(p protocol.Posting) bool {
+	if _, ok := p.Asset.(*protocol.MonasAsset); !ok {
+		return false
+	}
+	person, ok := p.Account.(*protocol.PersonAccount)
+	if !ok {
+		return false
+	}
+	return person.Id.RoutingNumber == e.myRouting
+}
+
+// creditSellerExerciseStrike builds a MONAS_CREDIT ref that pays the seller the strike on
+// commit. The seller's PERSON id resolves to their account in the leg's currency; the
+// amount credited is the ABSOLUTE wire amount (the seller always receives, regardless of
+// the wire sign convention the buyer's bank used). Returns ok=false only if the seller
+// person cannot be parsed (defensive — the validator/recorder already vetted it).
+func (e *Executor) creditSellerExerciseStrike(ctx context.Context, p protocol.Posting, allPostings []protocol.Posting) (store.ReservationRef, bool, error) {
+	asset, ok := p.Asset.(*protocol.MonasAsset)
+	if !ok {
+		return store.ReservationRef{}, false, nil
+	}
+	person, ok := p.Account.(*protocol.PersonAccount)
+	if !ok {
+		return store.ReservationRef{}, false, nil
+	}
+	if e.bc == nil {
+		return store.ReservationRef{}, false, errors.New("executor: BankingCoreReserver is nil for exercise seller credit")
+	}
+	ownerID, err := parseOwnerID(person.Id.Id)
+	if err != nil {
+		return store.ReservationRef{}, false, fmt.Errorf("executor: parse exercise seller id %q: %w", person.Id.Id, err)
+	}
+	num, err := e.bc.FindAccountByOwnerAndCurrency(ctx, ownerID, asset.Currency)
+	if err != nil || num == "" {
+		return store.ReservationRef{}, false, fmt.Errorf("executor: resolve exercise seller %d %s account: %w", ownerID, asset.Currency, err)
+	}
+	return store.ReservationRef{
+		Kind:              store.RefKindMonasCredit,
+		CreditAccountNum:  num,
+		CreditAmount:      p.Amount.Abs().String(), // seller RECEIVES the strike — absolute amount
+		CreditClientID:    ownerID,
+		CreditCurrency:    asset.Currency,
+		CreditFromAccount: foreignSenderAccount(p, allPostings),
+	}, true, nil
 }
 
 // reservePosting dispatches to the appropriate downstream reservation call
@@ -359,6 +689,139 @@ func (e *Executor) reserveMonasPosting(ctx context.Context, p protocol.Posting, 
 		return store.ReservationRef{}, fmt.Errorf("executor: ReserveMonas account=%s: %w", accountNum, err)
 	}
 	return store.ReservationRef{Kind: store.RefKindMonas, ReservationID: resID}, nil
+}
+
+// creditMonasPosting records an INCOMING MONAS credit to one of our accounts so it
+// can be applied on commit. It performs NO balance mutation at prepare (incoming money
+// needs no reservation). Returns ok=false for non-MONAS postings (e.g. option receipt),
+// which are recorded as contracts elsewhere, not credited.
+func (e *Executor) creditMonasPosting(ctx context.Context, p protocol.Posting, allPostings []protocol.Posting) (store.ReservationRef, bool, error) {
+	asset, ok := p.Asset.(*protocol.MonasAsset)
+	if !ok {
+		return store.ReservationRef{}, false, nil
+	}
+	if e.bc == nil {
+		return store.ReservationRef{}, false, errors.New("executor: BankingCoreReserver is nil")
+	}
+
+	var accountNum string
+	var clientID int64
+	switch acc := p.Account.(type) {
+	case *protocol.RealAccount:
+		info, err := e.bc.ResolveAccount(ctx, acc.Num)
+		if err != nil || info == nil {
+			return store.ReservationRef{}, false, fmt.Errorf("executor: resolve credit account %s: %w", acc.Num, err)
+		}
+		accountNum = acc.Num
+		clientID = info.OwnerID
+
+	case *protocol.PersonAccount:
+		ownerID, err := parseOwnerID(acc.Id.Id)
+		if err != nil {
+			return store.ReservationRef{}, false, fmt.Errorf("executor: parse credit owner id %q: %w", acc.Id.Id, err)
+		}
+		num, err := e.bc.FindAccountByOwnerAndCurrency(ctx, ownerID, asset.Currency)
+		if err != nil || num == "" {
+			return store.ReservationRef{}, false, fmt.Errorf("executor: resolve person %d %s account: %w", ownerID, asset.Currency, err)
+		}
+		accountNum = num
+		clientID = ownerID
+
+	default:
+		return store.ReservationRef{}, false, fmt.Errorf("executor: MONAS credit with unexpected account type %T", p.Account)
+	}
+
+	return store.ReservationRef{
+		Kind:              store.RefKindMonasCredit,
+		CreditAccountNum:  accountNum,
+		CreditAmount:      p.Amount.String(),
+		CreditClientID:    clientID,
+		CreditCurrency:    asset.Currency,
+		CreditFromAccount: foreignSenderAccount(p, allPostings),
+	}, true, nil
+}
+
+// creditStockPosting records an INCOMING STOCK delivery to one of our LOCAL buyers
+// (the buyer-side STOCK leg of a cross-bank OTC option exercise). It performs NO
+// mutation at prepare (like an incoming MONAS credit); the shares are credited to the
+// buyer's portfolio on commit via trading-service. Returns ok=false for any posting
+// that is not a positive STOCK leg on one of our PersonAccounts, so the caller falls
+// through to the MONAS-credit path.
+//
+// The per-unit strike (used by trading-service only as the average-purchase-price
+// fallback when no live market price exists) is derived from the matching negative
+// MONAS posting (the buyer's strike debit: |totalStrike| ÷ quantity).
+func (e *Executor) creditStockPosting(p protocol.Posting, allPostings []protocol.Posting) (store.ReservationRef, bool, error) {
+	if !p.Amount.IsPositive() {
+		return store.ReservationRef{}, false, nil
+	}
+	asset, ok := p.Asset.(*protocol.StockAsset)
+	if !ok {
+		return store.ReservationRef{}, false, nil
+	}
+	person, ok := p.Account.(*protocol.PersonAccount)
+	if !ok || person.Id.RoutingNumber != e.myRouting {
+		// Not a local buyer — partner handles their own side.
+		return store.ReservationRef{}, false, nil
+	}
+	buyerID, err := parseOwnerID(person.Id.Id)
+	if err != nil {
+		return store.ReservationRef{}, false, fmt.Errorf("executor: parse stock-credit buyer id %q: %w", person.Id.Id, err)
+	}
+	quantity := int(p.Amount.IntPart())
+	strike := perUnitStrike(allPostings, quantity)
+	return store.ReservationRef{
+		Kind:                store.RefKindStockCredit,
+		StockCreditBuyerID:  buyerID,
+		StockCreditTicker:   asset.Ticker,
+		StockCreditQuantity: quantity,
+		StockCreditStrike:   strike.String(),
+	}, true, nil
+}
+
+// perUnitStrike derives the per-unit strike price for a stock-credit leg from the
+// transaction's negative MONAS posting (the buyer's strike debit): |amount| ÷ quantity.
+// Returns zero when there is no negative MONAS leg or quantity is non-positive — in
+// that case trading-service falls back to the live market price.
+func perUnitStrike(allPostings []protocol.Posting, quantity int) decimal.Decimal {
+	if quantity <= 0 {
+		return decimal.Zero
+	}
+	for _, p := range allPostings {
+		if !p.Amount.IsNegative() {
+			continue
+		}
+		if _, ok := p.Asset.(*protocol.MonasAsset); !ok {
+			continue
+		}
+		return p.Amount.Abs().Div(decimal.NewFromInt(int64(quantity)))
+	}
+	return decimal.Zero
+}
+
+// foreignSenderAccount returns the 18-digit account number of the matching negative
+// MONAS posting (same currency) — i.e. the foreign sender that funds this incoming
+// credit. Returns "" when the sender side is not a RealAccount (e.g. a Person-only
+// counterparty), in which case the recorded payment leaves from_account blank-resolved
+// by banking-core to a sentinel. Used only for transaction-history audit metadata.
+func foreignSenderAccount(credit protocol.Posting, allPostings []protocol.Posting) string {
+	creditAsset, ok := credit.Asset.(*protocol.MonasAsset)
+	if !ok {
+		return ""
+	}
+	for _, p := range allPostings {
+		if !p.Amount.IsNegative() {
+			continue
+		}
+		asset, ok := p.Asset.(*protocol.MonasAsset)
+		if !ok || asset.Currency != creditAsset.Currency {
+			continue
+		}
+		if real, ok := p.Account.(*protocol.RealAccount); ok {
+			return real.Num
+		}
+	}
+	return ""
 }
 
 // reserveStockPosting handles STOCK reservation (only PersonAccount sellers are valid here).
@@ -432,8 +895,10 @@ func (e *Executor) reserveOptionPosting(ctx context.Context, p protocol.Posting,
 	}, nil
 }
 
-// commitRef finalizes a single reservation ref.
-func (e *Executor) commitRef(ctx context.Context, ref store.ReservationRef) error {
+// commitRef finalizes a single reservation ref. txID identifies the inter-bank
+// transaction and is used to derive the idempotent order_number for the
+// transaction-history audit record on incoming credits.
+func (e *Executor) commitRef(ctx context.Context, ref store.ReservationRef, txID protocol.ForeignBankId) error {
 	switch ref.Kind {
 	case store.RefKindMonas:
 		if e.bc == nil {
@@ -441,19 +906,53 @@ func (e *Executor) commitRef(ctx context.Context, ref store.ReservationRef) erro
 		}
 		return e.bc.CommitMonas(ctx, ref.ReservationID)
 
+	case store.RefKindMonasCredit:
+		if e.bc == nil {
+			return errors.New("executor: BankingCoreReserver is nil for MONAS credit")
+		}
+		amt, err := decimal.NewFromString(ref.CreditAmount)
+		if err != nil {
+			return fmt.Errorf("executor: parse credit amount %q: %w", ref.CreditAmount, err)
+		}
+		if err := e.bc.CreditMonas(ctx, ref.CreditAccountNum, amt, ref.CreditClientID); err != nil {
+			return err
+		}
+		// Best-effort: record the incoming money so it shows in transaction history.
+		// A recording failure must NOT fail the (already applied) credit — log & continue.
+		e.recordInboundPayment(ctx, ref, amt, txID)
+		return nil
+
 	case store.RefKindStock:
 		if e.td == nil {
 			return errors.New("executor: TradingReserver is nil for STOCK commit")
 		}
 		return e.td.CommitStock(ctx, ref.ReservationID)
 
-	case store.RefKindOption:
+	case store.RefKindStockCredit:
+		if e.td == nil {
+			return errors.New("executor: TradingReserver is nil for STOCK credit")
+		}
+		strike, err := decimal.NewFromString(ref.StockCreditStrike)
+		if err != nil {
+			// A blank/invalid strike just means "no fallback price" — credit at zero and
+			// let trading-service prefer the live market price.
+			strike = decimal.Zero
+		}
+		return e.td.CreditStock(ctx, ref.StockCreditBuyerID, ref.StockCreditTicker,
+			ref.StockCreditQuantity, txID.RoutingNumber, txID.Id, strike)
+
+	case store.RefKindOption, store.RefKindOptionExercise:
 		if e.td == nil {
 			return errors.New("executor: TradingReserver is nil for OPTION exercise")
 		}
 		if ref.NegotiationRouting == nil || ref.NegotiationID == nil {
 			return errors.New("executor: OPTION reservation ref missing negotiation fields")
 		}
+		// Both kinds finalize via ExerciseOption (idempotent): RefKindOption is the
+		// accept-reserved option being exercised; RefKindOptionExercise is the seller-side
+		// delivery leg of a cross-bank exercise tx. ExerciseOption commits the seller's
+		// held stock reservation (quantity & reserved_quantity decrement) and flips the
+		// option EXERCISED — the seller's shares are delivered and conservation holds.
 		return e.td.ExerciseOption(ctx, protocol.ForeignBankId{
 			RoutingNumber: *ref.NegotiationRouting,
 			Id:            *ref.NegotiationID,
@@ -465,11 +964,43 @@ func (e *Executor) commitRef(ctx context.Context, ref store.ReservationRef) erro
 	}
 }
 
+// recordInboundPayment writes a transaction-history row for an incoming cross-bank
+// credit (money arriving at one of our accounts). Best-effort: a failure is logged and
+// swallowed so it never affects the already-applied credit. The order_number is derived
+// deterministically from the inter-bank tx id, so a 2PC retry is idempotent (banking-core
+// does ON CONFLICT DO NOTHING). fromAccount may be "" when the foreign sender is a
+// Person-only counterparty; banking-core then resolves it to a sentinel.
+func (e *Executor) recordInboundPayment(ctx context.Context, ref store.ReservationRef, amt decimal.Decimal, txID protocol.ForeignBankId) {
+	orderNumber := interbankOrderNumber(txID, "IN", ref.CreditAccountNum)
+	if err := e.bc.RecordInterbankPayment(ctx, orderNumber, ref.CreditFromAccount, ref.CreditAccountNum, amt, ref.CreditCurrency, "", "Interbank inbound payment"); err != nil {
+		e.log.WarnContext(ctx, "executor: record inbound interbank payment failed — credit already applied, continuing",
+			"txID", txID, "account", ref.CreditAccountNum, "err", err)
+	}
+}
+
+// interbankOrderNumber builds a deterministic, idempotent order_number for an
+// inter-bank money leg. Multiple credit legs in one tx (rare) are disambiguated by the
+// recipient account suffix.
+func interbankOrderNumber(txID protocol.ForeignBankId, direction, accountSuffix string) string {
+	base := fmt.Sprintf("BANKA1-IB-%s-%d-%s", direction, txID.RoutingNumber, txID.Id)
+	if accountSuffix != "" {
+		base += "-" + accountSuffix
+	}
+	return base
+}
+
 // releaseRef frees a single reservation ref. Best-effort — logs failures but
 // does not return them (caller continues with remaining refs).
 func (e *Executor) releaseRef(ctx context.Context, ref store.ReservationRef) {
 	var err error
 	switch ref.Kind {
+	case store.RefKindMonasCredit, store.RefKindStockCredit, store.RefKindOptionExercise:
+		// Incoming credit (MONAS/STOCK) is applied only on commit — nothing was reserved at
+		// prepare, so there is nothing to release. OPTION_EXERCISE likewise reserves nothing
+		// new: the seller's shares were reserved at accept-time. An exercise abort MUST leave
+		// that reservation intact so the buyer can retry — releasing it here would strand the
+		// option without its backing shares (broken asset conservation). Deliberate no-op.
+		return
 	case store.RefKindMonas:
 		if e.bc != nil {
 			err = e.bc.ReleaseMonas(ctx, ref.ReservationID)

--- a/interbank-service/internal/service/executor_test.go
+++ b/interbank-service/internal/service/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 
@@ -19,9 +20,9 @@ import (
 
 // fakeExecStore is an in-memory ExecutorStore.
 type fakeExecStore struct {
-	txns    map[string]*store.Transaction // key: "routing:id"
-	failOn  string                        // if non-empty, PersistPrepared returns error
-	nextID  int64
+	txns   map[string]*store.Transaction // key: "routing:id"
+	failOn string                        // if non-empty, PersistPrepared returns error
+	nextID int64
 }
 
 func (f *fakeExecStore) key(routing int, id string) string {
@@ -82,11 +83,16 @@ type fakeBankingCoreReserver struct {
 	reserved  []string // reservation IDs created
 	committed []string
 	released  []string
+	credited  []creditCall          // CreditMonas calls (incoming credits applied on commit)
+	recorded  []recordedPaymentCall // RecordInterbankPayment calls (transaction-history audit)
 
 	failReserve bool
 	reserveErr  error
 	// failAfter: if > 0, the Nth call to ReserveMonas (1-indexed) will fail.
 	failAfter int
+	// failCredit: when true, CreditMonas fails (used to exercise FIX B settlement-failure
+	// → claim-release recovery).
+	failCredit bool
 }
 
 func newFakeBC(accounts map[string]*AccountInfo) *fakeBankingCoreReserver {
@@ -146,6 +152,41 @@ func (f *fakeBankingCoreReserver) ReleaseMonas(_ context.Context, reservationID 
 	return nil
 }
 
+// creditCall records one CreditMonas invocation for assertions.
+type creditCall struct {
+	account  string
+	amount   string
+	clientID int64
+}
+
+func (f *fakeBankingCoreReserver) CreditMonas(_ context.Context, accountNum string, amount decimal.Decimal, clientID int64) error {
+	if f.failCredit {
+		return errors.New("fakeBankingCoreReserver: CreditMonas forced failure")
+	}
+	f.credited = append(f.credited, creditCall{account: accountNum, amount: amount.String(), clientID: clientID})
+	return nil
+}
+
+// recordedPaymentCall records one RecordInterbankPayment invocation for assertions.
+type recordedPaymentCall struct {
+	orderNumber string
+	fromAccount string
+	toAccount   string
+	amount      string
+	currency    string
+}
+
+func (f *fakeBankingCoreReserver) RecordInterbankPayment(_ context.Context, orderNumber, fromAccount, toAccount string, amount decimal.Decimal, currency, _, _ string) error {
+	f.recorded = append(f.recorded, recordedPaymentCall{
+		orderNumber: orderNumber,
+		fromAccount: fromAccount,
+		toAccount:   toAccount,
+		amount:      amount.String(),
+		currency:    currency,
+	})
+	return nil
+}
+
 // fakeTradingReserver implements TradingReserver.
 type fakeTradingReserver struct {
 	reserved  []string
@@ -154,6 +195,19 @@ type fakeTradingReserver struct {
 
 	failReserveStock bool
 	optionSellers    map[string]string // negotiation id → sellerForeignID (for lookup validation)
+
+	// FIX 1 stock-credit capture.
+	stockCredits  []stockCreditCall
+	failCreditStk bool
+}
+
+type stockCreditCall struct {
+	buyerUserID int64
+	ticker      string
+	quantity    int
+	txRouting   int
+	txLocal     string
+	strike      decimal.Decimal
 }
 
 func (f *fakeTradingReserver) ReserveStock(_ context.Context, sellerUserID int64, ticker string, quantity int, txIDRouting int, txIDLocal string) (string, error) {
@@ -163,6 +217,17 @@ func (f *fakeTradingReserver) ReserveStock(_ context.Context, sellerUserID int64
 	id := "stock-res-" + ticker
 	f.reserved = append(f.reserved, id)
 	return id, nil
+}
+
+func (f *fakeTradingReserver) CreditStock(_ context.Context, buyerUserID int64, ticker string, quantity int, txIDRouting int, txIDLocal string, strike decimal.Decimal) error {
+	if f.failCreditStk {
+		return errors.New("fakeTradingReserver: CreditStock forced failure")
+	}
+	f.stockCredits = append(f.stockCredits, stockCreditCall{
+		buyerUserID: buyerUserID, ticker: ticker, quantity: quantity,
+		txRouting: txIDRouting, txLocal: txIDLocal, strike: strike,
+	})
+	return nil
 }
 
 func (f *fakeTradingReserver) CommitStock(_ context.Context, reservationID string) error {
@@ -202,6 +267,12 @@ type fakeNegForExec struct {
 	IsOngoing  bool
 	Amount     int
 	Settlement string // RFC3339
+
+	// Backing option-contract lifecycle (for the EXERCISE-time validator path):
+	// a closed negotiation (IsOngoing=false) is still exercisable while its contract
+	// is ACTIVE and ContractSettlement is in the future.
+	ContractStatus     string
+	ContractSettlement time.Time
 }
 
 func (f *fakeNegotiationLookup) FindNegotiation(ctx context.Context, id protocol.ForeignBankId) (*NegotiationLite, error) {
@@ -209,7 +280,12 @@ func (f *fakeNegotiationLookup) FindNegotiation(ctx context.Context, id protocol
 	if !ok {
 		return nil, errors.New("not found")
 	}
-	return &NegotiationLite{IsOngoing: n.IsOngoing, Amount: n.Amount}, nil
+	return &NegotiationLite{
+		IsOngoing:          n.IsOngoing,
+		Amount:             n.Amount,
+		ContractStatus:     n.ContractStatus,
+		ContractSettlement: n.ContractSettlement,
+	}, nil
 }
 
 func (f *fakeNegotiationLookup) FindSellerID(ctx context.Context, negID string) (string, error) {
@@ -274,6 +350,146 @@ func TestPrepareLocal_HappyPath_YesVote(t *testing.T) {
 	// But the tx should be persisted.
 	if len(s.txns) != 1 {
 		t.Errorf("expected 1 persisted tx, got %d", len(s.txns))
+	}
+}
+
+// BUG #1 fix: an incoming MONAS credit to one of our accounts must be recorded as a
+// MONAS_CREDIT ref at prepare (no reservation) and applied to the recipient on commit.
+// Before the fix, positive postings were skipped entirely and the recipient was never
+// credited (cross-bank money silently vanished).
+func TestPrepareLocal_IncomingMonasCredit_AppliedOnCommit(t *testing.T) {
+	bc := newFakeBC(map[string]*AccountInfo{
+		// 19-digit Banka 1 client account — must be recognised as ours (regression
+		// for the accountIsOurs len==18 bug that hid 19-digit client accounts).
+		"1110001100000000111": {OwnerID: 7, Currency: "USD", AvailableBalance: decimal.NewFromInt(1000)},
+	})
+	s := &fakeExecStore{}
+	e := newTestExecutor(111, s, bc, nil)
+
+	txID := protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-credit"}
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: txID,
+		Postings:      balancedMonasPosting("222000000000000099", "1110001100000000111", 5000, "USD"),
+	}
+
+	vote, err := e.PrepareLocal(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteYes {
+		t.Fatalf("expected YES, got %q reasons=%v", vote.Vote, vote.Reasons)
+	}
+
+	// A MONAS_CREDIT ref is recorded; incoming money is NOT reserved nor credited yet.
+	row, _ := s.FindTx(context.Background(), 222, "tx-credit")
+	if row == nil {
+		t.Fatal("expected persisted tx")
+	}
+	if len(row.ReservationRefs) != 1 || row.ReservationRefs[0].Kind != store.RefKindMonasCredit {
+		t.Fatalf("expected one MONAS_CREDIT ref, got %+v", row.ReservationRefs)
+	}
+	if len(bc.reserved) != 0 {
+		t.Fatalf("incoming credit must not reserve, got %v", bc.reserved)
+	}
+	if len(bc.credited) != 0 {
+		t.Fatalf("credit must be applied on commit, not prepare; got %v", bc.credited)
+	}
+
+	// Commit applies the credit to the recipient with the resolved owner as clientID.
+	if err := e.CommitLocal(context.Background(), txID); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	if len(bc.credited) != 1 {
+		t.Fatalf("expected exactly one credit on commit, got %v", bc.credited)
+	}
+	if got := bc.credited[0]; got.account != "1110001100000000111" || got.amount != "5000" || got.clientID != 7 {
+		t.Fatalf("unexpected credit %+v", got)
+	}
+}
+
+// FIX 1 (asset-conservation): the buyer-side STOCK leg of a cross-bank OTC option
+// exercise (a positive PERSON+STOCK posting on our routing) must be recorded as a
+// STOCK_CREDIT ref at prepare and delivered to the buyer's portfolio on commit via
+// trading-service. Before the fix this leg was silently dropped (creditMonasPosting
+// returned ok=false for non-MONAS) — the strike cash was debited but the shares never
+// arrived. The strike is derived from the matching negative MONAS leg (|total| ÷ qty).
+func TestPrepareLocal_IncomingStockCredit_DeliveredOnCommit(t *testing.T) {
+	// Our buyer's USD account funds the strike debit (leg a).
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000050": {OwnerID: 9, Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)},
+	})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(9, "USD"): "111000000000000050"}
+	s := &fakeExecStore{}
+	td := &fakeTradingReserver{}
+	e := newTestExecutor(111, s, bc, td)
+
+	txID := protocol.ForeignBankId{RoutingNumber: 111, Id: "tx-exercise"}
+	buyer := protocol.ForeignBankId{RoutingNumber: 111, Id: "C-9"}
+	seller := protocol.ForeignBankId{RoutingNumber: 222, Id: "C-3"}
+	// 4 shares, strike 250/unit → total strike 1000.
+	tx := protocol.InterbankTransactionPayload{
+		TransactionId: txID,
+		Postings: []protocol.Posting{
+			// a) buyer strike debit (our side, reserved).
+			{Account: &protocol.PersonAccount{Id: buyer}, Amount: decimal.NewFromInt(-1000), Asset: &protocol.MonasAsset{Currency: "USD"}},
+			// b) seller strike credit (partner side).
+			{Account: &protocol.PersonAccount{Id: seller}, Amount: decimal.NewFromInt(1000), Asset: &protocol.MonasAsset{Currency: "USD"}},
+			// c) seller stock debit (partner side).
+			{Account: &protocol.PersonAccount{Id: seller}, Amount: decimal.NewFromInt(-4), Asset: &protocol.StockAsset{Ticker: "AAPL"}},
+			// d) buyer stock credit (our side — must be delivered).
+			{Account: &protocol.PersonAccount{Id: buyer}, Amount: decimal.NewFromInt(4), Asset: &protocol.StockAsset{Ticker: "AAPL"}},
+		},
+	}
+
+	vote, err := e.PrepareLocal(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteYes {
+		t.Fatalf("expected YES, got %q reasons=%v", vote.Vote, vote.Reasons)
+	}
+
+	// Prepare must record a STOCK_CREDIT ref (plus the MONAS reservation for leg a) and
+	// NOT credit any stock yet (delivery happens on commit).
+	row, _ := s.FindTx(context.Background(), 111, "tx-exercise")
+	if row == nil {
+		t.Fatal("expected persisted tx")
+	}
+	var stockCreditRefs int
+	for _, r := range row.ReservationRefs {
+		if r.Kind == store.RefKindStockCredit {
+			stockCreditRefs++
+			if r.StockCreditBuyerID != 9 || r.StockCreditTicker != "AAPL" || r.StockCreditQuantity != 4 {
+				t.Errorf("unexpected stock-credit ref: %+v", r)
+			}
+			if r.StockCreditStrike != "250" {
+				t.Errorf("expected per-unit strike 250, got %q", r.StockCreditStrike)
+			}
+		}
+	}
+	if stockCreditRefs != 1 {
+		t.Fatalf("expected exactly one STOCK_CREDIT ref, got %d in %+v", stockCreditRefs, row.ReservationRefs)
+	}
+	if len(td.stockCredits) != 0 {
+		t.Fatalf("stock must be delivered on commit, not prepare; got %v", td.stockCredits)
+	}
+
+	// Commit delivers the shares to the buyer with the derived strike fallback.
+	if err := e.CommitLocal(context.Background(), txID); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+	if len(td.stockCredits) != 1 {
+		t.Fatalf("expected exactly one CreditStock on commit, got %v", td.stockCredits)
+	}
+	got := td.stockCredits[0]
+	if got.buyerUserID != 9 || got.ticker != "AAPL" || got.quantity != 4 {
+		t.Fatalf("unexpected CreditStock call: %+v", got)
+	}
+	if !got.strike.Equal(decimal.NewFromInt(250)) {
+		t.Fatalf("expected strike 250, got %s", got.strike)
+	}
+	if got.txRouting != 111 || got.txLocal != "tx-exercise" {
+		t.Fatalf("unexpected tx ids in CreditStock: %+v", got)
 	}
 }
 
@@ -687,5 +903,182 @@ func TestRollbackLocal_NotFound_NoOp(t *testing.T) {
 	err := e.RollbackLocal(context.Background(), protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-missing-rb"})
 	if err != nil {
 		t.Errorf("expected nil for missing tx during rollback, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cross-bank EXERCISE — B1 is SELLER, B2 is BUYER (the reported bug)
+// ---------------------------------------------------------------------------
+
+// sellerExerciseTx builds the exact §2.7.2 exercise transaction that B2 (buyer-bank, 222)
+// sends to B1 (seller-bank, 111) for an accepted cross-bank option. 1 share AAPL, strike
+// 200, USD. Sign convention matches B2's InterbankOtcWrapperService.exerciseContract:
+//
+//	p1  OPTION{111,neg}  +200 MONAS  — option pseudo-account receives strike
+//	p2  PERSON{111,C-5}  -200 MONAS  — seller (ours) receives strike cash
+//	p3  OPTION{111,neg}  -1   STOCK  — option pseudo-account delivers the share
+//	p4  PERSON{222,C-8}  +1   STOCK  — buyer (partner) receives the share
+func sellerExerciseTx(txID protocol.ForeignBankId, negID string) protocol.InterbankTransactionPayload {
+	neg := protocol.ForeignBankId{RoutingNumber: 111, Id: negID}
+	seller := protocol.ForeignBankId{RoutingNumber: 111, Id: "C-5"}
+	buyer := protocol.ForeignBankId{RoutingNumber: 222, Id: "C-8"}
+	usd := func() protocol.Asset { return &protocol.MonasAsset{Currency: "USD"} }
+	aapl := func() protocol.Asset { return &protocol.StockAsset{Ticker: "AAPL"} }
+	return protocol.InterbankTransactionPayload{
+		TransactionId: txID,
+		Postings: []protocol.Posting{
+			{Account: &protocol.OptionPseudoAccount{Id: neg}, Amount: decimal.NewFromInt(200), Asset: usd()},
+			{Account: &protocol.PersonAccount{Id: seller}, Amount: decimal.NewFromInt(-200), Asset: usd()},
+			{Account: &protocol.OptionPseudoAccount{Id: neg}, Amount: decimal.NewFromInt(-1), Asset: aapl()},
+			{Account: &protocol.PersonAccount{Id: buyer}, Amount: decimal.NewFromInt(1), Asset: aapl()},
+		},
+		Message: "OTC exercise option",
+	}
+}
+
+// newSellerExerciseExecutor wires an executor for B1-as-seller with a CLOSED negotiation
+// (accept set is_ongoing=false) whose contract is still ACTIVE and settlement is in the
+// future — the exact live state at exercise time.
+func newSellerExerciseExecutor(t *testing.T, negID string) (*Executor, *fakeExecStore, *fakeBankingCoreReserver, *fakeTradingReserver) {
+	t.Helper()
+	// Seller's USD account, resolvable by owner (C-5 → ownerID 5).
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000005": {OwnerID: 5, Currency: "USD", AvailableBalance: decimal.NewFromInt(10)},
+	})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(5, "USD"): "111000000000000005"}
+	s := &fakeExecStore{}
+	td := &fakeTradingReserver{}
+	negs := &fakeNegotiationLookup{negs: map[string]*fakeNegForExec{
+		negID: {
+			SellerID:           "C-5",
+			IsOngoing:          false, // accepted → closed
+			Amount:             1,
+			ContractStatus:     ContractStatusActive,
+			ContractSettlement: time.Now().Add(7 * 24 * time.Hour),
+		},
+	}}
+	return newExecutorWithNegs(111, s, bc, td, negs), s, bc, td
+}
+
+// The headline reproduction: B1 (seller) must VOTE YES for the exercise of an accepted,
+// still-ACTIVE option whose negotiation is closed. Pre-fix this voted NO with
+// OPTION_USED_OR_EXPIRED, aborting the 2PC so no accepted cross-bank option could be used.
+func TestPrepareLocal_SellerExercise_ClosedNegotiation_ActiveContract_YesVote(t *testing.T) {
+	negID := "neg-9f1830ac93f58786"
+	e, s, _, _ := newSellerExerciseExecutor(t, negID)
+	txID := protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-ex-seller"}
+
+	vote, err := e.PrepareLocal(context.Background(), sellerExerciseTx(txID, negID))
+	if err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if vote.Vote != protocol.VoteYes {
+		t.Fatalf("expected YES for exercisable closed-negotiation, got %q reasons=%v", vote.Vote, vote.Reasons)
+	}
+	// One OPTION_EXERCISE ref (seller stock delivery) + one MONAS_CREDIT ref (seller cash).
+	row, _ := s.FindTx(context.Background(), 222, "tx-ex-seller")
+	if row == nil {
+		t.Fatal("expected persisted tx")
+	}
+	var exerciseRefs, creditRefs int
+	for _, r := range row.ReservationRefs {
+		switch r.Kind {
+		case store.RefKindOptionExercise:
+			exerciseRefs++
+			if r.NegotiationID == nil || *r.NegotiationID != negID {
+				t.Errorf("OPTION_EXERCISE ref negID mismatch: %+v", r)
+			}
+		case store.RefKindMonasCredit:
+			creditRefs++
+		}
+	}
+	if exerciseRefs != 1 {
+		t.Fatalf("expected exactly one OPTION_EXERCISE ref, got %d in %+v", exerciseRefs, row.ReservationRefs)
+	}
+	if creditRefs != 1 {
+		t.Fatalf("expected exactly one MONAS_CREDIT ref (seller cash), got %d in %+v", creditRefs, row.ReservationRefs)
+	}
+}
+
+// Conservation on commit: seller's reserved share is DELIVERED (ExerciseOption) AND the
+// seller is CREDITED the strike exactly once. No double-settle, no value created/destroyed.
+func TestCommitLocal_SellerExercise_DeliversStock_CreditsStrike(t *testing.T) {
+	negID := "neg-9f1830ac93f58786"
+	e, _, bc, td := newSellerExerciseExecutor(t, negID)
+	txID := protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-ex-commit"}
+
+	if _, err := e.PrepareLocal(context.Background(), sellerExerciseTx(txID, negID)); err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	// Nothing delivered/credited at prepare.
+	if len(td.committed) != 0 {
+		t.Fatalf("no stock delivery at prepare, got %v", td.committed)
+	}
+	if len(bc.credited) != 0 {
+		t.Fatalf("no strike credit at prepare, got %v", bc.credited)
+	}
+
+	if err := e.CommitLocal(context.Background(), txID); err != nil {
+		t.Fatalf("CommitLocal: %v", err)
+	}
+
+	// (1) Seller's reserved share delivered via ExerciseOption (exactly once).
+	wantExercise := "option-exercise-" + negID
+	gotExercise := 0
+	for _, c := range td.committed {
+		if c == wantExercise {
+			gotExercise++
+		}
+	}
+	if gotExercise != 1 {
+		t.Fatalf("expected exactly one ExerciseOption(%s) on commit, got %v", negID, td.committed)
+	}
+	// (2) Seller credited the strike exactly once, to their USD account.
+	if len(bc.credited) != 1 {
+		t.Fatalf("expected exactly one strike credit to seller, got %v", bc.credited)
+	}
+	if got := bc.credited[0]; got.account != "111000000000000005" || got.amount != "200" || got.clientID != 5 {
+		t.Fatalf("unexpected seller strike credit: %+v", got)
+	}
+	// (3) No raw stock reservation/commit was made (delivery is via the option lifecycle).
+	if len(td.reserved) != 0 {
+		t.Fatalf("exercise must not raw-reserve stock on the seller side, got %v", td.reserved)
+	}
+
+	// Idempotent re-commit (duplicate COMMIT_TX §2.9) — no double delivery / double credit.
+	if err := e.CommitLocal(context.Background(), txID); err != nil {
+		t.Fatalf("idempotent re-CommitLocal: %v", err)
+	}
+	if len(bc.credited) != 1 {
+		t.Fatalf("re-commit must not double-credit, got %v", bc.credited)
+	}
+}
+
+// On a 2PC ROLLBACK of the exercise, the seller's accept-time stock reservation must be
+// LEFT INTACT (a later retry needs it) — ReleaseOption must NOT be called. The seller cash
+// credit is likewise un-applied (nothing was credited at prepare).
+func TestRollbackLocal_SellerExercise_PreservesReservation(t *testing.T) {
+	negID := "neg-9f1830ac93f58786"
+	e, s, bc, td := newSellerExerciseExecutor(t, negID)
+	txID := protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-ex-rollback"}
+
+	if _, err := e.PrepareLocal(context.Background(), sellerExerciseTx(txID, negID)); err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	if err := e.RollbackLocal(context.Background(), txID); err != nil {
+		t.Fatalf("RollbackLocal: %v", err)
+	}
+	if len(td.released) != 0 {
+		t.Fatalf("exercise rollback must NOT release the seller's reservation, got %v", td.released)
+	}
+	if len(td.committed) != 0 {
+		t.Fatalf("rollback must not deliver stock, got %v", td.committed)
+	}
+	if len(bc.credited) != 0 {
+		t.Fatalf("rollback must not credit the seller, got %v", bc.credited)
+	}
+	row, _ := s.FindTx(context.Background(), 222, "tx-ex-rollback")
+	if row == nil || row.Status != store.TxStatusRolledBack {
+		t.Fatalf("expected ROLLED_BACK status, got %+v", row)
 	}
 }

--- a/interbank-service/internal/service/exercise_idempotency_test.go
+++ b/interbank-service/internal/service/exercise_idempotency_test.go
@@ -1,0 +1,215 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+func dec(n int64) decimal.Decimal { return decimal.NewFromInt(n) }
+
+func mustMarshalPostings(t *testing.T, ps []protocol.Posting) string {
+	t.Helper()
+	b, err := json.Marshal(ps)
+	if err != nil {
+		t.Fatalf("marshal postings: %v", err)
+	}
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// FIX B — per-CONTRACT exercise idempotency gate.
+//
+// The desync: B1's exercise settlement (seller strike CreditMonas, seller stock
+// delivery via ExerciseOption, buyer CreditStock) is keyed per-txId / per-neg, NOT
+// per-contract. A coordinator retry with a NEW txId for the SAME contract re-runs
+// CommitLocal and re-applies the non-idempotent legs → double strike credit (money
+// created) / double stock credit (assets created). ExerciseOption alone is per-neg
+// idempotent. The ContractGate serializes different-txId exercises of one contract:
+// only the claiming tx settles; an already-EXERCISED contract makes the whole
+// exercise settlement a no-op.
+// ---------------------------------------------------------------------------
+
+// fakeContractGate simulates the atomic ACTIVE→EXERCISED CAS on interbank_contracts.
+// The FIRST ClaimExercise for a negId wins (claimed=true) and marks it EXERCISED;
+// subsequent claims for the same negId return claimed=false until ReleaseClaim reverts it.
+type fakeContractGate struct {
+	mu         sync.Mutex
+	exercised  map[string]bool // negId → already EXERCISED
+	claimCalls int
+	relCalls   int
+	failClaim  bool
+}
+
+func newFakeContractGate(knownNegs ...string) *fakeContractGate {
+	g := &fakeContractGate{exercised: make(map[string]bool)}
+	for _, n := range knownNegs {
+		// register as known-but-ACTIVE (exists, not yet exercised)
+		if _, ok := g.exercised[n]; !ok {
+			g.exercised[n] = false
+		}
+	}
+	return g
+}
+
+func (g *fakeContractGate) ClaimExercise(_ context.Context, negID string) (bool, bool, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.claimCalls++
+	if g.failClaim {
+		return false, false, context.DeadlineExceeded
+	}
+	already, exists := g.exercised[negID]
+	if !exists {
+		// No contract for this neg — proceed ungated (defensive).
+		return false, false, nil
+	}
+	if already {
+		return true, false, nil // exists but already EXERCISED → loser, skip settlement
+	}
+	g.exercised[negID] = true // claim it
+	return true, true, nil
+}
+
+func (g *fakeContractGate) ReleaseClaim(_ context.Context, negID string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.relCalls++
+	if _, exists := g.exercised[negID]; exists {
+		g.exercised[negID] = false // revert to ACTIVE
+	}
+	return nil
+}
+
+// TestCommitLocal_SellerExercise_NewTxId_SecondSettle_NoOp is the headline FIX B
+// reproduction: two SEPARATE inter-bank transactions (different txIds) exercise the
+// SAME seller contract. Without the per-contract gate the second commit re-credits the
+// seller strike (money created). With the gate, the second exercise is a complete no-op:
+// 0 additional CreditMonas, 0 additional ExerciseOption.
+func TestCommitLocal_SellerExercise_NewTxId_SecondSettle_NoOp(t *testing.T) {
+	negID := "neg-9f1830ac93f58786"
+	e, _, bc, td := newSellerExerciseExecutor(t, negID)
+	gate := newFakeContractGate(negID)
+	e.SetContractGate(gate)
+
+	// --- First exercise (txId #1): claims the contract, settles once. ---
+	tx1 := protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-ex-1"}
+	if _, err := e.PrepareLocal(context.Background(), sellerExerciseTx(tx1, negID)); err != nil {
+		t.Fatalf("PrepareLocal #1: %v", err)
+	}
+	if err := e.CommitLocal(context.Background(), tx1); err != nil {
+		t.Fatalf("CommitLocal #1: %v", err)
+	}
+
+	creditsAfter1 := len(bc.credited)
+	exercisesAfter1 := countExerciseCommits(td.committed, negID)
+	if creditsAfter1 != 1 {
+		t.Fatalf("first exercise must credit the seller exactly once, got %d: %+v", creditsAfter1, bc.credited)
+	}
+	if exercisesAfter1 != 1 {
+		t.Fatalf("first exercise must deliver stock exactly once, got %d", exercisesAfter1)
+	}
+
+	// --- Second exercise (txId #2, SAME contract): a coordinator retry with a fresh txId. ---
+	tx2 := protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-ex-2"}
+	if _, err := e.PrepareLocal(context.Background(), sellerExerciseTx(tx2, negID)); err != nil {
+		t.Fatalf("PrepareLocal #2: %v", err)
+	}
+	if err := e.CommitLocal(context.Background(), tx2); err != nil {
+		t.Fatalf("CommitLocal #2 (idempotent expected): %v", err)
+	}
+
+	// CONSERVATION: no second strike credit, no second stock delivery.
+	if got := len(bc.credited); got != creditsAfter1 {
+		t.Fatalf("second exercise of same contract DOUBLE-CREDITED the seller: %d → %d credits: %+v",
+			creditsAfter1, got, bc.credited)
+	}
+	if got := countExerciseCommits(td.committed, negID); got != exercisesAfter1 {
+		t.Fatalf("second exercise DOUBLE-DELIVERED stock: %d → %d ExerciseOption calls",
+			exercisesAfter1, got)
+	}
+	if gate.claimCalls != 2 {
+		t.Errorf("expected 2 claim attempts (one per txId), got %d", gate.claimCalls)
+	}
+	if gate.relCalls != 0 {
+		t.Errorf("happy-path retries must not release the claim, got %d release calls", gate.relCalls)
+	}
+}
+
+// TestCommitLocal_SellerExercise_SettlementFailureReleasesClaim verifies that when the
+// settlement fails AFTER the contract is claimed, the gate claim is REVERTED (so a §2.9
+// retransmit can re-settle) — conservation under partial failure.
+func TestCommitLocal_SellerExercise_SettlementFailureReleasesClaim(t *testing.T) {
+	negID := "neg-9f1830ac93f58786"
+	e, _, bc, td := newSellerExerciseExecutor(t, negID)
+	gate := newFakeContractGate(negID)
+	e.SetContractGate(gate)
+
+	tx1 := protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-ex-fail"}
+	if _, err := e.PrepareLocal(context.Background(), sellerExerciseTx(tx1, negID)); err != nil {
+		t.Fatalf("PrepareLocal: %v", err)
+	}
+	// Force the seller strike credit (a settlement ref) to fail on commit.
+	bc.failCredit = true
+
+	if err := e.CommitLocal(context.Background(), tx1); err == nil {
+		t.Fatalf("expected CommitLocal to fail when settlement credit fails")
+	}
+	if gate.relCalls != 1 {
+		t.Fatalf("settlement failure after claim must release the claim exactly once, got %d", gate.relCalls)
+	}
+
+	// Recovery: clear the fault, retry with a NEW txId → claim succeeds again and settles.
+	bc.failCredit = false
+	td.committed = nil
+	bc.credited = nil
+	tx2 := protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-ex-retry"}
+	if _, err := e.PrepareLocal(context.Background(), sellerExerciseTx(tx2, negID)); err != nil {
+		t.Fatalf("PrepareLocal retry: %v", err)
+	}
+	if err := e.CommitLocal(context.Background(), tx2); err != nil {
+		t.Fatalf("CommitLocal retry after release: %v", err)
+	}
+	if len(bc.credited) != 1 {
+		t.Fatalf("post-release retry must settle exactly once, got %d credits: %+v", len(bc.credited), bc.credited)
+	}
+	if countExerciseCommits(td.committed, negID) != 1 {
+		t.Fatalf("post-release retry must deliver stock exactly once, got %v", td.committed)
+	}
+}
+
+func countExerciseCommits(committed []string, negID string) int {
+	want := "option-exercise-" + negID
+	n := 0
+	for _, c := range committed {
+		if c == want {
+			n++
+		}
+	}
+	return n
+}
+
+// sanity: the exercise neg id is correctly extracted from the seller exercise postings.
+func TestExerciseNegotiationIDFromPostings_SellerShape(t *testing.T) {
+	negID := "neg-abc"
+	tx := sellerExerciseTx(protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-x"}, negID)
+	body := mustMarshalPostings(t, tx.Postings)
+	if got := exerciseNegotiationIDFromPostings(body); got != negID {
+		t.Fatalf("exerciseNegotiationIDFromPostings = %q, want %q", got, negID)
+	}
+	// Non-exercise (plain MONAS transfer) → "".
+	plain := []protocol.Posting{
+		{Account: &protocol.RealAccount{Num: "111000000000000001"}, Amount: dec(-10), Asset: &protocol.MonasAsset{Currency: "USD"}},
+		{Account: &protocol.RealAccount{Num: "222000000000000002"}, Amount: dec(10), Asset: &protocol.MonasAsset{Currency: "USD"}},
+	}
+	if got := exerciseNegotiationIDFromPostings(mustMarshalPostings(t, plain)); got != "" {
+		t.Fatalf("plain transfer must yield empty neg id, got %q", got)
+	}
+	_ = store.RefKindOptionExercise // keep store import used if helpers change
+}

--- a/interbank-service/internal/service/exercise_reverse_test.go
+++ b/interbank-service/internal/service/exercise_reverse_test.go
@@ -1,0 +1,245 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// FIX A — reverse-direction (B1-buyer / B2-seller) exercise canonical shape.
+//
+// These tests pin the CANONICAL §2.7.2 exercise wire shape the buyer-side
+// coordinator must emit so the seller bank recognises the exercise from the
+// SHAPE (Stock+Option signature) and settles its seller internally. They also
+// verify money/asset conservation: the buyer strike is reserved+committed
+// OFF-WIRE (not a posting) and the MONAS/STOCK groups each net to zero.
+// ---------------------------------------------------------------------------
+
+// fakeSellerNegResolver maps a local negotiation id to a seller-bank id.
+type fakeSellerNegResolver struct {
+	bySellerNeg map[string]string
+}
+
+func (f *fakeSellerNegResolver) SellerNegotiationID(_ context.Context, localNegotiationID string) string {
+	return f.bySellerNeg[localNegotiationID]
+}
+
+// buildBuyerExerciseContract returns a B1-buyer / B2-seller contract ready to
+// exercise (mirrors the live DB row otc-…/neg-… with remote seller neg).
+func buildBuyerExerciseContract() *store.Contract {
+	return &store.Contract{
+		ID:             "otc-rev-001",
+		NegotiationID:  "neg-local-rev-001", // our LOCAL mirror id
+		BuyerRouting:   myRouting,           // 111 — we are the buyer
+		BuyerID:        "C-100",
+		SellerRouting:  theirRouting, // 222 — partner is the seller
+		SellerID:       "C-8",
+		StockTicker:    "MSFT",
+		Amount:         3,
+		StrikeCurrency: "USD",
+		StrikeAmount:   decimal.NewFromInt(123),
+		SettlementDate: time.Now().Add(48 * time.Hour),
+		Status:         store.ContractStatusActive,
+	}
+}
+
+// TestExerciseContract_ReverseDirection_CanonicalShape asserts the buyer-side
+// coordinator emits the canonical exercise legs with the seller-bank routing and
+// authoritative negId on the OPTION pseudo-account, the correct signs, and the
+// buyer strike kept OFF the wire (reserved + committed locally instead).
+func TestExerciseContract_ReverseDirection_CanonicalShape(t *testing.T) {
+	const sellerBankNegID = "66b10b51-420e-41a3-9d8e-f2a0ee565933"
+
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	contract := buildBuyerExerciseContract()
+
+	// The buyer's USD account is ours, with plenty of funds.
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000900": {OwnerID: 100, Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)},
+	})
+	bc.byOwnerCurrency = map[string]string{
+		formatOwnerKey(100, "USD"): "111000000000000900",
+	}
+	td := &fakeTradingReserver{}
+	sellerNeg := &fakeSellerNegResolver{bySellerNeg: map[string]string{
+		contract.NegotiationID: sellerBankNegID,
+	}}
+
+	outbound := &capturingOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildCoordinatorForExercise(outbound, ns, cs, bc, sellerNeg, td)
+
+	txID, err := coord.ExerciseContract(context.Background(), contract)
+	if err != nil {
+		t.Fatalf("ExerciseContract returned error: %v", err)
+	}
+	if txID.Id == "" {
+		t.Fatalf("expected a non-empty tx id")
+	}
+
+	// ---- Wire shape ----
+	ps := outbound.lastTx.Postings
+	if len(ps) != 4 {
+		t.Fatalf("expected 4 wire postings, got %d: %+v", len(ps), ps)
+	}
+	if outbound.sentRouting != theirRouting {
+		t.Errorf("expected NEW_TX sent to seller routing %d, got %d", theirRouting, outbound.sentRouting)
+	}
+
+	totalStrike := decimal.NewFromInt(123 * 3)
+	qty := decimal.NewFromInt(3)
+
+	var sawOptionMonas, sawSellerCash, sawOptionStock, sawBuyerStock bool
+	monasSum := decimal.Zero
+	stockSum := decimal.Zero
+	for _, p := range ps {
+		switch a := p.Asset.(type) {
+		case *protocol.MonasAsset:
+			monasSum = monasSum.Add(p.Amount)
+			switch acc := p.Account.(type) {
+			case *protocol.OptionPseudoAccount:
+				// p1: OPTION pseudo (seller routing + seller-bank negId), +strike.
+				sawOptionMonas = true
+				if acc.Id.RoutingNumber != theirRouting {
+					t.Errorf("p1 OPTION routing = %d, want %d", acc.Id.RoutingNumber, theirRouting)
+				}
+				if acc.Id.Id != sellerBankNegID {
+					t.Errorf("p1 OPTION negId = %q, want seller-bank id %q", acc.Id.Id, sellerBankNegID)
+				}
+				if !p.Amount.Equal(totalStrike) {
+					t.Errorf("p1 OPTION MONAS amount = %s, want +%s", p.Amount, totalStrike)
+				}
+			case *protocol.PersonAccount:
+				// p2: seller PERSON@222, −strike (seller is CREDITED — negative sign).
+				sawSellerCash = true
+				if acc.Id.RoutingNumber != theirRouting {
+					t.Errorf("p2 seller PERSON routing = %d, want %d", acc.Id.RoutingNumber, theirRouting)
+				}
+				if !p.Amount.Equal(totalStrike.Neg()) {
+					t.Errorf("p2 seller cash amount = %s, want −%s (credit-seller sign)", p.Amount, totalStrike)
+				}
+			default:
+				t.Errorf("unexpected MONAS account type %T", acc)
+			}
+		case *protocol.StockAsset:
+			stockSum = stockSum.Add(p.Amount)
+			switch acc := p.Account.(type) {
+			case *protocol.OptionPseudoAccount:
+				// p3: OPTION pseudo (seller routing), −k STOCK — the exercise signature.
+				sawOptionStock = true
+				if acc.Id.RoutingNumber != theirRouting {
+					t.Errorf("p3 OPTION-stock routing = %d, want %d", acc.Id.RoutingNumber, theirRouting)
+				}
+				if acc.Id.Id != sellerBankNegID {
+					t.Errorf("p3 OPTION-stock negId = %q, want %q", acc.Id.Id, sellerBankNegID)
+				}
+				if !p.Amount.Equal(qty.Neg()) {
+					t.Errorf("p3 OPTION stock amount = %s, want −%s", p.Amount, qty)
+				}
+				if a.Ticker != "MSFT" {
+					t.Errorf("p3 ticker = %q, want MSFT", a.Ticker)
+				}
+			case *protocol.PersonAccount:
+				// p4: buyer PERSON@111, +k STOCK.
+				sawBuyerStock = true
+				if acc.Id.RoutingNumber != myRouting {
+					t.Errorf("p4 buyer PERSON routing = %d, want %d", acc.Id.RoutingNumber, myRouting)
+				}
+				if !p.Amount.Equal(qty) {
+					t.Errorf("p4 buyer stock amount = %s, want +%s", p.Amount, qty)
+				}
+			default:
+				t.Errorf("unexpected STOCK account type %T", acc)
+			}
+		default:
+			t.Errorf("unexpected wire asset type %T", a)
+		}
+	}
+
+	if !sawOptionMonas || !sawSellerCash || !sawOptionStock || !sawBuyerStock {
+		t.Fatalf("missing canonical legs: optMonas=%v sellerCash=%v optStock=%v buyerStock=%v",
+			sawOptionMonas, sawSellerCash, sawOptionStock, sawBuyerStock)
+	}
+
+	// ---- Conservation: each asset group nets to zero on the wire ----
+	if !monasSum.IsZero() {
+		t.Errorf("MONAS group does not balance: sum = %s (want 0)", monasSum)
+	}
+	if !stockSum.IsZero() {
+		t.Errorf("STOCK group does not balance: sum = %s (want 0)", stockSum)
+	}
+
+	// ---- Buyer strike is OFF the wire (no buyer-side negative MONAS posting) ----
+	for _, p := range ps {
+		if _, isMonas := p.Asset.(*protocol.MonasAsset); !isMonas {
+			continue
+		}
+		if person, ok := p.Account.(*protocol.PersonAccount); ok &&
+			person.Id.RoutingNumber == myRouting {
+			t.Errorf("buyer strike must NOT be a wire posting; found PERSON@%d MONAS %s", myRouting, p.Amount)
+		}
+		if real, ok := p.Account.(*protocol.RealAccount); ok {
+			t.Errorf("buyer strike must NOT be a wire RealAccount posting; found %s %s", real.Num, p.Amount)
+		}
+	}
+
+	// ---- Buyer strike was reserved AND committed off-wire (debit applied once) ----
+	if len(bc.reserved) != 1 {
+		t.Fatalf("expected exactly 1 off-wire buyer-strike reservation, got %d: %+v", len(bc.reserved), bc.reserved)
+	}
+	if len(bc.committed) != 1 {
+		t.Fatalf("expected exactly 1 off-wire buyer-strike commit, got %d: %+v", len(bc.committed), bc.committed)
+	}
+	if len(bc.released) != 0 {
+		t.Errorf("expected no buyer-strike release on the happy path, got %d: %+v", len(bc.released), bc.released)
+	}
+	if !outbound.committed {
+		t.Errorf("expected SendCommitTx to the partner on the happy path")
+	}
+}
+
+// TestExerciseContract_ReverseDirection_PartnerRejects_ReleasesStrike asserts that
+// when the seller bank votes NO the buyer strike reservation is RELEASED (no money
+// moves) and never committed.
+func TestExerciseContract_ReverseDirection_PartnerRejects_ReleasesStrike(t *testing.T) {
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	contract := buildBuyerExerciseContract()
+
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000000000000900": {OwnerID: 100, Currency: "USD", AvailableBalance: decimal.NewFromInt(100000)},
+	})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(100, "USD"): "111000000000000900"}
+	td := &fakeTradingReserver{}
+	sellerNeg := &fakeSellerNegResolver{bySellerNeg: map[string]string{
+		contract.NegotiationID: "seller-neg-xyz",
+	}}
+
+	outbound := &capturingOutboundClient{vote: protocol.TransactionVote{
+		Vote: protocol.VoteNo, Reasons: []protocol.NoVoteReason{{Reason: protocol.ReasonInsufficientAsset}},
+	}}
+	coord := buildCoordinatorForExercise(outbound, ns, cs, bc, sellerNeg, td)
+
+	if _, err := coord.ExerciseContract(context.Background(), contract); err == nil {
+		t.Fatalf("expected error when partner rejects, got nil")
+	}
+
+	if len(bc.reserved) != 1 {
+		t.Fatalf("expected 1 reservation attempt, got %d", len(bc.reserved))
+	}
+	if len(bc.committed) != 0 {
+		t.Errorf("buyer strike must NOT be committed on partner-reject, got %d: %+v", len(bc.committed), bc.committed)
+	}
+	if len(bc.released) != 1 {
+		t.Errorf("buyer strike must be RELEASED on partner-reject, got %d: %+v", len(bc.released), bc.released)
+	}
+	if !outbound.rolledBack {
+		t.Errorf("expected a partner rollback on reject")
+	}
+}

--- a/interbank-service/internal/service/helpers_unit_test.go
+++ b/interbank-service/internal/service/helpers_unit_test.go
@@ -177,7 +177,7 @@ func TestCommitRef_AllKinds(t *testing.T) {
 		{Kind: store.RefKindOption, NegotiationRouting: &negRouting, NegotiationID: &negID},
 	}
 	for _, ref := range refs {
-		if err := e.commitRef(context.Background(), ref); err != nil {
+		if err := e.commitRef(context.Background(), ref, protocol.ForeignBankId{RoutingNumber: 222, Id: "tx-commit"}); err != nil {
 			t.Errorf("commitRef %s: %v", ref.Kind, err)
 		}
 	}

--- a/interbank-service/internal/service/otc_contracts.go
+++ b/interbank-service/internal/service/otc_contracts.go
@@ -1,0 +1,222 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// DTOs
+// ---------------------------------------------------------------------------
+
+// ContractView is the frontend-friendly interbank option-contract representation.
+// Mirrors the NegotiationView style. Premium is intentionally omitted — the
+// interbank_contracts table tracks only the strike (premium lives on the
+// negotiation row and was already settled by the accept 2PC).
+type ContractView struct {
+	LocalID                  string                 `json:"localId"`
+	NegotiationID            string                 `json:"negotiationId"`
+	BuyerID                  protocol.ForeignBankId `json:"buyerId"`
+	SellerID                 protocol.ForeignBankId `json:"sellerId"`
+	StockTicker              string                 `json:"ticker"`
+	Amount                   int                    `json:"amount"`
+	StrikeCurrency           string                 `json:"strikeCurrency"`
+	StrikeAmount             decimal.Decimal        `json:"strikeAmount"`
+	SettlementDate           time.Time              `json:"settlementDate"`
+	Status                   string                 `json:"status"`
+	OptionPseudoOwnerRouting int                    `json:"optionPseudoOwnerRouting"`
+	OptionPseudoOwnerID      string                 `json:"optionPseudoOwnerId"`
+	CreatedAt                time.Time              `json:"createdAt"`
+	ExercisedAt              *time.Time             `json:"exercisedAt,omitempty"`
+	ExpiredAt                *time.Time             `json:"expiredAt,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Seams
+// ---------------------------------------------------------------------------
+
+// ContractStoreForService is the persistence seam for OtcContractsService.
+// *store.ContractStore satisfies it; tests use a fake.
+type ContractStoreForService interface {
+	ListForUser(ctx context.Context, userForeignID string, includeAll bool) ([]*store.Contract, error)
+	FindByID(ctx context.Context, id string) (*store.Contract, error)
+	UpdateStatus(ctx context.Context, id, status string) error
+	// ClaimExerciseByID atomically flips ACTIVE→EXERCISING under a row lock — the entry
+	// claim that serializes concurrent buyer-side exercises of the same contract. Returns
+	// (exists, claimed): claimed=true only for the single winner.
+	ClaimExerciseByID(ctx context.Context, id string) (exists bool, claimed bool, err error)
+	// RevertExercising returns an EXERCISING claim back to ACTIVE when the 2PC failed after
+	// the claim, so the user can retry. No-op on non-EXERCISING rows.
+	RevertExercising(ctx context.Context, id string) error
+}
+
+// ContractExerciser runs the buyer-side exercise 2PC. *Coordinator satisfies it.
+type ContractExerciser interface {
+	ExerciseContract(ctx context.Context, contract *store.Contract) (protocol.ForeignBankId, error)
+}
+
+// ---------------------------------------------------------------------------
+// OtcContractsService
+// ---------------------------------------------------------------------------
+
+// OtcContractsService implements the FE-facing /api/interbank/otc/contracts/*
+// wrapper: list the caller's interbank option contracts and exercise one.
+type OtcContractsService struct {
+	myRouting int
+	store     ContractStoreForService
+	exerciser ContractExerciser
+	log       *slog.Logger
+}
+
+// NewOtcContractsService constructs the service.
+func NewOtcContractsService(
+	myRouting int,
+	store ContractStoreForService,
+	exerciser ContractExerciser,
+	log *slog.Logger,
+) *OtcContractsService {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &OtcContractsService{
+		myRouting: myRouting,
+		store:     store,
+		exerciser: exerciser,
+		log:       log,
+	}
+}
+
+// ListForUser returns the contracts where principalUserID is buyer or seller.
+// Admin / supervisor callers set isAdmin=true to receive all contracts.
+func (s *OtcContractsService) ListForUser(ctx context.Context, principalUserID int64, isAdmin bool) ([]ContractView, error) {
+	var userForeignID string
+	if !isAdmin {
+		if principalUserID == 0 {
+			return nil, fmt.Errorf("%w: principalUserID is zero and isAdmin is false", ErrContractForbidden)
+		}
+		userForeignID = fmt.Sprintf("C-%d", principalUserID)
+	}
+
+	rows, err := s.store.ListForUser(ctx, userForeignID, isAdmin)
+	if err != nil {
+		return nil, fmt.Errorf("contracts: list: %w", err)
+	}
+
+	views := make([]ContractView, 0, len(rows))
+	for _, c := range rows {
+		views = append(views, toContractView(c))
+	}
+	return views, nil
+}
+
+// Exercise exercises the option contract `id` on behalf of principalUserID.
+// Only the buyer (or an admin/supervisor) may exercise. The contract must be
+// ACTIVE and its settlement date must not have passed. On success the contract
+// is flipped to EXERCISED and the resulting view is returned.
+func (s *OtcContractsService) Exercise(ctx context.Context, principalUserID int64, isAdmin bool, id string) (*ContractView, error) {
+	contract, err := s.store.FindByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("contracts: find: %w", err)
+	}
+	if contract == nil {
+		return nil, fmt.Errorf("%w: %s", ErrContractNotFound, id)
+	}
+
+	// Authorization: the caller must be the contract's buyer unless admin/supervisor.
+	if !isAdmin {
+		buyerForeignID := fmt.Sprintf("C-%d", principalUserID)
+		if principalUserID == 0 || contract.BuyerID != buyerForeignID {
+			return nil, fmt.Errorf("%w: caller is not the buyer of contract %s", ErrContractForbidden, id)
+		}
+	}
+
+	// The buyer side must be ours — we can only exercise an option we hold.
+	if contract.BuyerRouting != s.myRouting {
+		return nil, fmt.Errorf("%w: contract %s is not buyer-side for our bank", ErrContractForbidden, id)
+	}
+
+	// State checks (cheap pre-filter on the snapshot; the authoritative ACTIVE guard is the
+	// atomic claim below — the snapshot can race a concurrent exercise between read and claim).
+	if contract.Status != store.ContractStatusActive {
+		return nil, fmt.Errorf("%w: contract %s is %s (must be ACTIVE)", ErrContractNotExercisable, id, contract.Status)
+	}
+	if !contract.SettlementDate.IsZero() && contract.SettlementDate.Before(time.Now()) {
+		return nil, fmt.Errorf("%w: contract %s settlement date has passed", ErrContractNotExercisable, id)
+	}
+
+	// ENTRY CLAIM (mirrors B2 claimForExercise): atomically flip ACTIVE→EXERCISING under a
+	// row lock BEFORE any reserve/commit. This serializes concurrent Exercise(sameContract)
+	// calls — exactly one wins the claim; every other loses and is rejected here, so the
+	// buyer-strike reserve+commit in Coordinator.ExerciseContract runs at most once per
+	// contract (no double charge). The contract is NOT covered by the executor ContractGate
+	// on the buyer (off-wire) side, so this is the only serialization point for that path.
+	exists, claimed, err := s.store.ClaimExerciseByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("contracts: claim exercise: %w", err)
+	}
+	if !exists {
+		// The row vanished between FindByID and the claim — treat as not found.
+		return nil, fmt.Errorf("%w: %s", ErrContractNotFound, id)
+	}
+	if !claimed {
+		// Lost the race: another exercise already holds the claim (EXERCISING) or the
+		// contract moved past ACTIVE (EXERCISED/terminal). Reject WITHOUT reserve/commit.
+		return nil, fmt.Errorf("%w: contract %s", ErrContractAlreadyExercising, id)
+	}
+	// We hold the claim; reflect it on the snapshot for any downstream read.
+	contract.Status = store.ContractStatusExercising
+
+	if _, err := s.exerciser.ExerciseContract(ctx, contract); err != nil {
+		// 2PC/exercise failed after we claimed → revert EXERCISING→ACTIVE so the user can
+		// retry. Best-effort: a revert failure leaves the contract stuck EXERCISING (a manual
+		// /retry path can recover), but it must NOT mask the original exercise error.
+		if revertErr := s.store.RevertExercising(ctx, id); revertErr != nil {
+			s.log.ErrorContext(ctx, "contracts: exercise failed AND revert EXERCISING→ACTIVE failed — contract stuck EXERCISING",
+				"contract", id, "exerciseErr", err, "revertErr", revertErr)
+		}
+		return nil, err
+	}
+
+	if err := s.store.UpdateStatus(ctx, id, store.ContractStatusExercised); err != nil {
+		// The 2PC committed; failing to flip status is non-fatal but logged — the view will
+		// still reflect EXERCISING until a retry. Surface as a soft warning.
+		s.log.WarnContext(ctx, "contracts: exercise committed but status flip failed",
+			"contract", id, "err", err)
+	} else {
+		contract.Status = store.ContractStatusExercised
+	}
+
+	view := toContractView(contract)
+	return &view, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func toContractView(c *store.Contract) ContractView {
+	return ContractView{
+		LocalID:                  c.ID,
+		NegotiationID:            c.NegotiationID,
+		BuyerID:                  protocol.ForeignBankId{RoutingNumber: c.BuyerRouting, Id: c.BuyerID},
+		SellerID:                 protocol.ForeignBankId{RoutingNumber: c.SellerRouting, Id: c.SellerID},
+		StockTicker:              c.StockTicker,
+		Amount:                   c.Amount,
+		StrikeCurrency:           c.StrikeCurrency,
+		StrikeAmount:             c.StrikeAmount,
+		SettlementDate:           c.SettlementDate,
+		Status:                   c.Status,
+		OptionPseudoOwnerRouting: c.OptionPseudoOwnerRouting,
+		OptionPseudoOwnerID:      c.OptionPseudoOwnerID,
+		CreatedAt:                c.CreatedAt,
+		ExercisedAt:              c.ExercisedAt,
+		ExpiredAt:                c.ExpiredAt,
+	}
+}

--- a/interbank-service/internal/service/otc_contracts_test.go
+++ b/interbank-service/internal/service/otc_contracts_test.go
@@ -1,0 +1,514 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/protocol"
+	"github.com/raf-si-2025/banka-1-go/interbank-service/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes for OtcContractsService
+// ---------------------------------------------------------------------------
+
+type fakeContractStoreForSvc struct {
+	mu           sync.Mutex
+	rows         []*store.Contract
+	byID         map[string]*store.Contract
+	statusUpdate map[string]string // id → last UpdateStatus value
+	listAll      bool
+	listUserID   string
+	claimCalls   int
+	revertCalls  int
+	claimErr     error // forced error from ClaimExerciseByID
+}
+
+func newFakeContractStoreForSvc() *fakeContractStoreForSvc {
+	return &fakeContractStoreForSvc{byID: map[string]*store.Contract{}, statusUpdate: map[string]string{}}
+}
+
+func (f *fakeContractStoreForSvc) ListForUser(_ context.Context, userForeignID string, includeAll bool) ([]*store.Contract, error) {
+	f.listAll = includeAll
+	f.listUserID = userForeignID
+	return f.rows, nil
+}
+
+func (f *fakeContractStoreForSvc) FindByID(_ context.Context, id string) (*store.Contract, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c := f.byID[id]
+	if c == nil {
+		return nil, nil
+	}
+	// Hand back a copy so callers mutating the returned snapshot (e.g. Status) cannot
+	// poison the store's authoritative row that the atomic claim reads.
+	cp := *c
+	return &cp, nil
+}
+
+// ClaimExerciseByID mirrors the store's atomic ACTIVE→EXERCISING CAS under a lock. The
+// mutex makes concurrent claims on the same id serialize exactly as the row lock does in
+// Postgres: the first caller to find status=='ACTIVE' flips it and wins; everyone else loses.
+func (f *fakeContractStoreForSvc) ClaimExerciseByID(_ context.Context, id string) (bool, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.claimCalls++
+	if f.claimErr != nil {
+		return false, false, f.claimErr
+	}
+	c := f.byID[id]
+	if c == nil {
+		return false, false, nil // does not exist
+	}
+	if c.Status != store.ContractStatusActive {
+		return true, false, nil // exists but not ACTIVE → loser
+	}
+	c.Status = store.ContractStatusExercising
+	return true, true, nil
+}
+
+func (f *fakeContractStoreForSvc) RevertExercising(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.revertCalls++
+	if c := f.byID[id]; c != nil && c.Status == store.ContractStatusExercising {
+		c.Status = store.ContractStatusActive
+	}
+	return nil
+}
+
+func (f *fakeContractStoreForSvc) UpdateStatus(_ context.Context, id, status string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statusUpdate[id] = status
+	if c := f.byID[id]; c != nil {
+		c.Status = status
+	}
+	return nil
+}
+
+type fakeExerciser struct {
+	mu        sync.Mutex
+	called    int
+	lastC     *store.Contract
+	returnErr error
+}
+
+func (f *fakeExerciser) ExerciseContract(_ context.Context, c *store.Contract) (protocol.ForeignBankId, error) {
+	f.mu.Lock()
+	f.called++
+	f.lastC = c
+	retErr := f.returnErr
+	f.mu.Unlock()
+	if retErr != nil {
+		return protocol.ForeignBankId{}, retErr
+	}
+	return protocol.ForeignBankId{RoutingNumber: myRouting, Id: "tx-ex-1"}, nil
+}
+
+func (f *fakeExerciser) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.called
+}
+
+func activeContract(id, buyerID string) *store.Contract {
+	return &store.Contract{
+		ID:                       id,
+		NegotiationID:            "neg-" + id,
+		BuyerRouting:             myRouting,
+		BuyerID:                  buyerID,
+		SellerRouting:            theirRouting,
+		SellerID:                 "C-2",
+		StockTicker:              "AAPL",
+		Amount:                   10,
+		StrikeCurrency:           "USD",
+		StrikeAmount:             decimal.NewFromInt(150),
+		SettlementDate:           time.Now().Add(48 * time.Hour),
+		Status:                   store.ContractStatusActive,
+		OptionPseudoOwnerRouting: myRouting,
+		OptionPseudoOwnerID:      buyerID,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListForUser tests
+// ---------------------------------------------------------------------------
+
+func TestOtcContractsService_ListForUser_ScopesToUser(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	cs.rows = []*store.Contract{activeContract("otc-1", "C-15")}
+	svc := NewOtcContractsService(myRouting, cs, &fakeExerciser{}, discardLogger())
+
+	views, err := svc.ListForUser(context.Background(), 15, false)
+	if err != nil {
+		t.Fatalf("ListForUser: %v", err)
+	}
+	if len(views) != 1 || views[0].LocalID != "otc-1" {
+		t.Fatalf("unexpected views %+v", views)
+	}
+	if cs.listAll {
+		t.Error("non-admin list must not include all")
+	}
+	if cs.listUserID != "C-15" {
+		t.Errorf("expected scoping to C-15, got %q", cs.listUserID)
+	}
+}
+
+func TestOtcContractsService_ListForUser_AdminAll(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	svc := NewOtcContractsService(myRouting, cs, &fakeExerciser{}, discardLogger())
+
+	if _, err := svc.ListForUser(context.Background(), 0, true); err != nil {
+		t.Fatalf("ListForUser: %v", err)
+	}
+	if !cs.listAll {
+		t.Error("admin list must request all")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exercise tests
+// ---------------------------------------------------------------------------
+
+func TestOtcContractsService_Exercise_HappyPath(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	c := activeContract("otc-9", "C-15")
+	cs.byID["otc-9"] = c
+	ex := &fakeExerciser{}
+	svc := NewOtcContractsService(myRouting, cs, ex, discardLogger())
+
+	view, err := svc.Exercise(context.Background(), 15, false, "otc-9")
+	if err != nil {
+		t.Fatalf("Exercise: %v", err)
+	}
+	if ex.called != 1 {
+		t.Errorf("expected ExerciseContract called once, got %d", ex.called)
+	}
+	if cs.statusUpdate["otc-9"] != store.ContractStatusExercised {
+		t.Errorf("expected status flipped to EXERCISED, got %q", cs.statusUpdate["otc-9"])
+	}
+	if view == nil || view.Status != store.ContractStatusExercised {
+		t.Errorf("expected EXERCISED view, got %+v", view)
+	}
+}
+
+func TestOtcContractsService_Exercise_NotFound(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	svc := NewOtcContractsService(myRouting, cs, &fakeExerciser{}, discardLogger())
+
+	_, err := svc.Exercise(context.Background(), 15, false, "missing")
+	if !errors.Is(err, ErrContractNotFound) {
+		t.Errorf("expected ErrContractNotFound, got %v", err)
+	}
+}
+
+func TestOtcContractsService_Exercise_NotBuyer_Forbidden(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	cs.byID["otc-3"] = activeContract("otc-3", "C-15")
+	ex := &fakeExerciser{}
+	svc := NewOtcContractsService(myRouting, cs, ex, discardLogger())
+
+	// principal 99 is not the buyer (C-15) and not admin.
+	_, err := svc.Exercise(context.Background(), 99, false, "otc-3")
+	if !errors.Is(err, ErrContractForbidden) {
+		t.Errorf("expected ErrContractForbidden, got %v", err)
+	}
+	if ex.called != 0 {
+		t.Error("exercise must not run for a non-buyer")
+	}
+}
+
+func TestOtcContractsService_Exercise_NotActive_Conflict(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	c := activeContract("otc-4", "C-15")
+	c.Status = store.ContractStatusExercised
+	cs.byID["otc-4"] = c
+	svc := NewOtcContractsService(myRouting, cs, &fakeExerciser{}, discardLogger())
+
+	_, err := svc.Exercise(context.Background(), 15, false, "otc-4")
+	if !errors.Is(err, ErrContractNotExercisable) {
+		t.Errorf("expected ErrContractNotExercisable, got %v", err)
+	}
+}
+
+func TestOtcContractsService_Exercise_SettlementPassed_Conflict(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	c := activeContract("otc-5", "C-15")
+	c.SettlementDate = time.Now().Add(-1 * time.Hour)
+	cs.byID["otc-5"] = c
+	svc := NewOtcContractsService(myRouting, cs, &fakeExerciser{}, discardLogger())
+
+	_, err := svc.Exercise(context.Background(), 15, false, "otc-5")
+	if !errors.Is(err, ErrContractNotExercisable) {
+		t.Errorf("expected ErrContractNotExercisable for past settlement, got %v", err)
+	}
+}
+
+func TestOtcContractsService_Exercise_AdminCanExercise(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	cs.byID["otc-6"] = activeContract("otc-6", "C-15")
+	ex := &fakeExerciser{}
+	svc := NewOtcContractsService(myRouting, cs, ex, discardLogger())
+
+	// Admin (principal 0, isAdmin true) may exercise on behalf of the buyer.
+	if _, err := svc.Exercise(context.Background(), 0, true, "otc-6"); err != nil {
+		t.Fatalf("admin Exercise: %v", err)
+	}
+	if ex.called != 1 {
+		t.Errorf("expected exercise to run for admin, got called=%d", ex.called)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Coordinator.ExerciseContract posting structure
+// ---------------------------------------------------------------------------
+
+func TestCoordinator_ExerciseContract_PostingStructure(t *testing.T) {
+	ns := newFakeNegotiationStore()
+	cs := &fakeContractStore{}
+	// Buyer strike account is ours; resolveMonasAccount → RealAccount via fakeBC.
+	bc := newFakeBC(map[string]*AccountInfo{
+		"111000001234567890": {OwnerID: 15, Currency: "USD", AvailableBalance: decimal.NewFromInt(1_000_000)},
+	})
+	bc.byOwnerCurrency = map[string]string{formatOwnerKey(15, "USD"): "111000001234567890"}
+	outbound := &capturingOutboundClient{vote: protocol.TransactionVote{Vote: protocol.VoteYes}}
+	coord := buildCoordinatorWithBC(outbound, ns, cs, bc)
+
+	contract := &store.Contract{
+		ID:             "otc-ex",
+		NegotiationID:  "neg-ex",
+		BuyerRouting:   myRouting,
+		BuyerID:        "C-15",
+		SellerRouting:  theirRouting,
+		SellerID:       "C-2",
+		StockTicker:    "AAPL",
+		Amount:         10,
+		StrikeCurrency: "USD",
+		StrikeAmount:   decimal.NewFromInt(150),
+		SettlementDate: time.Now().Add(48 * time.Hour),
+		Status:         store.ContractStatusActive,
+	}
+
+	txID, err := coord.ExerciseContract(context.Background(), contract)
+	if err != nil {
+		t.Fatalf("ExerciseContract: %v", err)
+	}
+	if txID.RoutingNumber != myRouting || txID.Id == "" {
+		t.Errorf("expected our-routing tx id, got %+v", txID)
+	}
+	if outbound.sentRouting != theirRouting {
+		t.Errorf("expected partner routing %d, got %d", theirRouting, outbound.sentRouting)
+	}
+	if !outbound.committed {
+		t.Error("expected SendCommitTx to be called")
+	}
+
+	// 4 balanced postings: per-asset sums must be zero.
+	postings := outbound.lastTx.Postings
+	if len(postings) != 4 {
+		t.Fatalf("expected 4 postings, got %d", len(postings))
+	}
+	monasSum := decimal.Zero
+	stockSum := decimal.Zero
+	for _, p := range postings {
+		switch p.Asset.(type) {
+		case *protocol.MonasAsset:
+			monasSum = monasSum.Add(p.Amount)
+		case *protocol.StockAsset:
+			stockSum = stockSum.Add(p.Amount)
+		default:
+			t.Errorf("unexpected asset type %T", p.Asset)
+		}
+	}
+	if !monasSum.IsZero() {
+		t.Errorf("MONAS postings must balance, got %s", monasSum)
+	}
+	if !stockSum.IsZero() {
+		t.Errorf("STOCK postings must balance, got %s", stockSum)
+	}
+
+	// Total strike = 150 × 10 = 1500; buyer debit must be −1500 MONAS.
+	wantStrike := decimal.NewFromInt(1500)
+	var sawBuyerDebit, sawSellerStockDebit bool
+	for _, p := range postings {
+		if _, ok := p.Asset.(*protocol.MonasAsset); ok && p.Amount.Equal(wantStrike.Neg()) {
+			sawBuyerDebit = true
+		}
+		if sa, ok := p.Asset.(*protocol.StockAsset); ok && sa.Ticker == "AAPL" && p.Amount.Equal(decimal.NewFromInt(-10)) {
+			sawSellerStockDebit = true
+		}
+	}
+	if !sawBuyerDebit {
+		t.Error("expected a −1500 MONAS buyer strike debit posting")
+	}
+	if !sawSellerStockDebit {
+		t.Error("expected a −10 STOCK seller delivery posting")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// P0 — buyer-side concurrency-window: the entry claim (ACTIVE→EXERCISING) must
+// serialize concurrent/sequential Exercise(sameContract) so the off-wire buyer
+// strike is reserved+committed AT MOST ONCE (no double charge).
+// ---------------------------------------------------------------------------
+
+// TestOtcContractsService_Exercise_SequentialDouble_OnlyOneCharges reproduces the
+// original P0 deterministically WITHOUT goroutine timing: a second Exercise of the same
+// contract (e.g. a double-submit / retry that re-reads ACTIVE before the first settles)
+// must be rejected by the claim — never reaching ExerciseContract a second time.
+func TestOtcContractsService_Exercise_SequentialDouble_OnlyOneCharges(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	cs.byID["otc-dup"] = activeContract("otc-dup", "C-15")
+	ex := &fakeExerciser{}
+	svc := NewOtcContractsService(myRouting, cs, ex, discardLogger())
+
+	// First exercise wins the claim and settles.
+	if _, err := svc.Exercise(context.Background(), 15, false, "otc-dup"); err != nil {
+		t.Fatalf("first Exercise: %v", err)
+	}
+	// Second exercise: contract is now EXERCISED — the pre-filter rejects it as
+	// not-exercisable (a perfectly valid rejection); either way ExerciseContract must NOT
+	// run again and no second charge can occur.
+	_, err := svc.Exercise(context.Background(), 15, false, "otc-dup")
+	if err == nil {
+		t.Fatalf("second Exercise of a settled contract must be rejected, got nil")
+	}
+	if !errors.Is(err, ErrContractNotExercisable) && !errors.Is(err, ErrContractAlreadyExercising) {
+		t.Errorf("expected conflict (NotExercisable/AlreadyExercising), got %v", err)
+	}
+	if ex.callCount() != 1 {
+		t.Fatalf("DOUBLE CHARGE: ExerciseContract ran %d times, want exactly 1", ex.callCount())
+	}
+}
+
+// TestOtcContractsService_Exercise_ConcurrentDouble_OnlyOneCharges is the headline
+// reproduction: TWO goroutines call Exercise(sameContract) concurrently. Both can pass the
+// ACTIVE pre-filter on the snapshot, but the atomic ACTIVE→EXERCISING claim lets exactly
+// ONE through to ExerciseContract (one reserve+commit buyer strike); the other is rejected
+// with ErrContractAlreadyExercising and performs NO charge. Before the fix both reached
+// commitBuyerStrike → buyer double-charged.
+func TestOtcContractsService_Exercise_ConcurrentDouble_OnlyOneCharges(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	cs.byID["otc-race"] = activeContract("otc-race", "C-15")
+
+	// Block ExerciseContract until both goroutines have entered, widening the race window so a
+	// missing claim WOULD let both through (the test would then fail, as it must pre-fix).
+	enter := make(chan struct{}, 2)
+	release := make(chan struct{})
+	ex := &gatedExerciser{enter: enter, release: release}
+	svc := NewOtcContractsService(myRouting, cs, ex, discardLogger())
+
+	type res struct {
+		err error
+	}
+	results := make(chan res, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			_, err := svc.Exercise(context.Background(), 15, false, "otc-race")
+			results <- res{err: err}
+		}()
+	}
+
+	// At most ONE goroutine should reach the gated exerciser (the claim winner). Wait briefly
+	// for the winner to enter, then release. The loser must be rejected by the claim BEFORE
+	// ever entering ExerciseContract, so we never expect a second `enter`.
+	<-enter
+	close(release)
+
+	// The loser is rejected by a conflict — EITHER the atomic claim (ErrContractAlreadyExercising,
+	// when it read the still-ACTIVE snapshot but lost the CAS) OR the cheap pre-filter
+	// (ErrContractNotExercisable, when it read the snapshot after the winner already settled to
+	// EXERCISED). Both paths prevent the double charge — that is the money-conservation invariant.
+	var winners, conflicts, others int
+	for i := 0; i < 2; i++ {
+		r := <-results
+		switch {
+		case r.err == nil:
+			winners++
+		case errors.Is(r.err, ErrContractAlreadyExercising) || errors.Is(r.err, ErrContractNotExercisable):
+			conflicts++
+		default:
+			others++
+			t.Errorf("unexpected error from concurrent exercise: %v", r.err)
+		}
+	}
+
+	if winners != 1 {
+		t.Fatalf("expected exactly 1 winner, got %d (conflicts=%d others=%d)", winners, conflicts, others)
+	}
+	if conflicts != 1 {
+		t.Fatalf("expected exactly 1 conflict rejection, got %d", conflicts)
+	}
+	if got := ex.callCount(); got != 1 {
+		t.Fatalf("DOUBLE CHARGE: ExerciseContract ran %d times, want exactly 1", got)
+	}
+	if cs.statusUpdate["otc-race"] != store.ContractStatusExercised {
+		t.Errorf("winner must flip the contract to EXERCISED, got %q", cs.statusUpdate["otc-race"])
+	}
+	if cs.revertCalls != 0 {
+		t.Errorf("happy-path winner must not revert the claim, got %d revert calls", cs.revertCalls)
+	}
+}
+
+// TestOtcContractsService_Exercise_FailureRevertsToActive verifies that when the 2PC fails
+// AFTER the claim, the contract is reverted EXERCISING→ACTIVE so the user can retry — and the
+// retry then succeeds (claim wins again, settles once).
+func TestOtcContractsService_Exercise_FailureRevertsToActive(t *testing.T) {
+	cs := newFakeContractStoreForSvc()
+	cs.byID["otc-fail"] = activeContract("otc-fail", "C-15")
+	ex := &fakeExerciser{returnErr: ErrInterbankProtocol}
+	svc := NewOtcContractsService(myRouting, cs, ex, discardLogger())
+
+	// First attempt: claim taken, 2PC fails → must revert to ACTIVE.
+	_, err := svc.Exercise(context.Background(), 15, false, "otc-fail")
+	if !errors.Is(err, ErrInterbankProtocol) {
+		t.Fatalf("expected ErrInterbankProtocol from failed 2PC, got %v", err)
+	}
+	if cs.revertCalls != 1 {
+		t.Fatalf("a 2PC failure after claim must revert exactly once, got %d", cs.revertCalls)
+	}
+	if got := cs.byID["otc-fail"].Status; got != store.ContractStatusActive {
+		t.Fatalf("contract must be back to ACTIVE after revert, got %q", got)
+	}
+
+	// Retry after clearing the fault: claim wins again, settles once.
+	ex.returnErr = nil
+	if _, err := svc.Exercise(context.Background(), 15, false, "otc-fail"); err != nil {
+		t.Fatalf("retry after revert: %v", err)
+	}
+	if cs.statusUpdate["otc-fail"] != store.ContractStatusExercised {
+		t.Errorf("retry must flip the contract to EXERCISED, got %q", cs.statusUpdate["otc-fail"])
+	}
+}
+
+// gatedExerciser blocks inside ExerciseContract until `release` is closed, so a concurrency
+// test can hold a "winner" in flight while the racing goroutine attempts its claim. It signals
+// `enter` once per call so the test can assert at most one goroutine reaches it.
+type gatedExerciser struct {
+	mu      sync.Mutex
+	called  int
+	enter   chan struct{}
+	release chan struct{}
+}
+
+func (g *gatedExerciser) ExerciseContract(_ context.Context, _ *store.Contract) (protocol.ForeignBankId, error) {
+	g.mu.Lock()
+	g.called++
+	g.mu.Unlock()
+	g.enter <- struct{}{}
+	<-g.release
+	return protocol.ForeignBankId{RoutingNumber: myRouting, Id: "tx-gated"}, nil
+}
+
+func (g *gatedExerciser) callCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.called
+}

--- a/interbank-service/internal/service/otc_negotiation.go
+++ b/interbank-service/internal/service/otc_negotiation.go
@@ -344,14 +344,33 @@ func generateNegotiationID() string {
 	return "neg-" + hex.EncodeToString(b)
 }
 
+// ContractByNegotiationReader is the minimal contract-store seam the seller lookup needs to
+// resolve a negotiation id → its option contract lifecycle (status + settlement). Satisfied
+// by *store.ContractStore; tests use a fake. It is optional: a nil reader degrades to the
+// pre-exercise behaviour (contract fields left empty → only accept-time legs pass).
+type ContractByNegotiationReader interface {
+	FindByNegotiationID(ctx context.Context, negotiationID string) (*store.Contract, error)
+}
+
 // NegotiationSellerLookup adapts NegotiationStoreIface to the OptionNegotiationLookup
-// interface required by Executor. It resolves a negotiation id → seller foreign id string.
+// interface required by Executor. It resolves a negotiation id → seller foreign id string,
+// and (for the Validator's NegotiationReader role) enriches the negotiation view with the
+// backing option contract's lifecycle so EXERCISE-time legs on a closed negotiation pass.
 type NegotiationSellerLookup struct {
-	store NegotiationStoreIface
+	store     NegotiationStoreIface
+	contracts ContractByNegotiationReader // optional — nil is tolerated
 }
 
 func NewNegotiationSellerLookup(s NegotiationStoreIface) *NegotiationSellerLookup {
 	return &NegotiationSellerLookup{store: s}
+}
+
+// NewNegotiationSellerLookupWithContracts wires the contract store so the Validator can tell
+// an exercisable accepted option (closed negotiation + ACTIVE contract) apart from a
+// genuinely dead one. Used by production wiring; the plain constructor stays for callers
+// that only need seller resolution.
+func NewNegotiationSellerLookupWithContracts(s NegotiationStoreIface, c ContractByNegotiationReader) *NegotiationSellerLookup {
+	return &NegotiationSellerLookup{store: s, contracts: c}
 }
 
 // FindSellerID returns the seller's foreign-id string (e.g. "C-15") for the given negotiation id.
@@ -367,6 +386,12 @@ func (l *NegotiationSellerLookup) FindSellerID(ctx context.Context, negID string
 }
 
 // FindNegotiation adapts to service.NegotiationReader for Validator use.
+//
+// It additionally resolves the backing option contract (when a contract store is wired) so
+// the Validator can distinguish an EXERCISE of an accepted option (closed negotiation but
+// ACTIVE contract) from a genuinely dead negotiation. The contract lookup is best-effort:
+// any error is swallowed and the contract fields are left empty — the validator then falls
+// back to accept-time semantics, which is the safe (more-restrictive) default.
 func (l *NegotiationSellerLookup) FindNegotiation(ctx context.Context, id protocol.ForeignBankId) (*NegotiationLite, error) {
 	neg, err := l.store.FindByAuthoritativeRef(ctx, id.RoutingNumber, id.Id)
 	if err != nil {
@@ -375,12 +400,20 @@ func (l *NegotiationSellerLookup) FindNegotiation(ctx context.Context, id protoc
 	if neg == nil {
 		return nil, fmt.Errorf("%w: %v", ErrNegotiationNotFound, id)
 	}
-	return &NegotiationLite{
+	lite := &NegotiationLite{
 		IsOngoing:      neg.IsOngoing,
 		SettlementDate: neg.SettlementDate,
 		Amount:         neg.Amount,
 		PricePerUnit:   neg.PriceAmount,
-	}, nil
+	}
+	if l.contracts != nil {
+		// neg.ID is OUR local negotiation id; interbank_contracts.negotiation_id references it.
+		if c, cerr := l.contracts.FindByNegotiationID(ctx, neg.ID); cerr == nil && c != nil {
+			lite.ContractStatus = c.Status
+			lite.ContractSettlement = c.SettlementDate
+		}
+	}
+	return lite, nil
 }
 
 // ensure NegotiationSellerLookup implements OptionNegotiationLookup and NegotiationReader

--- a/interbank-service/internal/service/otc_outbound.go
+++ b/interbank-service/internal/service/otc_outbound.go
@@ -454,6 +454,17 @@ func (s *OtcOutboundService) AcceptOutbound(
 			"id", id, "partnerRouting", partnerRouting, "status", statusCode, "err", clientErr)
 		return mapOutboundErrorStatus(clientErr), nil
 	}
+	// FIX 2: on partner success the negotiation is settled — close our local mirror so
+	// it leaves the active feed and the FE no longer offers "Prihvati". Without this the
+	// mirror's is_ongoing stayed true and a second accept click hit the partner's now-
+	// closed negotiation → 409. The authoritative branch already closes via the
+	// coordinator; only the mirror path was leaking. Non-fatal: a close failure is logged.
+	if statusCode >= 200 && statusCode < 300 && n.IsOngoing {
+		if closeErr := s.store.MarkClosed(ctx, n.ID); closeErr != nil {
+			s.log.WarnContext(ctx, "accept outbound: MarkClosed mirror failed (non-fatal)",
+				"id", n.ID, "err", closeErr)
+		}
+	}
 	s.log.InfoContext(ctx, "accept outbound partner returned", "id", id, "status", statusCode)
 	return statusCode, nil
 }

--- a/interbank-service/internal/service/otc_outbound_test.go
+++ b/interbank-service/internal/service/otc_outbound_test.go
@@ -449,6 +449,69 @@ func TestAcceptOutbound_Mirror(t *testing.T) {
 	}
 }
 
+// FIX 2: a successful mirror accept must close the local mirror row so it leaves the
+// active feed and a second accept cannot fire (which would hit the partner's now-closed
+// negotiation → 409).
+func TestAcceptOutbound_Mirror_ClosesLocalMirror(t *testing.T) {
+	ns := newFakeOutboundNegStore()
+	remoteID := "neg-partner-acc2"
+	ns.rows["neg-acc2"] = &store.Negotiation{
+		ID:                    "neg-acc2",
+		BuyerRouting:          testOutboundMyRouting,
+		BuyerID:               "C-15",
+		SellerRouting:         testOutboundPartnerRN,
+		SellerID:              "C-2",
+		IsOngoing:             true,
+		IsAuthoritative:       false,
+		RemoteNegotiationID:   &remoteID,
+		LastModifiedByRouting: testOutboundPartnerRN,
+		LastModifiedByID:      "C-2",
+		SettlementDate:        time.Now().Add(48 * time.Hour),
+	}
+
+	client := &fakeOtcOutboundClient{acceptStatus: 204}
+	svc := newOutboundSvc(ns, client)
+
+	if _, err := svc.AcceptOutbound(context.Background(), "neg-acc2"); err != nil {
+		t.Fatalf("AcceptOutbound error: %v", err)
+	}
+	row, _ := ns.FindByID(context.Background(), "neg-acc2")
+	if row == nil || row.IsOngoing {
+		t.Fatalf("expected mirror closed (is_ongoing=false) after successful accept, got %+v", row)
+	}
+}
+
+// FIX 2 guard: a non-2xx partner accept must NOT close the local mirror (the
+// negotiation is still open and the user may retry once the partner recovers).
+func TestAcceptOutbound_Mirror_DoesNotCloseOnNon2xx(t *testing.T) {
+	ns := newFakeOutboundNegStore()
+	remoteID := "neg-partner-acc3"
+	ns.rows["neg-acc3"] = &store.Negotiation{
+		ID:                    "neg-acc3",
+		BuyerRouting:          testOutboundMyRouting,
+		BuyerID:               "C-15",
+		SellerRouting:         testOutboundPartnerRN,
+		SellerID:              "C-2",
+		IsOngoing:             true,
+		IsAuthoritative:       false,
+		RemoteNegotiationID:   &remoteID,
+		LastModifiedByRouting: testOutboundPartnerRN,
+		LastModifiedByID:      "C-2",
+		SettlementDate:        time.Now().Add(48 * time.Hour),
+	}
+
+	client := &fakeOtcOutboundClient{acceptStatus: 409}
+	svc := newOutboundSvc(ns, client)
+
+	if _, err := svc.AcceptOutbound(context.Background(), "neg-acc3"); err != nil {
+		t.Fatalf("AcceptOutbound error: %v", err)
+	}
+	row, _ := ns.FindByID(context.Background(), "neg-acc3")
+	if row == nil || !row.IsOngoing {
+		t.Fatalf("expected mirror to stay open after non-2xx accept, got %+v", row)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestDeleteOutbound_Idempotent — DELETE non-existent: no error
 // ---------------------------------------------------------------------------

--- a/interbank-service/internal/service/validator.go
+++ b/interbank-service/internal/service/validator.go
@@ -27,11 +27,49 @@ type AccountInfo struct {
 }
 
 // NegotiationLite is the minimal view of a negotiation row that the validator needs.
+//
+// ContractStatus / ContractSettlement carry the lifecycle of the OPTION CONTRACT that
+// the negotiation produced on accept (empty/zero when no contract exists yet). They are
+// what makes an EXERCISE tx pass: a negotiation is closed (IsOngoing=false) the moment it
+// is accepted, but the resulting option contract is still EXERCISABLE while it is ACTIVE
+// and its settlement date has not passed. Binding exercisability to the contract — not to
+// the negotiation's IsOngoing flag — is what lets an accepted cross-bank option actually
+// be used (see validateNegotiationOpen / validateOption).
 type NegotiationLite struct {
 	IsOngoing      bool
 	SettlementDate time.Time
 	Amount         int
 	PricePerUnit   decimal.Decimal
+
+	// ContractStatus is the status of the option contract backing this negotiation
+	// (e.g. "ACTIVE", "EXERCISED", "EXPIRED"), or "" when no contract exists yet
+	// (accept has not happened). ContractSettlement is that contract's settlement date.
+	ContractStatus     string
+	ContractSettlement time.Time
+}
+
+// ContractStatusActive mirrors store.ContractStatusActive — the only contract status that
+// makes an option exercisable. Duplicated here to keep the validator free of a store import.
+const ContractStatusActive = "ACTIVE"
+
+// negotiationExercisable reports whether the option backing this negotiation can still be
+// exercised: there is an ACTIVE contract whose settlement date is not before now. This is
+// the EXERCISE-time predicate (negotiation already closed on accept, contract still live).
+func negotiationExercisable(neg *NegotiationLite, now time.Time) bool {
+	if neg == nil || neg.ContractStatus != ContractStatusActive {
+		return false
+	}
+	// Settlement strictly in the future (option is unusable on/after settlement).
+	return neg.ContractSettlement.After(now)
+}
+
+// negotiationAcceptable reports whether the negotiation is still in its ACCEPT-time window:
+// ongoing and not past settlement. This is the original (pre-accept) predicate.
+func negotiationAcceptable(neg *NegotiationLite, now time.Time) bool {
+	if neg == nil || !neg.IsOngoing {
+		return false
+	}
+	return !neg.SettlementDate.Before(now)
 }
 
 // BankingCoreReader is what the validator needs from banking-core internal endpoints.
@@ -195,24 +233,91 @@ func (v *Validator) validatePersonAccount(ctx context.Context, person *protocol.
 		_ = monas
 		return nil, nil
 
+	case *protocol.StockAsset:
+		// PERSON + STOCK:
+		//   - Positive (incoming) → our user RECEIVES stock (e.g. the buyer-side
+		//     leg of a cross-bank OTC option exercise). Receiving an asset is always
+		//     acceptable — existence/capacity is not our concern here, exactly like
+		//     an incoming MONAS credit. The actual stock crediting happens via
+		//     trading-service on commit, outside the 2PC posting validation.
+		//   - Negative (outgoing) → our user would DELIVER stock via a raw posting.
+		//     B1 routes local stock delivery through trading-service reservations,
+		//     not raw protocol postings, so this stays UNACCEPTABLE_ASSET.
+		if p.Amount.IsPositive() {
+			return nil, nil
+		}
+		return &protocol.NoVoteReason{Reason: protocol.ReasonUnacceptableAsset, Posting: &p}, nil
+
 	default:
-		// PERSON + STOCK or other — UNACCEPTABLE_ASSET.
+		// PERSON + any other unsupported asset — UNACCEPTABLE_ASSET.
 		return &protocol.NoVoteReason{Reason: protocol.ReasonUnacceptableAsset, Posting: &p}, nil
 	}
 }
 
 // validateOptionPseudoAccount handles the OPTION account type.
-// OPTION + non-OPTION asset → UNACCEPTABLE_ASSET.
+//
 // OPTION + OPTION asset, routing=ours → run the option-specific checks.
 // OPTION + OPTION asset, routing=partner → not ours.
+//
+// OPTION + MONAS/STOCK asset (the premium / share legs a partner-coordinated accept
+// hangs off the option pseudo-account, e.g. B2 as coordinator with B1 as seller): when
+// the pseudo-account is on OUR routing and references a valid, ongoing negotiation, the
+// accompanying leg is accepted (FIX 3). Previously ANY non-OPTION asset on the pseudo-
+// account was rejected with UNACCEPTABLE_ASSET, which obered B2's accept-tx → 2PC abort.
+// The global balance-check still applies; only genuinely unsupported asset types remain
+// UNACCEPTABLE.
 func (v *Validator) validateOptionPseudoAccount(ctx context.Context, opt *protocol.OptionPseudoAccount, p protocol.Posting) (*protocol.NoVoteReason, error) {
-	if _, ok := p.Asset.(*protocol.OptionAsset); !ok {
+	switch p.Asset.(type) {
+	case *protocol.OptionAsset:
+		if opt.Id.RoutingNumber != v.myRouting {
+			return nil, nil
+		}
+		return v.validateOption(ctx, opt.Id, p)
+
+	case *protocol.MonasAsset, *protocol.StockAsset:
+		// Premium/share leg riding the option pseudo-account. Only our negotiations are
+		// our responsibility; a partner-routed pseudo-account is validated by the partner.
+		if opt.Id.RoutingNumber != v.myRouting {
+			return nil, nil
+		}
+		// The negotiation backing this pseudo-account must exist and still be ongoing for
+		// the leg to be acceptable (mirrors the OPTION_NEGOTIATION_NOT_FOUND /
+		// OPTION_USED_OR_EXPIRED checks, without the option-amount rule which only applies
+		// to the OPTION unit leg).
+		return v.validateNegotiationOpen(ctx, opt.Id, p)
+
+	default:
 		return &protocol.NoVoteReason{Reason: protocol.ReasonUnacceptableAsset, Posting: &p}, nil
 	}
-	if opt.Id.RoutingNumber != v.myRouting {
+}
+
+// validateNegotiationOpen verifies that the option backing an option pseudo-account is in
+// a usable lifecycle state for the MONAS/STOCK legs riding the pseudo-account. Two distinct
+// transaction shapes hang such legs off the pseudo-account:
+//
+//   - ACCEPT-shape (partner-coordinated accept, FIX 3): the negotiation is still ONGOING
+//     and the contract does not exist yet. negotiationAcceptable covers this.
+//   - EXERCISE-shape (cross-bank §2.7.2 exercise of an accepted option): the negotiation is
+//     CLOSED (accept set is_ongoing=false), but the resulting contract is still ACTIVE with
+//     a future settlement. negotiationExercisable covers this.
+//
+// Previously this rejected ANY non-ongoing negotiation with OPTION_USED_OR_EXPIRED, which
+// made every accepted cross-bank option impossible to exercise (accept always closes the
+// negotiation). We now accept the leg when EITHER predicate holds, and only reject
+// OPTION_USED_OR_EXPIRED when neither does (declined / already-exercised / expired contract).
+func (v *Validator) validateNegotiationOpen(ctx context.Context, id protocol.ForeignBankId, p protocol.Posting) (*protocol.NoVoteReason, error) {
+	if v.negs == nil {
+		return &protocol.NoVoteReason{Reason: protocol.ReasonOptionNegotiationNotFound, Posting: &p}, nil
+	}
+	neg, err := v.negs.FindNegotiation(ctx, id)
+	if err != nil || neg == nil {
+		return &protocol.NoVoteReason{Reason: protocol.ReasonOptionNegotiationNotFound, Posting: &p}, nil
+	}
+	now := time.Now()
+	if negotiationAcceptable(neg, now) || negotiationExercisable(neg, now) {
 		return nil, nil
 	}
-	return v.validateOption(ctx, opt.Id, p)
+	return &protocol.NoVoteReason{Reason: protocol.ReasonOptionUsedOrExpired, Posting: &p}, nil
 }
 
 // validateOption performs the three option-specific checks:
@@ -225,10 +330,12 @@ func (v *Validator) validateOption(ctx context.Context, id protocol.ForeignBankI
 	if err != nil || neg == nil {
 		return &protocol.NoVoteReason{Reason: protocol.ReasonOptionNegotiationNotFound, Posting: &p}, nil
 	}
-	if !neg.IsOngoing {
-		return &protocol.NoVoteReason{Reason: protocol.ReasonOptionUsedOrExpired, Posting: &p}, nil
-	}
-	if neg.SettlementDate.Before(time.Now()) {
+	// Lifecycle: accept-time (ongoing) OR exercise-time (closed negotiation, ACTIVE
+	// contract, future settlement). Reject only when the option is genuinely unusable.
+	// See validateNegotiationOpen for the rationale; kept consistent so the OPTION-unit
+	// leg and the MONAS/STOCK side legs apply the same exercisability rule.
+	now := time.Now()
+	if !negotiationAcceptable(neg, now) && !negotiationExercisable(neg, now) {
 		return &protocol.NoVoteReason{Reason: protocol.ReasonOptionUsedOrExpired, Posting: &p}, nil
 	}
 	// Amount check: |amount| ∈ {1, k, k·π}
@@ -242,10 +349,17 @@ func (v *Validator) validateOption(ctx context.Context, id protocol.ForeignBankI
 	return nil, nil
 }
 
-// accountIsOurs returns true if the 18-digit account number's routing prefix (first 3 digits)
+// accountIsOurs returns true if the account number's routing prefix (first 3 digits)
 // matches our routing number.
+//
+// Length is NOT fixed at 18: Banka 1 issues both 18-digit (bank/exchange) and
+// 19-digit (client) account numbers, so we match on the routing prefix only.
+// A previous `len(num) != 18` guard silently rejected every 19-digit client
+// account, so inbound cross-bank postings to a client were not recognised as ours
+// and the recipient was never credited (cross-bank money vanished). Existence is
+// still verified downstream by ResolveAccount, so prefix-matching is safe.
 func (v *Validator) accountIsOurs(num string) bool {
-	if len(num) != 18 {
+	if len(num) < 18 {
 		return false
 	}
 	prefix := num[:3]

--- a/interbank-service/internal/service/validator_test.go
+++ b/interbank-service/internal/service/validator_test.go
@@ -55,6 +55,11 @@ type fakeNegInfo struct {
 	settlement   time.Time
 	amount       int
 	pricePerUnit decimal.Decimal
+	// contractStatus / contractSettlement model the backing option contract (empty =
+	// no contract yet, i.e. accept-time). Used to exercise the EXERCISE-time path where
+	// the negotiation is closed but the contract is still ACTIVE.
+	contractStatus     string
+	contractSettlement time.Time
 }
 
 type fakeTD struct {
@@ -68,10 +73,12 @@ func (f *fakeTD) FindNegotiation(_ context.Context, id protocol.ForeignBankId) (
 		return nil, errors.New("not found")
 	}
 	return &NegotiationLite{
-		IsOngoing:      n.isOngoing,
-		SettlementDate: n.settlement,
-		Amount:         n.amount,
-		PricePerUnit:   n.pricePerUnit,
+		IsOngoing:          n.isOngoing,
+		SettlementDate:     n.settlement,
+		Amount:             n.amount,
+		PricePerUnit:       n.pricePerUnit,
+		ContractStatus:     n.contractStatus,
+		ContractSettlement: n.contractSettlement,
 	}, nil
 }
 
@@ -307,7 +314,12 @@ func TestValidatePosting_UnacceptableAsset_PersonPlusStock(t *testing.T) {
 	}
 }
 
-func TestValidatePosting_UnacceptableAsset_OptionAccountPlusMonas(t *testing.T) {
+// FIX 3: with no negotiation lookup wired, a MONAS leg on our OPTION pseudo-account
+// can no longer be authorised, so it is rejected as OPTION_NEGOTIATION_NOT_FOUND
+// (previously a blanket UNACCEPTABLE_ASSET). The premium/share legs of a partner-
+// coordinated accept are allowed only against a live negotiation (see the FIX 3 tests
+// below).
+func TestValidatePosting_OptionAccountPlusMonas_NoNegLookup_NotFound(t *testing.T) {
 	v := NewValidator(111, nil, nil, nil)
 	p := protocol.Posting{
 		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-1"}},
@@ -318,8 +330,257 @@ func TestValidatePosting_UnacceptableAsset_OptionAccountPlusMonas(t *testing.T) 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if r == nil || r.Reason != protocol.ReasonUnacceptableAsset {
-		t.Errorf("expected UNACCEPTABLE_ASSET for OptionAccount+Monas, got %+v", r)
+	if r == nil || r.Reason != protocol.ReasonOptionNegotiationNotFound {
+		t.Errorf("expected OPTION_NEGOTIATION_NOT_FOUND for OptionAccount+Monas without neg lookup, got %+v", r)
+	}
+}
+
+// FIX 3: an OPTION pseudo-account with a genuinely unsupported asset type stays
+// UNACCEPTABLE_ASSET. (OptionAsset/MONAS/STOCK are the only handled cases.) We cannot
+// construct an unknown protocol.Asset here without an internal type, so this guard is
+// covered by the default branch in validateOptionPseudoAccount; the MONAS/STOCK accept
+// path is exercised by the tests below.
+
+// FIX 3: when B2 coordinates and B1 is the seller, B2 hangs the premium MONAS leg off
+// the OPTION pseudo-account. With a live negotiation on our routing, B1 must accept it
+// (return nil) instead of voting UNACCEPTABLE_ASSET → 2PC abort.
+func TestValidatePosting_OptionAccountPlusMonas_LiveNegotiation_Accepted(t *testing.T) {
+	td := &fakeTD{negs: map[string]fakeNegInfo{
+		"111:neg-live": {
+			isOngoing:    true,
+			settlement:   time.Now().Add(30 * 24 * time.Hour),
+			amount:       10,
+			pricePerUnit: decimal.NewFromInt(200),
+		},
+	}}
+	v := NewValidator(111, td, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-live"}},
+		Amount:  decimal.NewFromInt(1000), // premium credit leg
+		Asset:   &protocol.MonasAsset{Currency: "USD"},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Errorf("expected nil (accepted premium leg on live negotiation), got %+v", r)
+	}
+}
+
+// FIX 3: a STOCK leg on the OPTION pseudo-account is likewise accepted against a live
+// negotiation.
+func TestValidatePosting_OptionAccountPlusStock_LiveNegotiation_Accepted(t *testing.T) {
+	td := &fakeTD{negs: map[string]fakeNegInfo{
+		"111:neg-live": {
+			isOngoing:    true,
+			settlement:   time.Now().Add(30 * 24 * time.Hour),
+			amount:       10,
+			pricePerUnit: decimal.NewFromInt(200),
+		},
+	}}
+	v := NewValidator(111, td, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-live"}},
+		Amount:  decimal.NewFromInt(-10),
+		Asset:   &protocol.StockAsset{Ticker: "AAPL"},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Errorf("expected nil (accepted stock leg on live negotiation), got %+v", r)
+	}
+}
+
+// FIX 3: a MONAS/STOCK leg on a CLOSED negotiation's pseudo-account is rejected as
+// OPTION_USED_OR_EXPIRED (the negotiation is no longer live).
+func TestValidatePosting_OptionAccountPlusMonas_ClosedNegotiation_Rejected(t *testing.T) {
+	td := &fakeTD{negs: map[string]fakeNegInfo{
+		"111:neg-closed": {
+			isOngoing:    false,
+			settlement:   time.Now().Add(30 * 24 * time.Hour),
+			amount:       10,
+			pricePerUnit: decimal.NewFromInt(200),
+		},
+	}}
+	v := NewValidator(111, td, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-closed"}},
+		Amount:  decimal.NewFromInt(1000),
+		Asset:   &protocol.MonasAsset{Currency: "USD"},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil || r.Reason != protocol.ReasonOptionUsedOrExpired {
+		t.Errorf("expected OPTION_USED_OR_EXPIRED for closed negotiation, got %+v", r)
+	}
+}
+
+// EXERCISE fix — the cross-bank exercise of an ACCEPTED option (B2 buyer / B1 seller).
+// After accept the negotiation is CLOSED (is_ongoing=false), but the resulting contract is
+// still ACTIVE with a future settlement. The §2.7.2 exercise tx hangs the seller's
+// stock-delivery (STOCK) and strike (MONAS) legs off the option pseudo-account. These MUST
+// pass — pre-fix they were rejected OPTION_USED_OR_EXPIRED, making every accepted cross-bank
+// option impossible to exercise.
+func TestValidatePosting_OptionAccountPlusStock_ExercisableClosedNegotiation_Accepted(t *testing.T) {
+	td := &fakeTD{negs: map[string]fakeNegInfo{
+		"111:neg-9f1830": {
+			isOngoing:          false, // closed on accept — the bug trigger
+			settlement:         time.Now().Add(-1 * time.Hour),
+			amount:             1,
+			pricePerUnit:       decimal.NewFromInt(200),
+			contractStatus:     ContractStatusActive,               // contract is still live …
+			contractSettlement: time.Now().Add(7 * 24 * time.Hour), // … with a future settlement
+		},
+	}}
+	v := NewValidator(111, td, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-9f1830"}},
+		Amount:  decimal.NewFromInt(-1), // seller delivers k stocks
+		Asset:   &protocol.StockAsset{Ticker: "AAPL"},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Errorf("expected nil (exercisable closed-negotiation + ACTIVE contract), got %+v", r)
+	}
+}
+
+func TestValidatePosting_OptionAccountPlusMonas_ExercisableClosedNegotiation_Accepted(t *testing.T) {
+	td := &fakeTD{negs: map[string]fakeNegInfo{
+		"111:neg-ex": {
+			isOngoing:          false,
+			settlement:         time.Now().Add(-1 * time.Hour),
+			amount:             1,
+			pricePerUnit:       decimal.NewFromInt(200),
+			contractStatus:     ContractStatusActive,
+			contractSettlement: time.Now().Add(7 * 24 * time.Hour),
+		},
+	}}
+	v := NewValidator(111, td, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-ex"}},
+		Amount:  decimal.NewFromInt(200), // strike into option pseudo-account
+		Asset:   &protocol.MonasAsset{Currency: "USD"},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Errorf("expected nil (exercisable closed-negotiation MONAS leg), got %+v", r)
+	}
+}
+
+// An already-EXERCISED contract on a closed negotiation must STILL be rejected (a second
+// exercise is not allowed) — exercisability requires an ACTIVE contract, not just any.
+func TestValidatePosting_OptionAccountPlusStock_AlreadyExercisedContract_Rejected(t *testing.T) {
+	td := &fakeTD{negs: map[string]fakeNegInfo{
+		"111:neg-done": {
+			isOngoing:          false,
+			settlement:         time.Now().Add(-1 * time.Hour),
+			amount:             1,
+			pricePerUnit:       decimal.NewFromInt(200),
+			contractStatus:     "EXERCISED",
+			contractSettlement: time.Now().Add(7 * 24 * time.Hour),
+		},
+	}}
+	v := NewValidator(111, td, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-done"}},
+		Amount:  decimal.NewFromInt(-1),
+		Asset:   &protocol.StockAsset{Ticker: "AAPL"},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil || r.Reason != protocol.ReasonOptionUsedOrExpired {
+		t.Errorf("expected OPTION_USED_OR_EXPIRED for already-exercised contract, got %+v", r)
+	}
+}
+
+// A closed negotiation whose ACTIVE contract is PAST its settlement is not exercisable.
+func TestValidatePosting_OptionAccountPlusStock_ContractPastSettlement_Rejected(t *testing.T) {
+	td := &fakeTD{negs: map[string]fakeNegInfo{
+		"111:neg-late": {
+			isOngoing:          false,
+			settlement:         time.Now().Add(-48 * time.Hour),
+			amount:             1,
+			pricePerUnit:       decimal.NewFromInt(200),
+			contractStatus:     ContractStatusActive,
+			contractSettlement: time.Now().Add(-1 * time.Hour), // contract settlement already passed
+		},
+	}}
+	v := NewValidator(111, td, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-late"}},
+		Amount:  decimal.NewFromInt(-1),
+		Asset:   &protocol.StockAsset{Ticker: "AAPL"},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil || r.Reason != protocol.ReasonOptionUsedOrExpired {
+		t.Errorf("expected OPTION_USED_OR_EXPIRED for past-settlement contract, got %+v", r)
+	}
+}
+
+// The OPTION-unit leg (OptionAsset) on a closed negotiation with an ACTIVE contract is also
+// exercisable — keeps validateOption consistent with validateNegotiationOpen.
+func TestValidatePosting_OptionUnit_ExercisableClosedNegotiation_Accepted(t *testing.T) {
+	td := &fakeTD{negs: map[string]fakeNegInfo{
+		"111:neg-unit": {
+			isOngoing:          false,
+			settlement:         time.Now().Add(-1 * time.Hour),
+			amount:             10,
+			pricePerUnit:       decimal.NewFromInt(200),
+			contractStatus:     ContractStatusActive,
+			contractSettlement: time.Now().Add(7 * 24 * time.Hour),
+		},
+	}}
+	v := NewValidator(111, td, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-unit"}},
+		Amount:  decimal.NewFromInt(1), // valid amount (∈ {1, k, k·π})
+		Asset: &protocol.OptionAsset{OptionDescription: protocol.OptionDescription{
+			NegotiationId:  protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-unit"},
+			Stock:          protocol.StockDescription{Ticker: "AAPL"},
+			PricePerUnit:   protocol.MonetaryValue{Currency: "USD", Amount: decimal.NewFromInt(200)},
+			SettlementDate: "2026-12-01T00:00:00Z",
+			Amount:         10,
+		}},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Errorf("expected nil (exercisable OPTION-unit leg), got %+v", r)
+	}
+}
+
+// FIX 3: a MONAS/STOCK leg on a PARTNER-routed pseudo-account is not ours to validate.
+func TestValidatePosting_OptionAccountPlusMonas_PartnerRouting_NotOurs(t *testing.T) {
+	v := NewValidator(111, &fakeTD{negs: map[string]fakeNegInfo{}}, nil, nil)
+	p := protocol.Posting{
+		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 222, Id: "neg-partner"}},
+		Amount:  decimal.NewFromInt(1000),
+		Asset:   &protocol.MonasAsset{Currency: "USD"},
+	}
+	r, err := v.ValidatePosting(context.Background(), p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Errorf("expected nil (partner-routed pseudo-account is not ours), got %+v", r)
 	}
 }
 
@@ -334,11 +595,11 @@ func TestValidatePosting_OptionNegotiationNotFound(t *testing.T) {
 		Account: &protocol.OptionPseudoAccount{Id: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-missing"}},
 		Amount:  decimal.NewFromInt(-1),
 		Asset: &protocol.OptionAsset{OptionDescription: protocol.OptionDescription{
-			NegotiationId: protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-missing"},
-			Stock:         protocol.StockDescription{Ticker: "AAPL"},
-			PricePerUnit:  protocol.MonetaryValue{Currency: "USD", Amount: decimal.NewFromInt(200)},
+			NegotiationId:  protocol.ForeignBankId{RoutingNumber: 111, Id: "neg-missing"},
+			Stock:          protocol.StockDescription{Ticker: "AAPL"},
+			PricePerUnit:   protocol.MonetaryValue{Currency: "USD", Amount: decimal.NewFromInt(200)},
 			SettlementDate: "2026-12-01T00:00:00Z",
-			Amount:        10,
+			Amount:         10,
 		}},
 	}
 	r, err := v.ValidatePosting(context.Background(), p)

--- a/interbank-service/internal/store/contracts.go
+++ b/interbank-service/internal/store/contracts.go
@@ -14,6 +14,7 @@ import (
 const (
 	ContractStatusPendingPremium = "PENDING_PREMIUM" // created; premium 2PC not yet committed
 	ContractStatusActive         = "ACTIVE"          // premium received; option is live
+	ContractStatusExercising     = "EXERCISING"      // buyer exercise 2PC in flight (entry-level claim held)
 	ContractStatusExercised      = "EXERCISED"       // option exercised successfully
 	ContractStatusExpired        = "EXPIRED"         // settlement_date passed without exercise
 	ContractStatusReleased       = "RELEASED"        // cancelled before expiry
@@ -105,6 +106,107 @@ func (s *ContractStore) FindByID(ctx context.Context, id string) (*Contract, err
 	return scanContract(row)
 }
 
+// FindByIDForUpdate is FindByID under a row-level write lock (SELECT ... FOR UPDATE).
+// It returns (nil, nil) when no row matches. Callers MUST run it inside a transaction
+// (the lock is held until the surrounding tx commits/rolls back); outside a tx the lock is
+// released immediately and offers no serialization. Used by the buyer-side exercise entry
+// claim so two concurrent Exercise(sameContract) calls serialize on the row before either
+// can read+flip its status.
+func (s *ContractStore) FindByIDForUpdate(ctx context.Context, id string) (*Contract, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+contractSelectCols+` FROM interbank_contracts WHERE id = $1 FOR UPDATE`, id)
+	return scanContract(row)
+}
+
+// ClaimExerciseByID atomically transitions a contract ACTIVE→EXERCISING, ONLY when it is
+// currently ACTIVE — the per-contract ENTRY claim for the BUYER-side off-wire exercise
+// (mirrors B2's claimForExercise: findByIdForUpdate + ACTIVE→EXERCISING under the row lock).
+// This single conditional UPDATE is the serialization point: two concurrent Exercise calls on
+// the same contract race on the same row inside the locking CTE, exactly one observes
+// status='ACTIVE' and flips it (rows-affected = 1); the loser sees 0 and is rejected BEFORE
+// any strike reserve/commit, so the buyer is never double-charged. The final ACTIVE/EXERCISING
+// →EXERCISED flip stays on the settlement path (UpdateStatus); this claim only guards the door.
+//
+// Returns (exists, claimed): exists=false when no contract row matches id at all; claimed=true
+// when THIS call won the ACTIVE→EXERCISING transition; claimed=false when the row exists but was
+// not ACTIVE (already EXERCISING / EXERCISED / terminal) — the caller must reject as a conflict.
+func (s *ContractStore) ClaimExerciseByID(ctx context.Context, id string) (exists bool, claimed bool, err error) {
+	const q = `
+		WITH target AS (
+			SELECT c.id, c.status
+			FROM interbank_contracts c
+			WHERE c.id = $1
+			FOR UPDATE
+		),
+		upd AS (
+			UPDATE interbank_contracts c
+			SET status = 'EXERCISING', version = version + 1
+			FROM target
+			WHERE c.id = target.id AND target.status = 'ACTIVE'
+			RETURNING c.id
+		)
+		SELECT
+			(SELECT count(*) FROM target) AS existed,
+			(SELECT count(*) FROM upd)    AS claimed`
+	var existed, claimedCnt int
+	if scanErr := s.pool.QueryRow(ctx, q, id).Scan(&existed, &claimedCnt); scanErr != nil {
+		return false, false, scanErr
+	}
+	return existed > 0, claimedCnt > 0, nil
+}
+
+// RevertExercising reverts an EXERCISING claim (taken by ClaimExerciseByID) back to ACTIVE when
+// the buyer-side 2PC/exercise failed after the claim, so the user can retry. Best-effort and
+// idempotent: it only touches EXERCISING rows, never an already-EXERCISED one (settlement owns
+// that final flip), so a revert that races a successful settlement is a no-op.
+func (s *ContractStore) RevertExercising(ctx context.Context, id string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE interbank_contracts
+		SET status  = 'ACTIVE',
+		    version = version + 1
+		WHERE id = $1 AND status = 'EXERCISING'`, id)
+	return err
+}
+
+// ListForUser returns all contracts where the given user is buyer or seller
+// (matching by foreign-id string, e.g. "C-15"), ordered by created_at DESC.
+// When includeAll is true (admin/supervisor scope), userForeignID is ignored and
+// all rows are returned. Mirrors NegotiationStore.ListForUser.
+func (s *ContractStore) ListForUser(ctx context.Context, userForeignID string, includeAll bool) ([]*Contract, error) {
+	var rows pgx.Rows
+	var err error
+	if includeAll {
+		rows, err = s.pool.Query(ctx,
+			`SELECT `+contractSelectCols+` FROM interbank_contracts
+			 ORDER BY created_at DESC`)
+	} else {
+		rows, err = s.pool.Query(ctx,
+			`SELECT `+contractSelectCols+` FROM interbank_contracts
+			 WHERE buyer_id = $1 OR seller_id = $1
+			 ORDER BY created_at DESC`,
+			userForeignID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []*Contract
+	for rows.Next() {
+		c, scanErr := scanContract(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if c != nil {
+			out = append(out, c)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SumActiveBySellerAndTicker returns the total stock quantity reserved across
 // ACTIVE inter-bank contracts where the seller matches (sellerRouting, sellerID)
 // AND ticker matches. Used by GET /public-stock to subtract the
@@ -120,6 +222,71 @@ func (s *ContractStore) SumActiveBySellerAndTicker(ctx context.Context, sellerRo
 		  AND status                = 'ACTIVE'`,
 		sellerRouting, sellerID, ticker).Scan(&sum)
 	return sum, err
+}
+
+// ClaimExerciseByNegotiation atomically transitions to EXERCISED the contract whose
+// negotiation matches negID, ONLY when it is currently ACTIVE — the per-contract
+// idempotency claim for cross-bank OTC exercise settlement (FIX B). The single
+// conditional UPDATE is the serialization point: concurrent / different-txId exercises
+// of the same contract race on the same row, and exactly one observes status='ACTIVE'
+// and flips it (rows-affected = 1); the loser sees 0. negID may be EITHER our LOCAL
+// negotiation id (seller-host case: contracts.negotiation_id == the option pseudo id we
+// issued) OR the SELLER bank's authoritative id (buyer case: the option pseudo id is the
+// seller-bank id, mapped to our local mirror via interbank_negotiations.remote_negotiation_id).
+// Both are resolved in one statement.
+//
+// Returns (exists, claimed): exists=false when there is no matching contract row at all
+// (gate then proceeds ungated); claimed=true when THIS call won the ACTIVE→EXERCISED
+// transition; claimed=false when the contract exists but was not ACTIVE (already EXERCISED
+// or terminal) — settlement must then be skipped.
+func (s *ContractStore) ClaimExerciseByNegotiation(ctx context.Context, negID string) (exists bool, claimed bool, err error) {
+	// Resolve the matching contract id via either keying scheme, then conditionally flip.
+	// A CTE keeps it to one round-trip and makes the ACTIVE-guard atomic with the lookup.
+	const q = `
+		WITH target AS (
+			SELECT c.id, c.status
+			FROM interbank_contracts c
+			WHERE c.negotiation_id = $1
+			   OR c.negotiation_id IN (
+					SELECT n.id FROM interbank_negotiations n
+					WHERE n.remote_negotiation_id = $1
+			   )
+			LIMIT 1
+			FOR UPDATE
+		),
+		upd AS (
+			UPDATE interbank_contracts c
+			SET status = 'EXERCISED', exercised_at = now(), version = version + 1
+			FROM target
+			WHERE c.id = target.id AND target.status = 'ACTIVE'
+			RETURNING c.id
+		)
+		SELECT
+			(SELECT count(*) FROM target)  AS existed,
+			(SELECT count(*) FROM upd)     AS claimed`
+	var existed, claimedCnt int
+	if scanErr := s.pool.QueryRow(ctx, q, negID).Scan(&existed, &claimedCnt); scanErr != nil {
+		return false, false, scanErr
+	}
+	return existed > 0, claimedCnt > 0, nil
+}
+
+// ReleaseExerciseClaimByNegotiation reverts an EXERCISED contract (claimed via
+// ClaimExerciseByNegotiation) back to ACTIVE when settlement failed after the claim, so a
+// §2.9 retransmit can re-settle. Best-effort and idempotent: it only touches EXERCISED rows
+// and clears exercised_at. Uses the same dual-keying resolution as the claim.
+func (s *ContractStore) ReleaseExerciseClaimByNegotiation(ctx context.Context, negID string) error {
+	const q = `
+		UPDATE interbank_contracts c
+		SET status = 'ACTIVE', exercised_at = NULL, version = version + 1
+		WHERE c.status = 'EXERCISED'
+		  AND (c.negotiation_id = $1
+		       OR c.negotiation_id IN (
+				SELECT n.id FROM interbank_negotiations n
+				WHERE n.remote_negotiation_id = $1
+		       ))`
+	_, err := s.pool.Exec(ctx, q, negID)
+	return err
 }
 
 // UpdateStatus flips a contract's status (e.g. ACTIVE→EXERCISED or →EXPIRED).

--- a/interbank-service/internal/store/db_test.go
+++ b/interbank-service/internal/store/db_test.go
@@ -286,6 +286,122 @@ func TestNewContractStore_Nil(t *testing.T) {
 	}
 }
 
+func TestContractStore_FindByIDForUpdate_UsesRowLock(t *testing.T) {
+	db := &fakeDB{row: &fakeRow{vals: contractRowVals()}}
+	s := &ContractStore{pool: db}
+	got, err := s.FindByIDForUpdate(context.Background(), "c-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.ID != "c-1" {
+		t.Errorf("got %+v", got)
+	}
+	if !contains(db.lastSQL, "FOR UPDATE") {
+		t.Errorf("FindByIDForUpdate must take a row lock; SQL = %s", db.lastSQL)
+	}
+}
+
+func TestContractStore_ClaimExerciseByID(t *testing.T) {
+	// Won the claim: existed=1, claimed=1.
+	won := &fakeDB{row: &fakeRow{vals: []any{1, 1}}}
+	s := &ContractStore{pool: won}
+	exists, claimed, err := s.ClaimExerciseByID(context.Background(), "c-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists || !claimed {
+		t.Errorf("expected exists+claimed, got exists=%v claimed=%v", exists, claimed)
+	}
+	if !contains(won.lastSQL, "FOR UPDATE") {
+		t.Errorf("claim must lock the row; SQL = %s", won.lastSQL)
+	}
+	if !contains(won.lastSQL, "'EXERCISING'") || !contains(won.lastSQL, "'ACTIVE'") {
+		t.Errorf("claim must CAS ACTIVE→EXERCISING; SQL = %s", won.lastSQL)
+	}
+
+	// Exists but lost the CAS (already EXERCISING/EXERCISED): existed=1, claimed=0.
+	lost := &fakeDB{row: &fakeRow{vals: []any{1, 0}}}
+	exists, claimed, _ = (&ContractStore{pool: lost}).ClaimExerciseByID(context.Background(), "c-1")
+	if !exists || claimed {
+		t.Errorf("loser: expected exists+!claimed, got exists=%v claimed=%v", exists, claimed)
+	}
+
+	// No such contract: existed=0, claimed=0.
+	missing := &fakeDB{row: &fakeRow{vals: []any{0, 0}}}
+	exists, claimed, _ = (&ContractStore{pool: missing}).ClaimExerciseByID(context.Background(), "nope")
+	if exists || claimed {
+		t.Errorf("missing: expected !exists+!claimed, got exists=%v claimed=%v", exists, claimed)
+	}
+
+	// Scan error propagates.
+	boom := &fakeDB{row: &fakeRow{scanErr: errors.New("boom")}}
+	if _, _, err := (&ContractStore{pool: boom}).ClaimExerciseByID(context.Background(), "c-1"); err == nil {
+		t.Error("expected scan error to propagate")
+	}
+}
+
+func TestContractStore_RevertExercising(t *testing.T) {
+	db := &fakeDB{execTag: commandTag(1)}
+	s := &ContractStore{pool: db}
+	if err := s.RevertExercising(context.Background(), "c-1"); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(db.lastSQL, "'ACTIVE'") || !contains(db.lastSQL, "status = 'EXERCISING'") {
+		t.Errorf("revert must only touch EXERCISING rows and set ACTIVE; SQL = %s", db.lastSQL)
+	}
+
+	// exec error propagates.
+	boom := &fakeDB{execErr: errors.New("boom")}
+	if err := (&ContractStore{pool: boom}).RevertExercising(context.Background(), "c-1"); err == nil {
+		t.Error("expected exec error to propagate")
+	}
+}
+
+func TestContractStore_ListForUser_ScopedAndAll(t *testing.T) {
+	// Scoped (non-admin): filters by buyer_id OR seller_id and binds the user id.
+	scoped := &fakeDB{rows: &fakeRows{rows: [][]any{contractRowVals(), contractRowVals()}}}
+	s := &ContractStore{pool: scoped}
+	out, err := s.ListForUser(context.Background(), "C-2", false)
+	if err != nil {
+		t.Fatalf("ListForUser scoped: %v", err)
+	}
+	if len(out) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(out))
+	}
+	if len(scoped.lastArgs) != 1 || scoped.lastArgs[0] != "C-2" {
+		t.Errorf("expected user-id bound arg, got %v", scoped.lastArgs)
+	}
+	if !contains(scoped.lastSQL, "buyer_id = $1 OR seller_id = $1") {
+		t.Errorf("scoped query should filter by user, got: %s", scoped.lastSQL)
+	}
+
+	// Admin (includeAll): no user-id arg, no WHERE filter.
+	all := &fakeDB{rows: &fakeRows{rows: [][]any{contractRowVals()}}}
+	s2 := &ContractStore{pool: all}
+	out2, err := s2.ListForUser(context.Background(), "", true)
+	if err != nil {
+		t.Fatalf("ListForUser all: %v", err)
+	}
+	if len(out2) != 1 {
+		t.Errorf("expected 1 row, got %d", len(out2))
+	}
+	if len(all.lastArgs) != 0 {
+		t.Errorf("admin list should bind no args, got %v", all.lastArgs)
+	}
+}
+
+// contains is a tiny substring helper (avoids importing strings just for tests).
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
 // ---------------------------------------------------------------------------
 // MessageStore
 // ---------------------------------------------------------------------------

--- a/interbank-service/internal/store/negotiations.go
+++ b/interbank-service/internal/store/negotiations.go
@@ -171,10 +171,18 @@ func (s *NegotiationStore) MarkClosed(ctx context.Context, id string) error {
 	return err
 }
 
-// ListForUser returns all negotiations where the given user is buyer or seller
+// ListForUser returns negotiations where the given user is buyer or seller
 // (matching by foreign-id string, e.g. "C-15").
-// When includeAll is true (admin/supervisor scope), userForeignID is ignored and
-// all rows are returned ordered by last_modified_at DESC.
+//
+// When includeAll is true (admin/supervisor scope), userForeignID is ignored and ALL
+// rows — open and closed — are returned for oversight/history, ordered by
+// last_modified_at DESC.
+//
+// For a non-admin user the feed is the ACTIVE list only: closed negotiations
+// (is_ongoing = false) are filtered out (FIX 4). Previously closed mirrors lingered in
+// the user's active list because the FE maps is_ongoing=false → 'ACCEPTED' and could
+// not tell a partner-rejected/closed mirror from a settled one, so a stale "open"
+// negotiation kept showing an actionable Accept button.
 func (s *NegotiationStore) ListForUser(ctx context.Context, userForeignID string, includeAll bool) ([]*Negotiation, error) {
 	var rows interface {
 		Next() bool
@@ -190,7 +198,7 @@ func (s *NegotiationStore) ListForUser(ctx context.Context, userForeignID string
 	} else {
 		rows, err = s.pool.Query(ctx,
 			`SELECT `+negotiationSelectCols+` FROM interbank_negotiations
-			 WHERE buyer_id = $1 OR seller_id = $1
+			 WHERE (buyer_id = $1 OR seller_id = $1) AND is_ongoing = true
 			 ORDER BY last_modified_at DESC`,
 			userForeignID)
 	}

--- a/interbank-service/internal/store/transactions.go
+++ b/interbank-service/internal/store/transactions.go
@@ -23,16 +23,57 @@ const (
 	RefKindMonas  = "MONAS"
 	RefKindStock  = "STOCK"
 	RefKindOption = "OPTION"
+	// RefKindOptionExercise marks the seller-side delivery of a cross-bank OTC option
+	// EXERCISE (the negative STOCK leg on our option pseudo-account, §2.7.2). On commit it
+	// drives ExerciseOption — committing the seller's already-held accept-time stock
+	// reservation (quantity & reserved_quantity decrement) and flipping the option to
+	// EXERCISED. It reserves NOTHING new at prepare (the shares were reserved at accept),
+	// so releaseRef is a deliberate no-op: an exercise abort must leave the accept-time
+	// reservation intact for a retry — releasing it (as a plain OPTION ref would) would
+	// strand the option without its backing shares.
+	RefKindOptionExercise = "OPTION_EXERCISE"
+	// RefKindMonasCredit marks an INCOMING money posting to one of our accounts.
+	// Unlike the others it is not a reservation: nothing is held at prepare; the
+	// recipient is credited on commit, and releaseRef is a no-op (no debit to undo).
+	RefKindMonasCredit = "MONAS_CREDIT"
+	// RefKindStockCredit marks an INCOMING stock posting to one of our local buyers
+	// (the buyer-side STOCK leg of a cross-bank OTC option exercise). Like
+	// MONAS_CREDIT it reserves nothing at prepare: the shares are credited to the
+	// buyer's portfolio on commit (via trading-service), and releaseRef is a no-op.
+	// Without this the exercise debited the buyer's strike cash but never delivered
+	// the shares (FIX 1: asset-conservation).
+	RefKindStockCredit = "STOCK_CREDIT"
 )
 
 // ReservationRef captures a downstream reservation made during prepareLocal.
 // On COMMIT_TX we commit each ref; on ROLLBACK_TX we release each ref (LIFO).
 // Stored as JSONB array in interbank_transactions.reservation_refs.
 type ReservationRef struct {
-	Kind               string  `json:"kind"`                         // MONAS | STOCK | OPTION
-	ReservationID      string  `json:"reservationId,omitempty"`       // banking-core / trading UUID
+	Kind               string  `json:"kind"`                         // MONAS | STOCK | OPTION | MONAS_CREDIT
+	ReservationID      string  `json:"reservationId,omitempty"`      // banking-core / trading UUID
 	NegotiationRouting *int    `json:"negotiationRouting,omitempty"` // OPTION refs only
 	NegotiationID      *string `json:"negotiationId,omitempty"`      // OPTION refs only
+
+	// MONAS_CREDIT refs only — an incoming credit applied (not reserved) on commit.
+	CreditAccountNum string `json:"creditAccountNum,omitempty"`
+	CreditAmount     string `json:"creditAmount,omitempty"` // decimal serialized as a plain string
+	CreditClientID   int64  `json:"creditClientId,omitempty"`
+	// CreditCurrency and CreditFromAccount carry the audit metadata needed to record
+	// the incoming money in this bank's transaction history on commit. CreditFromAccount
+	// is the foreign sender's account (the matching negative MONAS posting), or "" when
+	// the sender is a Person-only counterparty with no real account number on the wire.
+	CreditCurrency    string `json:"creditCurrency,omitempty"`
+	CreditFromAccount string `json:"creditFromAccount,omitempty"`
+
+	// STOCK_CREDIT refs only — an incoming stock delivery to a local buyer, credited
+	// (not reserved) on commit via trading-service. StockCreditBuyerID is the local
+	// owner id; StockCreditTicker / StockCreditQuantity describe the shares; and
+	// StockCreditStrike is the contract strike used as the average-purchase-price
+	// fallback when trading-service has no live market price for the ticker.
+	StockCreditBuyerID  int64  `json:"stockCreditBuyerId,omitempty"`
+	StockCreditTicker   string `json:"stockCreditTicker,omitempty"`
+	StockCreditQuantity int    `json:"stockCreditQuantity,omitempty"`
+	StockCreditStrike   string `json:"stockCreditStrike,omitempty"` // decimal serialized as a plain string
 }
 
 // Transaction is one row in interbank_transactions.

--- a/trading-service-go/internal/clients/market.go
+++ b/trading-service-go/internal/clients/market.go
@@ -32,6 +32,49 @@ func (c *MarketClient) GetListing(ctx context.Context, id int64) (*StockListing,
 	return &out, nil
 }
 
+// StockListingSummary is the subset of market-service's ListingSummaryResponse
+// (GET /api/listings/stocks) that the interbank credit-stock path consumes when
+// resolving a ticker to its listing id + current price.
+type StockListingSummary struct {
+	ListingID int64           `json:"listingId"`
+	Ticker    string          `json:"ticker"`
+	Price     decimal.Decimal `json:"price"`
+	Currency  string          `json:"currency"`
+}
+
+// stockListingPage mirrors the Spring-style PageListingSummaryResponse envelope
+// (only the content slice is consumed).
+type stockListingPage struct {
+	Content []StockListingSummary `json:"content"`
+}
+
+// ResolveStockListing resolves a ticker to its STOCK listing (id + current price)
+// via market-service's paginated stock-listing endpoint
+// (GET /api/listings/stocks?search=TICKER), filtering for an exact case-insensitive
+// ticker match. Returns (nil, nil) when no listing matches. Used by the interbank
+// credit-stock path (FIX 1: crediting a local buyer the shares delivered on a
+// cross-bank OTC option exercise), which needs the listing id to key the portfolio
+// row and a sensible average purchase price.
+func (c *MarketClient) ResolveStockListing(ctx context.Context, ticker string) (*StockListingSummary, error) {
+	wanted := strings.TrimSpace(ticker)
+	if wanted == "" {
+		return nil, nil
+	}
+	q := url.Values{}
+	q.Set("search", wanted)
+	q.Set("size", "200")
+	var page stockListingPage
+	if err := c.base.doJSON(ctx, http.MethodGet, "/api/listings/stocks", q, nil, &page); err != nil {
+		return nil, err
+	}
+	for i := range page.Content {
+		if strings.EqualFold(strings.TrimSpace(page.Content[i].Ticker), wanted) {
+			return &page.Content[i], nil
+		}
+	}
+	return nil, nil
+}
+
 // Calculate mirrors ExchangeClient.calculate: GET /calculate?fromCurrency&toCurrency&amount.
 func (c *MarketClient) Calculate(ctx context.Context, from, to string, amount decimal.Decimal) (*ExchangeRate, error) {
 	q := url.Values{}

--- a/trading-service-go/internal/http/interbank_handlers.go
+++ b/trading-service-go/internal/http/interbank_handlers.go
@@ -34,6 +34,22 @@ func (h *Handlers) InterbankReserveStock(w http.ResponseWriter, r *http.Request)
 	httpx.JSON(w, http.StatusOK, interbank.ReserveStockRes{ReservationID: reservationID})
 }
 
+// InterbankCreditStock ↔ POST /internal/interbank/credit-stock (204). Credits the
+// local buyer the shares delivered on a cross-bank OTC option exercise (FIX 1).
+func (h *Handlers) InterbankCreditStock(w http.ResponseWriter, r *http.Request) {
+	var req interbank.CreditStockReq
+	if err := decodeJSONLenient(r, &req); err != nil {
+		writeDomainError(w, r, api.NewOrderError(http.StatusBadRequest, "Malformed JSON request body"))
+		return
+	}
+	if err := h.app.Interbank.CreditStock(r.Context(), req.BuyerUserID, req.Ticker,
+		req.Quantity, req.TransactionIDRouting, req.TransactionIDLocal, req.StrikePrice); err != nil {
+		writeDomainError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // InterbankCommitStock ↔ POST /internal/interbank/reservations/{id}/commit-stock
 // (204). {id} is the reservation UUID (string).
 func (h *Handlers) InterbankCommitStock(w http.ResponseWriter, r *http.Request) {

--- a/trading-service-go/internal/http/misc_service_handlers_test.go
+++ b/trading-service-go/internal/http/misc_service_handlers_test.go
@@ -159,6 +159,12 @@ func (ibPortStub) UpdateReservedQuantity(context.Context, portfolio.Querier, int
 func (ibPortStub) UpdateQuantityAndReserved(context.Context, portfolio.Querier, int64, int, int) error {
 	return nil
 }
+func (ibPortStub) UpdateQuantityAndAvg(context.Context, portfolio.Querier, int64, int, decimal.Decimal) error {
+	return nil
+}
+func (ibPortStub) Insert(context.Context, portfolio.Querier, int64, int64, string, int, decimal.Decimal) error {
+	return nil
+}
 func (ibPortStub) FindAllPublicStocks(context.Context, portfolio.Querier) ([]portfolio.Portfolio, error) {
 	return nil, nil
 }
@@ -166,6 +172,9 @@ func (ibPortStub) FindAllPublicStocks(context.Context, portfolio.Querier) ([]por
 type ibMktStub struct{}
 
 func (ibMktStub) GetListing(context.Context, int64) (*clients.StockListing, error) { return nil, nil }
+func (ibMktStub) ResolveStockListing(context.Context, string) (*clients.StockListingSummary, error) {
+	return nil, nil
+}
 
 func newInterbankHandlers() *Handlers {
 	svc := interbank.NewServiceForTest(ibRepoStub{}, ibPortStub{}, ibMktStub{}, noTx, 111, nil)

--- a/trading-service-go/internal/http/routes.go
+++ b/trading-service-go/internal/http/routes.go
@@ -224,6 +224,7 @@ func registerRoutes(handle func(method, path string, handler http.Handler), app 
 	// errors → OTC 404/409 shape via writeDomainError. {id} is the reservation UUID;
 	// {negotiationId} is the option negotiation key (string).
 	handle(http.MethodPost, "/internal/interbank/reserve-stock", orderSecured(jwtService, serviceOnly, handlers.InterbankReserveStock))
+	handle(http.MethodPost, "/internal/interbank/credit-stock", orderSecured(jwtService, serviceOnly, handlers.InterbankCreditStock))
 	handle(http.MethodPost, "/internal/interbank/reservations/{id}/commit-stock", orderSecured(jwtService, serviceOnly, handlers.InterbankCommitStock))
 	handle(http.MethodDelete, "/internal/interbank/reservations/{id}", orderSecured(jwtService, serviceOnly, handlers.InterbankReleaseStock))
 	handle(http.MethodPost, "/internal/interbank/options/{negotiationId}/reserve", orderSecured(jwtService, serviceOnly, handlers.InterbankReserveOption))

--- a/trading-service-go/internal/interbank/deps.go
+++ b/trading-service-go/internal/interbank/deps.go
@@ -10,6 +10,7 @@ import (
 	gpdb "banka1/go-platform/db"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
 )
 
 // interbankRepo abstracts *Repository for unit testing.
@@ -31,12 +32,18 @@ type interbankPortfolio interface {
 	FindByIDForUpdate(ctx context.Context, q portfolio.Querier, id int64) (*portfolio.Portfolio, error)
 	UpdateReservedQuantity(ctx context.Context, q portfolio.Querier, id int64, reserved int) error
 	UpdateQuantityAndReserved(ctx context.Context, q portfolio.Querier, id int64, quantity, reserved int) error
+	UpdateQuantityAndAvg(ctx context.Context, q portfolio.Querier, id int64, quantity int, avg decimal.Decimal) error
+	Insert(ctx context.Context, q portfolio.Querier, userID, listingID int64, listingType string, quantity int, avg decimal.Decimal) error
 	FindAllPublicStocks(ctx context.Context, q portfolio.Querier) ([]portfolio.Portfolio, error)
 }
 
 // interbankMarket abstracts the MarketClient methods used by Service.
 type interbankMarket interface {
 	GetListing(ctx context.Context, id int64) (*clients.StockListing, error)
+	// ResolveStockListing maps a ticker to its STOCK listing (id + current price).
+	// Used by CreditStock (FIX 1) to key the buyer's portfolio row when the buyer
+	// has no existing position for that ticker.
+	ResolveStockListing(ctx context.Context, ticker string) (*clients.StockListingSummary, error)
 }
 
 // txRunner runs fn inside a single transaction.

--- a/trading-service-go/internal/interbank/dtos.go
+++ b/trading-service-go/internal/interbank/dtos.go
@@ -1,5 +1,7 @@
 package interbank
 
+import "github.com/shopspring/decimal"
+
 // These are the request/response DTOs for the /internal/interbank* endpoints.
 // JSON tags match the Java controller record field names exactly — interbank-
 // service's TradingInternalClient depends on them being byte-compatible.
@@ -21,6 +23,21 @@ type ReserveStockReq struct {
 // lowercase string, which is exactly what newUUIDv4 produces.
 type ReserveStockRes struct {
 	ReservationID string `json:"reservationId"`
+}
+
+// CreditStockReq is the body of POST /internal/interbank/credit-stock (FIX 1):
+// interbank-service posts it on the COMMIT of a cross-bank OTC option exercise so the
+// local buyer is credited the shares delivered by the partner-side seller. buyerUserId
+// is the local owner id (the "C-N" prefix already stripped by interbank-service);
+// strikePrice is the fallback average purchase price when market-service has no live
+// price for the ticker.
+type CreditStockReq struct {
+	BuyerUserID          int64           `json:"buyerUserId"`
+	Ticker               string          `json:"ticker"`
+	Quantity             int             `json:"quantity"`
+	TransactionIDRouting int             `json:"transactionIdRouting"`
+	TransactionIDLocal   string          `json:"transactionIdLocal"`
+	StrikePrice          decimal.Decimal `json:"strikePrice"`
 }
 
 // ReserveOptionReq mirrors InterbankOptionController.ReserveOptionReq.

--- a/trading-service-go/internal/interbank/service.go
+++ b/trading-service-go/internal/interbank/service.go
@@ -13,6 +13,7 @@ import (
 	"banka1/trading-service-go/internal/portfolio"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/shopspring/decimal"
 )
 
 // Service exposes the interbank 2PC stock primitives + the option lifecycle +
@@ -84,6 +85,84 @@ func (s *Service) ReleaseStock(ctx context.Context, reservationID string) error 
 	return s.runTx(ctx, func(tx pgx.Tx) error {
 		return s.releaseStockTx(ctx, tx, reservationID)
 	})
+}
+
+// CreditStock credits `quantity` of `ticker` shares to the local buyer's portfolio
+// (FIX 1: asset-conservation on a cross-bank OTC option exercise). On the exercise
+// 2PC our buyer pays the strike (legs a/b, reserved+committed via banking-core) and
+// the partner-side seller delivers the shares (legs c/d). The buyer's incoming STOCK
+// credit (leg d) has no raw-posting path on our side, so interbank-service routes it
+// here on commit: without this the cash was debited but the shares never landed.
+//
+// The ticker is resolved to its listing id via market-service (the buyer may hold no
+// prior position for it, so we cannot key off an existing portfolio row). The buyer
+// position is upserted as a new lot at the listing's current price (falling back to
+// the strike when the market price is unavailable), mirroring TransferOwnership's
+// buyer-side merge. One transaction.
+//
+// Idempotency note: interbank-service only invokes this once per committed tx —
+// Executor.CommitLocal flips the transaction to COMMITTED after running every ref and
+// short-circuits on a re-commit, and the retry scheduler re-sends the COMMIT only to
+// the partner, never re-running our local refs. So no extra dedup table is needed.
+func (s *Service) CreditStock(ctx context.Context, buyerUserID int64, ticker string, quantity, transactionIDRouting int, transactionIDLocal string, strikePrice decimal.Decimal) error {
+	if quantity <= 0 {
+		return api.NewOtcError(http.StatusNotFound, "Quantity must be positive: "+itoa(int64(quantity)))
+	}
+	if strings.TrimSpace(ticker) == "" {
+		return api.NewOtcError(http.StatusNotFound, "Ticker must not be blank")
+	}
+
+	listing, err := s.market.ResolveStockListing(ctx, ticker)
+	if err != nil {
+		return err
+	}
+	if listing == nil {
+		return api.NewOtcError(http.StatusNotFound, "No STOCK listing found for ticker "+ticker)
+	}
+	// Average purchase price for the new lot: prefer the listing's current price; fall
+	// back to the contract strike when the market price is missing or non-positive.
+	avg := listing.Price
+	if avg.Sign() <= 0 {
+		avg = strikePrice
+	}
+
+	return s.runTx(ctx, func(tx pgx.Tx) error {
+		existing, err := s.portfolio.FindByUserIDAndListingIDForUpdate(ctx, tx, buyerUserID, listing.ListingID)
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			if err := s.portfolio.Insert(ctx, tx, buyerUserID, listing.ListingID, "STOCK", quantity, avg); err != nil {
+				return err
+			}
+			s.logger.Info("interbank creditStock (new lot)", "buyer", buyerUserID, "ticker", ticker,
+				"qty", quantity, "listing", listing.ListingID, "avg", avg.String(),
+				"txRouting", transactionIDRouting, "txLocal", transactionIDLocal)
+			return nil
+		}
+		// Merge into the existing lot at a quantity-weighted average price.
+		newQty := existing.Quantity + quantity
+		mergedAvg := weightedAvg(existing.Quantity, existing.AveragePurchasePrice, quantity, avg)
+		if err := s.portfolio.UpdateQuantityAndAvg(ctx, tx, existing.ID, newQty, mergedAvg); err != nil {
+			return err
+		}
+		s.logger.Info("interbank creditStock (merge)", "buyer", buyerUserID, "ticker", ticker,
+			"qty", quantity, "listing", listing.ListingID, "newQty", newQty, "avg", mergedAvg.String(),
+			"txRouting", transactionIDRouting, "txLocal", transactionIDLocal)
+		return nil
+	})
+}
+
+// weightedAvg computes the quantity-weighted average price when merging an incoming
+// lot (qtyB @ priceB) into an existing position (qtyA @ priceA). Degenerates to
+// priceB when the combined quantity is non-positive (defensive; should not happen).
+func weightedAvg(qtyA int, priceA decimal.Decimal, qtyB int, priceB decimal.Decimal) decimal.Decimal {
+	total := qtyA + qtyB
+	if total <= 0 {
+		return priceB
+	}
+	sum := priceA.Mul(decimal.NewFromInt(int64(qtyA))).Add(priceB.Mul(decimal.NewFromInt(int64(qtyB))))
+	return sum.Div(decimal.NewFromInt(int64(total)))
 }
 
 // reserveStockTx is the core reserve logic, run inside a caller-owned tx so the

--- a/trading-service-go/internal/interbank/service_stub_test.go
+++ b/trading-service-go/internal/interbank/service_stub_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
 )
 
 // ---- stubs ----
@@ -52,6 +53,24 @@ type stubIBPortfolio struct {
 	position  *portfolio.Portfolio
 	posOneErr error
 	updateErr error
+	insertErr error
+
+	// FIX 1 credit-stock call capture.
+	inserted     []insertedLot
+	updatedQtyAvg []updatedLot
+}
+
+type insertedLot struct {
+	userID, listingID int64
+	listingType       string
+	quantity          int
+	avg               decimal.Decimal
+}
+
+type updatedLot struct {
+	id       int64
+	quantity int
+	avg      decimal.Decimal
 }
 
 func (s *stubIBPortfolio) Pool() *pgxpool.Pool { return nil }
@@ -70,6 +89,20 @@ func (s *stubIBPortfolio) UpdateReservedQuantity(_ context.Context, _ portfolio.
 func (s *stubIBPortfolio) UpdateQuantityAndReserved(_ context.Context, _ portfolio.Querier, _ int64, _, _ int) error {
 	return s.updateErr
 }
+func (s *stubIBPortfolio) UpdateQuantityAndAvg(_ context.Context, _ portfolio.Querier, id int64, quantity int, avg decimal.Decimal) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	s.updatedQtyAvg = append(s.updatedQtyAvg, updatedLot{id: id, quantity: quantity, avg: avg})
+	return nil
+}
+func (s *stubIBPortfolio) Insert(_ context.Context, _ portfolio.Querier, userID, listingID int64, listingType string, quantity int, avg decimal.Decimal) error {
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+	s.inserted = append(s.inserted, insertedLot{userID: userID, listingID: listingID, listingType: listingType, quantity: quantity, avg: avg})
+	return nil
+}
 func (s *stubIBPortfolio) FindAllPublicStocks(_ context.Context, _ portfolio.Querier) ([]portfolio.Portfolio, error) {
 	return s.positions, s.posErr
 }
@@ -77,10 +110,18 @@ func (s *stubIBPortfolio) FindAllPublicStocks(_ context.Context, _ portfolio.Que
 type stubIBMarket struct {
 	listing    *clients.StockListing
 	listingErr error
+
+	// FIX 1 ResolveStockListing stub.
+	summary    *clients.StockListingSummary
+	summaryErr error
 }
 
 func (s *stubIBMarket) GetListing(_ context.Context, _ int64) (*clients.StockListing, error) {
 	return s.listing, s.listingErr
+}
+
+func (s *stubIBMarket) ResolveStockListing(_ context.Context, _ string) (*clients.StockListingSummary, error) {
+	return s.summary, s.summaryErr
 }
 
 func noopTx(_ context.Context, fn func(pgx.Tx) error) error { return fn(nil) }
@@ -251,6 +292,92 @@ func TestReleaseStock_Success(t *testing.T) {
 	svc := newIBService(repo, port, &stubIBMarket{})
 	if err := svc.ReleaseStock(context.Background(), "r1"); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---- CreditStock (FIX 1) ----
+
+func TestCreditStock_ZeroQuantity_Error(t *testing.T) {
+	svc := newIBService(&stubIBRepo{}, &stubIBPortfolio{}, &stubIBMarket{})
+	if err := svc.CreditStock(context.Background(), 7, "AAPL", 0, 222, "tx-x", decimal.NewFromInt(10)); err == nil {
+		t.Error("expected error for zero quantity")
+	}
+}
+
+func TestCreditStock_BlankTicker_Error(t *testing.T) {
+	svc := newIBService(&stubIBRepo{}, &stubIBPortfolio{}, &stubIBMarket{})
+	if err := svc.CreditStock(context.Background(), 7, "  ", 5, 222, "tx-x", decimal.NewFromInt(10)); err == nil {
+		t.Error("expected error for blank ticker")
+	}
+}
+
+func TestCreditStock_NoListing_Error(t *testing.T) {
+	mkt := &stubIBMarket{summary: nil} // ResolveStockListing → no match
+	svc := newIBService(&stubIBRepo{}, &stubIBPortfolio{}, mkt)
+	if err := svc.CreditStock(context.Background(), 7, "AAPL", 5, 222, "tx-x", decimal.NewFromInt(10)); err == nil {
+		t.Error("expected 404 when ticker resolves to no listing")
+	}
+}
+
+func TestCreditStock_NewLot_Inserts(t *testing.T) {
+	mkt := &stubIBMarket{summary: &clients.StockListingSummary{ListingID: 99, Ticker: "AAPL", Price: decimal.NewFromInt(150)}}
+	port := &stubIBPortfolio{position: nil} // buyer holds no position yet
+	svc := newIBService(&stubIBRepo{}, port, mkt)
+	if err := svc.CreditStock(context.Background(), 7, "AAPL", 5, 222, "tx-x", decimal.NewFromInt(140)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(port.inserted) != 1 {
+		t.Fatalf("expected 1 insert, got %d", len(port.inserted))
+	}
+	got := port.inserted[0]
+	if got.userID != 7 || got.listingID != 99 || got.quantity != 5 || got.listingType != "STOCK" {
+		t.Errorf("unexpected insert: %+v", got)
+	}
+	if !got.avg.Equal(decimal.NewFromInt(150)) { // uses listing price, not strike
+		t.Errorf("expected avg=150 (listing price), got %s", got.avg)
+	}
+}
+
+func TestCreditStock_NewLot_FallsBackToStrikeWhenNoPrice(t *testing.T) {
+	mkt := &stubIBMarket{summary: &clients.StockListingSummary{ListingID: 99, Ticker: "AAPL", Price: decimal.Zero}}
+	port := &stubIBPortfolio{position: nil}
+	svc := newIBService(&stubIBRepo{}, port, mkt)
+	if err := svc.CreditStock(context.Background(), 7, "AAPL", 5, 222, "tx-x", decimal.NewFromInt(140)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(port.inserted) != 1 || !port.inserted[0].avg.Equal(decimal.NewFromInt(140)) {
+		t.Errorf("expected fallback avg=140 (strike), got %+v", port.inserted)
+	}
+}
+
+func TestCreditStock_ExistingLot_MergesWeightedAvg(t *testing.T) {
+	mkt := &stubIBMarket{summary: &clients.StockListingSummary{ListingID: 99, Ticker: "AAPL", Price: decimal.NewFromInt(200)}}
+	// Existing: 10 shares @ 100. Incoming: 10 shares @ 200 → 20 @ 150.
+	port := &stubIBPortfolio{position: &portfolio.Portfolio{ID: 3, Quantity: 10, AveragePurchasePrice: decimal.NewFromInt(100)}}
+	svc := newIBService(&stubIBRepo{}, port, mkt)
+	if err := svc.CreditStock(context.Background(), 7, "AAPL", 10, 222, "tx-x", decimal.NewFromInt(180)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(port.inserted) != 0 {
+		t.Errorf("expected no insert on merge, got %d", len(port.inserted))
+	}
+	if len(port.updatedQtyAvg) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(port.updatedQtyAvg))
+	}
+	got := port.updatedQtyAvg[0]
+	if got.id != 3 || got.quantity != 20 {
+		t.Errorf("unexpected updated qty: %+v", got)
+	}
+	if !got.avg.Equal(decimal.NewFromInt(150)) {
+		t.Errorf("expected weighted avg=150, got %s", got.avg)
+	}
+}
+
+func TestCreditStock_MarketError_Propagates(t *testing.T) {
+	mkt := &stubIBMarket{summaryErr: errors.New("market down")}
+	svc := newIBService(&stubIBRepo{}, &stubIBPortfolio{}, mkt)
+	if err := svc.CreditStock(context.Background(), 7, "AAPL", 5, 222, "tx-x", decimal.NewFromInt(10)); err == nil {
+		t.Error("expected error to propagate from market resolution")
 	}
 }
 


### PR DESCRIPTION
Interbank OTC:
- Exercise asset-conservation: buyer dobija isporucene hartije (novi CreditStock put:
  executor RefKindStockCredit -> trading-service /internal/interbank/credit-stock portfolio upsert).
- Reverse smer (B1-buyer/B2-seller): Coordinator.ExerciseContract emituje kanonski OPTION-pseudo
  oblik (stock+strike na OPTION pseudo-nalogu sa seller-bank negId, ispravni znaci) da partner
  prepozna exercise i settle-uje seller stranu.
- Validator: exercisabilnost vezana za ACTIVE ugovor (ne za is_ongoing pregovora; accept
  zatvara pregovor ali ugovor ostaje exercisable do settlement-a); prima partnerov accept-oblik
  (OPTION pseudo + MONAS/STOCK leg).
- Per-contract idempotency: ContractGate (ClaimExerciseByNegotiation CTE CAS) + buyer-side
  ClaimExerciseByID (ACTIVE->EXERCISING pod FOR UPDATE lock) -> retry/konkurentni exercise no-op.
- Mirror accept zatvara lokalni pregovor (MarkClosed) -> nema 409 na ponovni accept.
- Reject vidljivost: ListForUser filtrira is_ongoing.
- accountIsOurs: prihvata 19-cifrene klijentske naloge (ne samo 18) -> cross-bank credit ne nestaje.

Placanja:
- RSD-only guard za medjubankarska placanja (SendOutboundPayment).
- banking-core RecordInterbankPayment: sentinel "INTERBANK-EXTERNAL" za prazan fromAccount
  (foreign PERSON posiljalac) -> primljena uplata/premija ulazi u istoriju.

trading-service: CreditStock + market.ResolveStockListing (ticker -> listing id/price).