### PR TITLE
fix(banking-core): interbank_reservations.account_number VARCHAR(18) -> VARCHAR(32)

### DIFF
--- a/banking-core-service-go/internal/db/db.go
+++ b/banking-core-service-go/internal/db/db.go
@@ -336,13 +336,18 @@ CREATE TABLE IF NOT EXISTS interbank_reservations (
     reservation_id UUID NOT NULL UNIQUE,
     transaction_id_routing INT NOT NULL,
     transaction_id_local VARCHAR(64) NOT NULL,
-    account_number VARCHAR(18) NOT NULL,
+    account_number VARCHAR(32) NOT NULL,
     currency VARCHAR(8) NOT NULL,
     amount NUMERIC(20,4) NOT NULL CHECK (amount > 0),
     status VARCHAR(16) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     finalized_at TIMESTAMP WITH TIME ZONE
 );
+-- Self-heal: CREATE TABLE IF NOT EXISTS ne menja vec postojecu tabelu, a racuni su
+-- 19 cifara — kolona je bila VARCHAR(18) pa je odlazna interbank rezervacija padala
+-- na 22001 ("value too long"). Idempotentno sirenje na 32 (konzistentno sa
+-- fund_reservations.account_number); bezbedno na svakom startup-u.
+ALTER TABLE interbank_reservations ALTER COLUMN account_number TYPE VARCHAR(32);
 
 CREATE INDEX IF NOT EXISTS idx_interbank_reservations_tx
     ON interbank_reservations(transaction_id_routing, transaction_id_local);


### PR DESCRIPTION
## Problem
Odlazna medjubankarska placanja (i svaki OTC flow gde nas klijent placa — prihvatanje ponude kao kupac, exercise ugovora) padaju na:

```
value too long for type character varying(18) (SQLSTATE 22001)
```

Brojevi racuna su **19 cifara** (npr. `1110009900000000111`), a kolona `interbank_reservations.account_number` je bila `VARCHAR(18)`. Pri svakom odlaznom placanju interbank-service zove banking-core `POST /internal/interbank/reserve-monas`, INSERT u `interbank_reservations` pada sa 22001 → "local prepare infra failure" → ceo 2PC se abortuje. (Dolazna placanja Banka 2 → mi ne diraju ovu tabelu — kredit ide UPDATE-om po account id, pa nisu pogodjena.)

## Fix
- `interbank_reservations.account_number`: `VARCHAR(18)` → `VARCHAR(32)` (konzistentno sa `fund_reservations.account_number`).
- Bootstrap koristi `CREATE TABLE IF NOT EXISTS` koji ne menja postojecu tabelu, pa je dodat i **idempotentan** `ALTER TABLE interbank_reservations ALTER COLUMN account_number TYPE VARCHAR(32)` odmah posle `CREATE TABLE` — postojece baze se self-heal-uju na svakom startup-u.

## Primenjeno na deploy bazu
Isti ALTER je vec rucno primenjen na zivi klaster (`banka-1`): kolona je sada `character_maximum_length = 32` (bila 18). Ovaj PR osigurava da i clean deploy i restart-ovi ostanu ispravni.

## Verifikacija
- Tip kolone na zivoj bazi potvrdjen: 18 → 32.
- Preostaje end-to-end: 1 RSD sa naseg racuna ka racunu u Banci 2 → COMPLETED, bez `varying(18)` u logu.