### PR TITLE
fix(banking-core): ukloni ';' iz schemaSQL komentara (bootstrap crashloop)

### DIFF
--- a/banking-core-service-go/internal/db/db.go
+++ b/banking-core-service-go/internal/db/db.go
@@ -343,10 +343,8 @@ CREATE TABLE IF NOT EXISTS interbank_reservations (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     finalized_at TIMESTAMP WITH TIME ZONE
 );
--- Self-heal: CREATE TABLE IF NOT EXISTS ne menja vec postojecu tabelu, a racuni su
--- 19 cifara — kolona je bila VARCHAR(18) pa je odlazna interbank rezervacija padala
--- na 22001 ("value too long"). Idempotentno sirenje na 32 (konzistentno sa
--- fund_reservations.account_number); bezbedno na svakom startup-u.
+-- Self-heal postojece baze: CREATE TABLE IF NOT EXISTS ne menja kolonu, a racuni su 19 cifara (bili 18).
+-- VAZNO: komentari u schemaSQL NE smeju sadrzati tacka-zarez jer execStatements deli skriptu po njoj.
 ALTER TABLE interbank_reservations ALTER COLUMN account_number TYPE VARCHAR(32);
 
 CREATE INDEX IF NOT EXISTS idx_interbank_reservations_tx


### PR DESCRIPTION
## Hitno — regresija iz #341
Posle merge-a #341, banking-core ulazi u **CrashLoopBackOff** na startup-u:

```
run migrations: execute migration statement "bezbedno na svakom startup-u. ALTER TABLE interbank_reservations ALTER COLUMN account_number TYPE VA...": ERROR: syntax error at or near "bezbedno" (SQLSTATE 42601)
```

### Uzrok
Bootstrap `execStatements` deli `schemaSQL` po `;` (`strings.Split(script, ";")`). Komentar dodat u #341 je u tekstu sadrzao `;`:
```
-- ... (konzistentno sa
-- fund_reservations.account_number); bezbedno na svakom startup-u.
```
`;` unutar komentara je iscepao statement, pa je `bezbedno na svakom startup-u. ALTER TABLE ...` zavrsilo kao zaseban "statement" bez `--` prefiksa -> PG syntax error.

### Fix
- Komentar je sada jednolinijski i **bez `;`**.
- Dodato eksplicitno upozorenje da komentari u `schemaSQL` ne smeju sadrzati `;` (jer ih `execStatements` deli po njemu).
- `ALTER TABLE ... TYPE VARCHAR(32)` (i `account_number VARCHAR(32)` u CREATE) ostaju — sustinski fix iz #341 je nepromenjen.

### Stanje na klasteru
Crashloop rollout je vec `rollout undo`-ovan — stari (zdrav) pod servisira; nema ispada. Live DB kolona je vec `VARCHAR(32)`. Posle merge-a + CI build-a, banking-core ce se restartovati na ispravan image.