### PR TITLE
fix(interbank): cross-bank OTC exercise kad je nas klijent KUPAC ne kreditira akcije

### DIFF
--- a/interbank-service/internal/store/contracts.go
+++ b/interbank-service/internal/store/contracts.go
@@ -225,20 +225,27 @@ func (s *ContractStore) SumActiveBySellerAndTicker(ctx context.Context, sellerRo
 }
 
 // ClaimExerciseByNegotiation atomically transitions to EXERCISED the contract whose
-// negotiation matches negID, ONLY when it is currently ACTIVE — the per-contract
+// negotiation matches negID, when it is currently ACTIVE or EXERCISING — the per-contract
 // idempotency claim for cross-bank OTC exercise settlement (FIX B). The single
 // conditional UPDATE is the serialization point: concurrent / different-txId exercises
-// of the same contract race on the same row, and exactly one observes status='ACTIVE'
-// and flips it (rows-affected = 1); the loser sees 0. negID may be EITHER our LOCAL
-// negotiation id (seller-host case: contracts.negotiation_id == the option pseudo id we
-// issued) OR the SELLER bank's authoritative id (buyer case: the option pseudo id is the
-// seller-bank id, mapped to our local mirror via interbank_negotiations.remote_negotiation_id).
+// of the same contract race on the same row, and exactly one observes status IN
+// ('ACTIVE','EXERCISING') and flips it (rows-affected = 1); the loser sees 0. negID may be
+// EITHER our LOCAL negotiation id (seller-host case: contracts.negotiation_id == the option
+// pseudo id we issued) OR the SELLER bank's authoritative id (buyer case: the option pseudo
+// id is the seller-bank id, mapped to our local mirror via interbank_negotiations.remote_negotiation_id).
 // Both are resolved in one statement.
 //
+// EXERCISING is accepted because on the BUYER-coordinator side the entry claim
+// (ClaimExerciseByID) has ALREADY flipped ACTIVE→EXERCISING before CommitLocal runs. With an
+// ACTIVE-only CAS this call would miss (0 rows), settlement would be skipped, and the buyer's
+// stock-credit leg dropped — while the strike debit (off-wire, not under the skip gate) still
+// goes through: buyer paid but never received the shares. The seller-host side has no entry
+// claim, so its contract is ACTIVE and still matches.
+//
 // Returns (exists, claimed): exists=false when there is no matching contract row at all
-// (gate then proceeds ungated); claimed=true when THIS call won the ACTIVE→EXERCISED
-// transition; claimed=false when the contract exists but was not ACTIVE (already EXERCISED
-// or terminal) — settlement must then be skipped.
+// (gate then proceeds ungated); claimed=true when THIS call won the →EXERCISED transition;
+// claimed=false when the contract exists but was already EXERCISED or terminal — settlement
+// must then be skipped (idempotent: a second exercise sees EXERCISED and claims nothing).
 func (s *ContractStore) ClaimExerciseByNegotiation(ctx context.Context, negID string) (exists bool, claimed bool, err error) {
 	// Resolve the matching contract id via either keying scheme, then conditionally flip.
 	// A CTE keeps it to one round-trip and makes the ACTIVE-guard atomic with the lookup.
@@ -258,7 +265,7 @@ func (s *ContractStore) ClaimExerciseByNegotiation(ctx context.Context, negID st
 			UPDATE interbank_contracts c
 			SET status = 'EXERCISED', exercised_at = now(), version = version + 1
 			FROM target
-			WHERE c.id = target.id AND target.status = 'ACTIVE'
+			WHERE c.id = target.id AND target.status IN ('ACTIVE', 'EXERCISING')
 			RETURNING c.id
 		)
 		SELECT

--- a/interbank-service/internal/store/db_test.go
+++ b/interbank-service/internal/store/db_test.go
@@ -340,6 +340,48 @@ func TestContractStore_ClaimExerciseByID(t *testing.T) {
 	}
 }
 
+func TestContractStore_ClaimExerciseByNegotiation(t *testing.T) {
+	// Won the claim: existed=1, claimed=1.
+	won := &fakeDB{row: &fakeRow{vals: []any{1, 1}}}
+	s := &ContractStore{pool: won}
+	exists, claimed, err := s.ClaimExerciseByNegotiation(context.Background(), "neg-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists || !claimed {
+		t.Errorf("expected exists+claimed, got exists=%v claimed=%v", exists, claimed)
+	}
+	if !contains(won.lastSQL, "FOR UPDATE") {
+		t.Errorf("claim must lock the row; SQL = %s", won.lastSQL)
+	}
+	// FIX: on the buyer-coordinator side the entry claim already flipped ACTIVE→EXERCISING,
+	// so the CAS must accept BOTH ACTIVE and EXERCISING — otherwise the buyer's stock-credit
+	// leg is skipped while the strike is still debited (paid, no shares).
+	if !contains(won.lastSQL, "'ACTIVE'") || !contains(won.lastSQL, "'EXERCISING'") {
+		t.Errorf("CAS must claim ACTIVE or EXERCISING → EXERCISED; SQL = %s", won.lastSQL)
+	}
+
+	// Exists but already EXERCISED/terminal: existed=1, claimed=0 → settlement skipped (idempotent).
+	lost := &fakeDB{row: &fakeRow{vals: []any{1, 0}}}
+	exists, claimed, _ = (&ContractStore{pool: lost}).ClaimExerciseByNegotiation(context.Background(), "neg-1")
+	if !exists || claimed {
+		t.Errorf("already-settled: expected exists+!claimed, got exists=%v claimed=%v", exists, claimed)
+	}
+
+	// No matching contract: existed=0, claimed=0 → gate proceeds ungated.
+	missing := &fakeDB{row: &fakeRow{vals: []any{0, 0}}}
+	exists, claimed, _ = (&ContractStore{pool: missing}).ClaimExerciseByNegotiation(context.Background(), "nope")
+	if exists || claimed {
+		t.Errorf("missing: expected !exists+!claimed, got exists=%v claimed=%v", exists, claimed)
+	}
+
+	// Scan error propagates.
+	boom := &fakeDB{row: &fakeRow{scanErr: errors.New("boom")}}
+	if _, _, err := (&ContractStore{pool: boom}).ClaimExerciseByNegotiation(context.Background(), "neg-1"); err == nil {
+		t.Error("expected scan error to propagate")
+	}
+}
+
 func TestContractStore_RevertExercising(t *testing.T) {
 	db := &fakeDB{execTag: commandTag(1)}
 	s := &ContractStore{pool: db}


### PR DESCRIPTION
## Simptom
Kad NAS klijent (kupac) iskoristi cross-bank OTC opciju a prodavac je u Banci 2: kupcu se skine **strike (novac)** ali **NE stignu akcije**. Prodavcu u Banci 2 se akcije skinu i strike legne (njihova strana radi). Asset "nestane" na nasoj strani.

## Root cause — dvostruki claim na buyer strani
1. `OtcContractsService.Exercise` → `store.ClaimExerciseByID` (entry-claim): ugovor `ACTIVE → EXERCISING` pre 2PC.
2. `executor.CommitLocal` → `ClaimExerciseByNegotiation`: CAS je trazio `status = 'ACTIVE'`, ali je ugovor vec `EXERCISING` → 0 redova → `claimed=false` → `skipExercise=true` → **buyer-stock-credit leg se preskoci**.
3. Strike ide off-wire (`reserveBuyerStrike`/`commitBuyerStrike`, van `skipExercise` gate-a) → kupac placen, akcije ne stignu.

## Fix (jedan CAS uslov)
`ClaimExerciseByNegotiation` (`internal/store/contracts.go`):
```diff
- WHERE c.id = target.id AND target.status = 'ACTIVE'
+ WHERE c.id = target.id AND target.status IN ('ACTIVE', 'EXERCISING')
```
- **SELLER-host** strana: ugovor je `ACTIVE` (nema entry-claim) → radi kao i sad.
- **BUYER-coordinator** strana: ugovor je `EXERCISING` → sad uspe, buyer-stock-credit se primeni → kupac dobije akcije.
- **Idempotencija ocuvana:** vec `EXERCISED` → CAS i dalje 0 redova → skip (exactly-once, bez dvostrukog kredita).
- Entry-claim (`ClaimExerciseByID`, `ACTIVE→EXERCISING`) ostaje **ACTIVE-only** — netaknut.

## Testovi
Dodat `TestContractStore_ClaimExerciseByNegotiation` (CAS pokriva i `ACTIVE` i `EXERCISING`; won/already-settled/missing/scan-error grane). `go test ./internal/store/ ./internal/service/` prolazi.

## Verifikacija (predlog)
Nas klijent napravi ponudu da kupi akciju klijenta Banke 2, prihvati pa "Iskoristi" → kupcu se i poveca kolicina akcije i skine strike; u logu nema vise "exercise already settled for contract — skipping settlement" za PRVI exercise.